### PR TITLE
Add configurable block feed-in on negative export prices

### DIFF
--- a/api/defaults/default-settings.json
+++ b/api/defaults/default-settings.json
@@ -11,6 +11,7 @@
   "dischargeEfficiency_percent": 95,
   "batteryCost_cent_per_kWh": 2,
   "idleDrain_W": 40,
+  "blockFeedInOnNegativePrices": true,
   "terminalSocValuation": "zero",
   "terminalSocCustomPrice_cents_per_kWh": 0,
   "dataSources": {

--- a/api/services/planner-service.ts
+++ b/api/services/planner-service.ts
@@ -123,7 +123,9 @@ export async function computePlan({ updateData = false } = {}): Promise<ComputeP
 
   const rows = parseSolution(result, cfg, timing);
 
-  const { perSlot, diagnostics } = mapRowsToDessV2(rows, cfg);
+  const { perSlot, diagnostics } = mapRowsToDessV2(rows, cfg, {
+    blockFeedInOnNegativePrices: settings.blockFeedInOnNegativePrices !== false,
+  });
 
   const rowsWithDess: PlanRowWithDess[] = rows.map((row, i) => ({ ...row, dess: perSlot[i] }));
 

--- a/api/types.ts
+++ b/api/types.ts
@@ -34,6 +34,7 @@ export interface Settings {
   dischargeEfficiency_percent: number;
   batteryCost_cent_per_kWh: number;
   idleDrain_W: number;
+  blockFeedInOnNegativePrices: boolean;
   terminalSocValuation: TerminalSocValuation;
   terminalSocCustomPrice_cents_per_kWh: number;
   dataSources: DataSources;

--- a/app/index.html
+++ b/app/index.html
@@ -1197,6 +1197,11 @@
           <label class="text-sm">Rebalance hold (h)
             <input id="rebalance-hold-hours" type="number" min="0.25" step="0.25" class="form-input" />
           </label>
+          <label class="toggle col-span-2 mt-2">
+            <input id="block-feedin-negative-prices" type="checkbox" checked>
+            <span class="toggle-knob"></span>
+            <span class="text-sm">Block feed-in when export price is negative</span>
+          </label>
         </div>
       </section>
 

--- a/app/src/state.js
+++ b/app/src/state.js
@@ -16,6 +16,7 @@ export function snapshotUI(els) {
     dischargeEfficiency_percent: num(els.etaD?.value),
     batteryCost_cent_per_kWh: num(els.bwear?.value),
     idleDrain_W: num(els.idleDrain?.value),
+    blockFeedInOnNegativePrices: !!els.blockFeedInOnNegativePrices?.checked,
 
     // ALGORITHM
     terminalSocValuation: els.terminal?.value || "zero",
@@ -68,6 +69,9 @@ export function hydrateUI(els, obj = {}) {
   setIfDef(els.etaD, obj.dischargeEfficiency_percent);
   setIfDef(els.bwear, obj.batteryCost_cent_per_kWh);
   setIfDef(els.idleDrain, obj.idleDrain_W);
+  if (els.blockFeedInOnNegativePrices && obj.blockFeedInOnNegativePrices != null) {
+    els.blockFeedInOnNegativePrices.checked = !!obj.blockFeedInOnNegativePrices;
+  }
 
   // DATA (display-only metadata)
   updatePlanMeta(els, obj.initialSoc_percent, obj.tsStart);

--- a/app/src/ui-binding.js
+++ b/app/src/ui-binding.js
@@ -12,6 +12,7 @@ export function getElements() {
     sourceSoc: $("#source-soc"),
     rebalanceEnabled: $("#rebalance-enabled"),
     rebalanceHoldHours: $("#rebalance-hold-hours"),
+    blockFeedInOnNegativePrices: $("#block-feedin-negative-prices"),
 
     // numeric inputs
     step: $("#step"),
@@ -144,4 +145,3 @@ export function wireGlobalInputs(els, { onInput, onSave = onInput, onRun, update
 export function wireVrmSettingInput(els, { onRefresh }) {
   els.vrmFetchSettings?.addEventListener("click", onRefresh);
 }
-

--- a/lib/dess-mapper.ts
+++ b/lib/dess-mapper.ts
@@ -39,15 +39,24 @@ interface SegmentTippingPoints {
   pvExportTp: number;
 }
 
-export function mapRowsToDess(rows: PlanRow[], cfg: SolverConfig): DessResult {
+export interface DessMapperOptions {
+  blockFeedInOnNegativePrices?: boolean;
+}
+
+function feedInForRow(row: PlanRow, options: DessMapperOptions): number {
+  return options.blockFeedInOnNegativePrices !== false && row.ec < 0
+    ? FeedIn.blocked
+    : FeedIn.allowed;
+}
+
+export function mapRowsToDess(rows: PlanRow[], cfg: SolverConfig, options: DessMapperOptions = {}): DessResult {
   const segments = buildSegments(rows, cfg);
   const perSlot = new Array<DessSlot>(rows.length);
 
   for (let t = 0; t < rows.length; t++) {
     const row = rows[t];
 
-    // Feed-in: allow unless export price is negative.
-    const feedin = row.ec < 0 ? FeedIn.blocked : FeedIn.allowed;
+    const feedin = feedInForRow(row, options);
 
     // Primitive flows — all non-negative by LP construction
     const g2l = row.g2l;
@@ -337,7 +346,7 @@ function computeDessDiagnostics(rows: PlanRow[], segments: Segment[], cfg: Solve
  *      (only when expected PV > expected load)
  *   5. else                         → selfConsumption + block both
  */
-export function mapRowsToDessV2(rows: PlanRow[], cfg: SolverConfig): DessResult {
+export function mapRowsToDessV2(rows: PlanRow[], cfg: SolverConfig, options: DessMapperOptions = {}): DessResult {
   const segments = buildSegments(rows, cfg);
   const perSlot = new Array<DessSlot>(rows.length);
 
@@ -355,8 +364,7 @@ export function mapRowsToDessV2(rows: PlanRow[], cfg: SolverConfig): DessResult 
   for (let t = 0; t < rows.length; t++) {
     const row = rows[t];
 
-    // Feed-in: same rule as v1
-    const feedin = row.ec < 0 ? FeedIn.blocked : FeedIn.allowed;
+    const feedin = feedInForRow(row, options);
 
     const importCost = row.ic;
     const exportPrice = row.ec;
@@ -421,4 +429,3 @@ export function mapRowsToDessV2(rows: PlanRow[], cfg: SolverConfig): DessResult 
 
   return { perSlot, diagnostics };
 }
-

--- a/tests/api/services/planner-service.test.js
+++ b/tests/api/services/planner-service.test.js
@@ -11,6 +11,7 @@ import { loadData, saveData } from '../../../api/services/data-store.ts';
 import { refreshSeriesFromVrmAndPersist } from '../../../api/services/vrm-refresh.ts';
 import { setDynamicEssSchedule } from '../../../api/services/mqtt-service.ts';
 import { computePlan } from '../../../api/services/planner-service.ts';
+import { FeedIn } from '../../../lib/dess-mapper.ts';
 
 const NOW_STRING = '2024-01-01T00:00:00Z';
 const NOW_MS = new Date(NOW_STRING).getTime();
@@ -101,5 +102,17 @@ describe('computePlan — rebalance bookkeeping', () => {
     expect(saveData).toHaveBeenCalledWith(
       expect.objectContaining({ rebalanceState: { startMs: null } })
     );
+  });
+
+  it('keeps feed-in allowed on negative export prices when blocking is disabled', async () => {
+    loadSettings.mockResolvedValue({ ...baseSettings, blockFeedInOnNegativePrices: false });
+    loadData.mockResolvedValue({
+      ...baseData,
+      exportPrice: { ...baseData.exportPrice, values: [-1, -1, -1, -1, -1] },
+    });
+
+    const result = await computePlan();
+
+    expect(result.rows[0].dess.feedin).toBe(FeedIn.allowed);
   });
 });

--- a/tests/lib/dess-mapper.test.js
+++ b/tests/lib/dess-mapper.test.js
@@ -179,6 +179,12 @@ describe('mapRowsToDess', () => {
       expect(perSlot[0].feedin).toBe(FeedIn.blocked);
     });
 
+    it('allows feed-in at negative export prices when blocking is disabled', () => {
+      const rows = [{ ...baseRow, ec: -1 }];
+      const { perSlot } = mapRowsToDess(rows, cfg, { blockFeedInOnNegativePrices: false });
+      expect(perSlot[0].feedin).toBe(FeedIn.allowed);
+    });
+
     it('allows feed-in when export price is positive', () => {
       const rows = [{ ...baseRow, ec: 1 }];
       const { perSlot } = mapRowsToDess(rows, cfg);
@@ -560,6 +566,12 @@ describe('mapRowsToDessV2', () => {
     expect(perSlot[0].feedin).toBe(FeedIn.blocked);
   });
 
+  it('allows feed-in at negative export prices when blocking is disabled', () => {
+    const rows = [makeRow({ ec: -1 })];
+    const { perSlot } = mapRowsToDessV2(rows, cfg, { blockFeedInOnNegativePrices: false });
+    expect(perSlot[0].feedin).toBe(FeedIn.allowed);
+  });
+
   it('allows feed-in when export price is positive', () => {
     const rows = [makeRow({ ec: 5 })];
     const { perSlot } = mapRowsToDessV2(rows, cfg);
@@ -593,4 +605,3 @@ describe('mapRowsToDessV2', () => {
     expect(v2Result.diagnostics.pvExportTippingPoint_cents_per_kWh).toBe(25);
   });
 });
-


### PR DESCRIPTION
## Summary

- Replaces the hardcoded always-block behaviour with a user-controlled toggle (`blockFeedInOnNegativePrices`, default `true`)
- Adds the toggle to the UI (Algorithm section, beneath rebalancing controls)
- Both `mapRowsToDess` and `mapRowsToDessV2` accept a `DessMapperOptions` object; shared logic extracted into `feedInForRow()`

## Test plan

- [ ] Toggle visible in the Algorithm section and persists correctly via save/reload
- [ ] With the toggle **on** (default): feed-in is blocked when export price is negative — existing behaviour unchanged
- [ ] With the toggle **off**: feed-in remains allowed even at negative export prices
- [ ] Unit tests for both mapper functions (`dess-mapper.test.js`)
- [ ] Integration test in `planner-service.test.js` verifies the setting is wired end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)