### PR TITLE
DST fix

### DIFF
--- a/api/services/load-prediction-service.ts
+++ b/api/services/load-prediction-service.ts
@@ -177,8 +177,8 @@ export async function runForecast(config: PredictionRunConfig): Promise<Forecast
     futureTargets.push({
       date: d.toISOString(),
       time: t,
-      hour: d.getHours(),
-      dayOfWeek: d.getDay(),
+      hour: d.getUTCHours(),
+      dayOfWeek: d.getUTCDay(),
       value: null,
     });
   }

--- a/lib/load-predictor-historical.ts
+++ b/lib/load-predictor-historical.ts
@@ -77,7 +77,9 @@ export function predict(
     const maxDays = lookbackWeeks * 7;
 
     for (let d = 1; d <= maxDays; d++) {
-      const pastDate = new Date(entryDate.getTime() - d * 24 * 60 * 60 * 1000);
+      // setDate() subtracts in local time, preserving the same wall-clock hour across DST boundaries
+      const pastDate = new Date(entryDate);
+      pastDate.setDate(pastDate.getDate() - d);
       const pastISO = pastDate.toISOString();
       const pastEntry = valueByDate.get(pastISO);
 

--- a/tests/lib/load-predictor-historical.test.js
+++ b/tests/lib/load-predictor-historical.test.js
@@ -265,6 +265,59 @@ describe('generateAllConfigs', () => {
 });
 
 // ---------------------------------------------------------------------------
+// predict — DST boundary
+// ---------------------------------------------------------------------------
+
+describe('predict across DST boundary (CET→CEST)', () => {
+  // 2026 spring-forward: March 29 at 02:00 local (01:00 UTC)
+  // Boiler runs at 04:00 local every day.
+  // Before DST: 04:00 CET  = 03:00 UTC
+  // After DST:  04:00 CEST = 02:00 UTC
+  const dstHistory = [
+    {
+      date: '2026-03-16T03:00:00.000Z', // Mon 04:00 CET
+      time: new Date('2026-03-16T03:00:00.000Z').getTime(),
+      hour: 3,
+      dayOfWeek: 1,
+      sensor: 'Load',
+      value: 500,
+    },
+    {
+      date: '2026-03-23T03:00:00.000Z', // Mon 04:00 CET
+      time: new Date('2026-03-23T03:00:00.000Z').getTime(),
+      hour: 3,
+      dayOfWeek: 1,
+      sensor: 'Load',
+      value: 700,
+    },
+  ];
+
+  // Target: Mon March 30 at 04:00 CEST = 02:00 UTC
+  const dstTarget = {
+    date: '2026-03-30T02:00:00.000Z',
+    time: new Date('2026-03-30T02:00:00.000Z').getTime(),
+    hour: 2,
+    dayOfWeek: 1, // Monday UTC
+    value: null,
+  };
+
+  it('finds historical records at the same local hour across a DST transition', () => {
+    const results = predict(dstHistory, {
+      sensor: 'Load',
+      lookbackWeeks: 3,
+      dayFilter: 'all',
+      aggregation: 'mean',
+    }, [dstTarget]);
+
+    expect(results).toHaveLength(1);
+    // setDate lookback: March 30 04:00 CEST -7d → March 23 04:00 CET = 03:00 UTC ✓
+    //                   March 30 04:00 CEST -14d → March 16 04:00 CET = 03:00 UTC ✓
+    // Mean of 500 and 700 = 600
+    expect(results[0].predicted).toBeCloseTo(600);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // buildForecastSeriesRange
 // ---------------------------------------------------------------------------
 

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -4,6 +4,9 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    env: {
+      TZ: 'Europe/Amsterdam',
+    },
     include: ['tests/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
## Summary

- Fixes a **DST bug** in the historical predictor: lookback now uses `setDate()` to preserve wall-clock hour across spring/autumn transitions, and future target slots use `getUTCHours`/`getUTCDay` since their ISO strings are already UTC-normalised
- Regression test covers a CET→CEST spring-forward week; vitest configured with `TZ=Europe/Amsterdam`

🤖 Generated with [Claude Code](https://claude.com/claude-code)