### PR TITLE
Use new MQTT topic for targetsoc and fix race condition

### DIFF
--- a/api/routes/predictions.ts
+++ b/api/routes/predictions.ts
@@ -3,10 +3,12 @@ import type { Request, Response, NextFunction } from 'express';
 import { HttpError, assertCondition, toHttpError } from '../http-errors.ts';
 import { loadPredictionConfig, savePredictionConfig } from '../services/prediction-config-store.ts';
 import { runValidation, runForecast } from '../services/load-prediction-service.ts';
+import type { ForecastRunResult } from '../services/load-prediction-service.ts';
 import { runPvForecast } from '../services/pv-prediction-service.ts';
+import type { PvForecastRunResult } from '../services/pv-prediction-service.ts';
 import { loadData, saveData } from '../services/data-store.ts';
 import { loadSettings } from '../services/settings-store.ts';
-import type { PredictionConfig, PredictionRunConfig } from '../types.ts';
+import type { PredictionConfig, PredictionRunConfig, TimeSeries } from '../types.ts';
 
 const router = express.Router();
 
@@ -79,6 +81,7 @@ router.post('/load/forecast', async (req: Request, res: Response, next: NextFunc
     }
 
     const result = await executeLoadForecast(config, 'load/forecast');
+    await persistForecastData({ load: result.forecast });
     res.json(result);
   } catch (error) {
     next(error instanceof HttpError ? error : toHttpError(error, 500, 'Load forecast failed'));
@@ -92,6 +95,7 @@ router.post('/pv/forecast', async (req: Request, res: Response, next: NextFuncti
     const config = await buildRunConfig();
 
     const result = await executePvForecast(config, 'pv/forecast');
+    await persistForecastData({ pv: result?.forecast });
     res.json(result);
   } catch (error) {
     next(error instanceof HttpError ? error : toHttpError(error, 500, 'PV forecast failed'));
@@ -103,17 +107,8 @@ router.post('/pv/forecast', async (req: Request, res: Response, next: NextFuncti
 router.post('/forecast', async (req: Request, res: Response, next: NextFunction) => {
   try {
     const config = await buildRunConfig();
-
-    if (req.query.recent === 'false') {
-      config.includeRecent = false;
-    }
-
-    const [loadResult, pvResult] = await Promise.all([
-      executeLoadForecast(config, 'forecast').catch(handleCombinedForecastError('load')),
-      executePvForecast(config, 'forecast').catch(handleCombinedForecastError('pv')),
-    ]);
-
-    res.json({ load: loadResult, pv: pvResult });
+    if (req.query.recent === 'false') config.includeRecent = false;
+    res.json(await runCombinedForecast(config, 'forecast'));
   } catch (error) {
     next(error instanceof HttpError ? error : toHttpError(error, 500, 'Forecast failed'));
   }
@@ -123,13 +118,7 @@ router.get('/forecast/now', async (_req: Request, res: Response, next: NextFunct
   try {
     const config = await buildRunConfig();
     config.includeRecent = false;
-
-    const [loadResult, pvResult] = await Promise.all([
-      executeLoadForecast(config, 'forecast/now').catch(handleCombinedForecastError('load', 'forecast/now')),
-      executePvForecast(config, 'forecast/now').catch(handleCombinedForecastError('pv', 'forecast/now')),
-    ]);
-
-    res.json({ load: loadResult, pv: pvResult });
+    res.json(await runCombinedForecast(config, 'forecast/now'));
   } catch (error) {
     next(error instanceof HttpError ? error : toHttpError(error, 500, 'Forecast failed'));
   }
@@ -142,7 +131,16 @@ async function buildRunConfig(): Promise<PredictionRunConfig> {
   return { ...config, haUrl: settings.haUrl, haToken: settings.haToken };
 }
 
-async function executeLoadForecast(config: PredictionRunConfig, logLabel: string): Promise<unknown> {
+async function runCombinedForecast(config: PredictionRunConfig, endpoint: string) {
+  const [loadResult, pvResult] = await Promise.all([
+    executeLoadForecast(config, endpoint).catch(handleCombinedForecastError('load', endpoint)),
+    executePvForecast(config, endpoint).catch(handleCombinedForecastError('pv', endpoint)),
+  ]);
+  await persistForecastData({ load: loadResult?.forecast, pv: pvResult?.forecast });
+  return { load: loadResult, pv: pvResult };
+}
+
+async function executeLoadForecast(config: PredictionRunConfig, logLabel: string): Promise<ForecastRunResult> {
   assertCondition(config.activeType != null, 400, 'activeType is required');
   if (config.activeType === 'historical') {
     assertHaConnection(config);
@@ -162,14 +160,13 @@ async function executeLoadForecast(config: PredictionRunConfig, logLabel: string
 
   try {
     const result = await runForecast(config);
-    await maybeSaveForecastData('load', result?.forecast);
     return result;
   } catch (err) {
     throw mapPredictionError(err, false);
   }
 }
 
-async function executePvForecast(config: PredictionRunConfig, logLabel: string): Promise<unknown> {
+async function executePvForecast(config: PredictionRunConfig, logLabel: string): Promise<PvForecastRunResult | null> {
   if (
     !config.pvConfig ||
     config.pvConfig.latitude == null || Number.isNaN(config.pvConfig.latitude) ||
@@ -185,7 +182,6 @@ async function executePvForecast(config: PredictionRunConfig, logLabel: string):
 
   try {
     const result = await runPvForecast(config);
-    await maybeSaveForecastData('pv', result?.forecast);
     return result;
   } catch (err) {
     throw mapPredictionError(err, true);
@@ -214,14 +210,15 @@ function handleCombinedForecastError(type: string, logLabel: string = 'combined'
   };
 }
 
-async function maybeSaveForecastData(type: 'load' | 'pv', forecast: any) {
-  if (!forecast?.values) return;
+async function persistForecastData(updates: { load?: TimeSeries; pv?: TimeSeries }) {
   const settings = await loadSettings();
-  if (settings.dataSources[type] === 'api') {
-    const currentData = await loadData();
-    currentData[type] = forecast;
-    await saveData(currentData);
-  }
+  const setLoad = !!updates.load?.values && settings.dataSources.load === 'api';
+  const setPv   = !!updates.pv?.values   && settings.dataSources.pv   === 'api';
+  if (!setLoad && !setPv) return;
+  const data = await loadData();
+  if (setLoad) data.load = updates.load!;
+  if (setPv)   data.pv   = updates.pv!;
+  await saveData(data);
 }
 
 function mapPredictionError(err: unknown, isPv: boolean): Error {

--- a/api/routes/predictions.ts
+++ b/api/routes/predictions.ts
@@ -136,7 +136,11 @@ async function runCombinedForecast(config: PredictionRunConfig, endpoint: string
     executeLoadForecast(config, endpoint).catch(handleCombinedForecastError('load', endpoint)),
     executePvForecast(config, endpoint).catch(handleCombinedForecastError('pv', endpoint)),
   ]);
-  await persistForecastData({ load: loadResult?.forecast, pv: pvResult?.forecast });
+  try {
+    await persistForecastData({ load: loadResult?.forecast, pv: pvResult?.forecast });
+  } catch (err) {
+    console.warn('[predict] forecast persistence failed:', err instanceof Error ? err.message : err);
+  }
   return { load: loadResult, pv: pvResult };
 }
 
@@ -211,6 +215,7 @@ function handleCombinedForecastError(type: string, logLabel: string = 'combined'
 }
 
 async function persistForecastData(updates: { load?: TimeSeries; pv?: TimeSeries }) {
+  if (!updates.load?.values && !updates.pv?.values) return;
   const settings = await loadSettings();
   const setLoad = !!updates.load?.values && settings.dataSources.load === 'api';
   const setPv   = !!updates.pv?.values   && settings.dataSources.pv   === 'api';

--- a/api/services/load-prediction-service.ts
+++ b/api/services/load-prediction-service.ts
@@ -36,7 +36,7 @@ interface ValidationRunResult {
   results: ValidationEntry[];
 }
 
-interface ForecastRunResult {
+export interface ForecastRunResult {
   forecast: ForecastSeries;
   recent: PredictionResult[];
   metrics: { mae: number; rmse: number; mape: number; n: number };

--- a/lib/victron-mqtt.ts
+++ b/lib/victron-mqtt.ts
@@ -341,7 +341,7 @@ export class VictronMqttClient {
 
   /**
    * Write a single schedule slot:
-   *   Settings/DynamicEss/Schedule/<slotIndex>/{Start,Duration,Strategy,Flags,Soc,Restrictions,AllowGridFeedIn}
+   *   Settings/DynamicEss/Schedule/<slotIndex>/{Start,Duration,Strategy,Flags,Soc,TargetSoc,Restrictions,AllowGridFeedIn}
    */
   async writeScheduleSlot(slotIndex: number, slot: ScheduleSlot, { serial }: { serial?: string } = {}): Promise<void> {
     const s = serial ?? (await this.getSerial());
@@ -353,7 +353,10 @@ export class VictronMqttClient {
     if (slot.durationSeconds !== undefined) tasks.push(this.writeSetting(`${base}/Duration`, slot.durationSeconds, { serial: s }));
     if (slot.strategy !== undefined) tasks.push(this.writeSetting(`${base}/Strategy`, slot.strategy, { serial: s }));
     if (slot.flags !== undefined) tasks.push(this.writeSetting(`${base}/Flags`, slot.flags, { serial: s }));
-    if (slot.socTarget !== undefined) tasks.push(this.writeSetting(`${base}/Soc`, slot.socTarget, { serial: s }));
+    if (slot.socTarget !== undefined) {
+      tasks.push(this.writeSetting(`${base}/Soc`, slot.socTarget, { serial: s }));
+      tasks.push(this.writeSetting(`${base}/TargetSoc`, slot.socTarget, { serial: s }));
+    }
     if (slot.restrictions !== undefined) tasks.push(this.writeSetting(`${base}/Restrictions`, slot.restrictions, { serial: s }));
     if (slot.allowGridFeedIn !== undefined) tasks.push(this.writeSetting(`${base}/AllowGridFeedIn`, slot.allowGridFeedIn, { serial: s }));
 

--- a/tests/api/predictions.test.js
+++ b/tests/api/predictions.test.js
@@ -191,4 +191,65 @@ describe('POST /predictions/load/forecast', () => {
     const res = await request(app).post('/predictions/load/forecast').send({});
     expect(res.status).toBe(502);
   });
+
+  it('persists forecast when dataSources.load is api', async () => {
+    loadSettings.mockResolvedValue({ ...mockSettings, dataSources: { load: 'api', pv: 'vrm' } });
+    const res = await request(app).post('/predictions/load/forecast').send({});
+    expect(res.status).toBe(200);
+    expect(saveData).toHaveBeenCalledTimes(1);
+    expect(saveData.mock.calls[0][0].load.values).toHaveLength(96);
+  });
+
+  it('skips saveData when dataSources.load is vrm', async () => {
+    const res = await request(app).post('/predictions/load/forecast').send({});
+    expect(res.status).toBe(200);
+    expect(saveData).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /predictions/forecast (combined) - persistence', () => {
+  const loadForecast = { start: '2026-02-20T00:00:00.000Z', step: 15, values: new Array(96).fill(200) };
+  const pvForecast = { start: '2026-02-20T00:00:00.000Z', step: 15, values: new Array(96).fill(500) };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    loadPredictionConfig.mockResolvedValue({ ...mockConfig, pvConfig: { latitude: 51.0, longitude: 4.5 } });
+    savePredictionConfig.mockResolvedValue();
+    loadSettings.mockResolvedValue({ ...mockSettings, dataSources: { load: 'api', pv: 'api' } });
+    loadData.mockResolvedValue({ load: {}, pv: {} });
+    saveData.mockResolvedValue();
+    runForecast.mockResolvedValue({ forecast: loadForecast, recent: [] });
+    runPvForecast.mockResolvedValue({ forecast: pvForecast, points: [], recent: [], metrics: {} });
+  });
+
+  it('calls saveData exactly once with both forecasts (race condition fix)', async () => {
+    const res = await request(app).post('/predictions/forecast').send({});
+    expect(res.status).toBe(200);
+    expect(saveData).toHaveBeenCalledTimes(1);
+    expect(saveData.mock.calls[0][0].load).toEqual(loadForecast);
+    expect(saveData.mock.calls[0][0].pv).toEqual(pvForecast);
+  });
+
+  it('saves only load when dataSources.pv is vrm', async () => {
+    loadSettings.mockResolvedValue({ ...mockSettings, dataSources: { load: 'api', pv: 'vrm' } });
+    const res = await request(app).post('/predictions/forecast').send({});
+    expect(res.status).toBe(200);
+    expect(saveData).toHaveBeenCalledTimes(1);
+    expect(saveData.mock.calls[0][0].load).toEqual(loadForecast);
+  });
+
+  it('saves only pv when load branch fails', async () => {
+    runForecast.mockRejectedValue(new Error('HA WebSocket timed out after 30000ms'));
+    const res = await request(app).post('/predictions/forecast').send({});
+    expect(res.status).toBe(200);
+    expect(saveData).toHaveBeenCalledTimes(1);
+    expect(saveData.mock.calls[0][0].pv).toEqual(pvForecast);
+  });
+
+  it('skips saveData when both dataSources are vrm', async () => {
+    loadSettings.mockResolvedValue({ ...mockSettings, dataSources: { load: 'vrm', pv: 'vrm' } });
+    const res = await request(app).post('/predictions/forecast').send({});
+    expect(res.status).toBe(200);
+    expect(saveData).not.toHaveBeenCalled();
+  });
 });

--- a/tests/api/predictions.test.js
+++ b/tests/api/predictions.test.js
@@ -252,4 +252,12 @@ describe('POST /predictions/forecast (combined) - persistence', () => {
     expect(res.status).toBe(200);
     expect(saveData).not.toHaveBeenCalled();
   });
+
+  it('returns 200 with forecast results even when persistence fails', async () => {
+    saveData.mockRejectedValue(new Error('disk full'));
+    const res = await request(app).post('/predictions/forecast').send({});
+    expect(res.status).toBe(200);
+    expect(res.body.load).toBeTruthy();
+    expect(res.body.pv).toBeTruthy();
+  });
 });


### PR DESCRIPTION
This PR fixes 2 bugs reported by @nudded

- Victron started using a new MQTT topic to push float target socs. If this new topic was set (e.g. when running the built-in DESS), the old topic was ignored.

- When running predictions, load and PV predictions are run concurrently. They both wrote to the same file at the end, resulting in a race condition.

