### PR TITLE
Add manual prediction adjustments

### DIFF
--- a/api/routes/predictions.ts
+++ b/api/routes/predictions.ts
@@ -8,7 +8,14 @@ import { runPvForecast } from '../services/pv-prediction-service.ts';
 import type { PvForecastRunResult } from '../services/pv-prediction-service.ts';
 import { loadData, saveData } from '../services/data-store.ts';
 import { loadSettings } from '../services/settings-store.ts';
-import type { PredictionConfig, PredictionRunConfig, TimeSeries } from '../types.ts';
+import type { PredictionAdjustmentSeries, PredictionConfig, PredictionRunConfig, TimeSeries } from '../types.ts';
+import type { PredictionAdjustmentInput } from '../services/prediction-adjustments.ts';
+import {
+  applyPredictionAdjustmentsToSeries,
+  createPredictionAdjustment,
+  pruneExpiredPredictionAdjustments,
+  updatePredictionAdjustment,
+} from '../services/prediction-adjustments.ts';
 
 const router = express.Router();
 
@@ -42,6 +49,77 @@ router.post('/config', async (req: Request, res: Response, next: NextFunction) =
     res.json({ message: 'Prediction config saved.', config: merged });
   } catch (error) {
     next(toHttpError(error, 500, 'Failed to save prediction config'));
+  }
+});
+
+// ----------------------------- Manual adjustments ------------------------
+
+router.get('/adjustments', async (_req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { adjustments } = await loadActiveAdjustmentsAndPrune();
+    res.json({ adjustments });
+  } catch (error) {
+    next(toHttpError(error, 500, 'Failed to read prediction adjustments'));
+  }
+});
+
+router.post('/adjustments', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    assertCondition(
+      req.body && typeof req.body === 'object' && !Array.isArray(req.body),
+      400,
+      'prediction adjustment payload must be an object',
+    );
+
+    const data = await loadData();
+    const { data: pruned } = pruneExpiredPredictionAdjustments(data);
+    const adjustment = createPredictionAdjustment(req.body as PredictionAdjustmentInput);
+    const adjustments = [...(pruned.predictionAdjustments ?? []), adjustment];
+    const nextData = { ...pruned, predictionAdjustments: adjustments };
+    await saveData(nextData);
+    res.status(201).json({ adjustment, adjustments });
+  } catch (error) {
+    next(error instanceof HttpError ? error : toHttpError(error, 500, 'Failed to create prediction adjustment'));
+  }
+});
+
+router.patch('/adjustments/:id', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    assertCondition(
+      req.body && typeof req.body === 'object' && !Array.isArray(req.body),
+      400,
+      'prediction adjustment payload must be an object',
+    );
+
+    const data = await loadData();
+    const { data: pruned } = pruneExpiredPredictionAdjustments(data);
+    const adjustments = pruned.predictionAdjustments ?? [];
+    const index = adjustments.findIndex(adj => adj.id === req.params.id);
+    assertCondition(index >= 0, 404, 'Prediction adjustment not found');
+
+    const updated = updatePredictionAdjustment(adjustments[index], req.body as PredictionAdjustmentInput);
+    const nextAdjustments = adjustments.map((adj, i) => i === index ? updated : adj);
+    const nextData = { ...pruned, predictionAdjustments: nextAdjustments };
+    await saveData(nextData);
+    res.json({ adjustment: updated, adjustments: nextAdjustments });
+  } catch (error) {
+    next(error instanceof HttpError ? error : toHttpError(error, 500, 'Failed to update prediction adjustment'));
+  }
+});
+
+router.delete('/adjustments/:id', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const data = await loadData();
+    const { data: pruned } = pruneExpiredPredictionAdjustments(data);
+    const adjustments = pruned.predictionAdjustments ?? [];
+    const nextAdjustments = adjustments.filter(adj => adj.id !== req.params.id);
+    assertCondition(nextAdjustments.length !== adjustments.length, 404, 'Prediction adjustment not found');
+
+    const nextData = { ...pruned, predictionAdjustments: nextAdjustments };
+    await saveData(nextData);
+    res.json({ adjustments: nextAdjustments });
+  } catch (error) {
+    next(error instanceof HttpError ? error : toHttpError(error, 500, 'Failed to delete prediction adjustment'));
   }
 });
 
@@ -82,7 +160,7 @@ router.post('/load/forecast', async (req: Request, res: Response, next: NextFunc
 
     const result = await executeLoadForecast(config, 'load/forecast');
     await persistForecastData({ load: result.forecast });
-    res.json(result);
+    res.json(await withAdjustedForecast(result, 'load'));
   } catch (error) {
     next(error instanceof HttpError ? error : toHttpError(error, 500, 'Load forecast failed'));
   }
@@ -96,7 +174,7 @@ router.post('/pv/forecast', async (req: Request, res: Response, next: NextFuncti
 
     const result = await executePvForecast(config, 'pv/forecast');
     await persistForecastData({ pv: result?.forecast });
-    res.json(result);
+    res.json(await withAdjustedForecast(result, 'pv'));
   } catch (error) {
     next(error instanceof HttpError ? error : toHttpError(error, 500, 'PV forecast failed'));
   }
@@ -141,7 +219,11 @@ async function runCombinedForecast(config: PredictionRunConfig, endpoint: string
   } catch (err) {
     console.warn('[predict] forecast persistence failed:', err instanceof Error ? err.message : err);
   }
-  return { load: loadResult, pv: pvResult };
+  const { adjustments } = await loadActiveAdjustmentsAndPrune();
+  return {
+    load: applyForecastAdjustments(loadResult, 'load', adjustments),
+    pv: applyForecastAdjustments(pvResult, 'pv', adjustments),
+  };
 }
 
 async function executeLoadForecast(config: PredictionRunConfig, logLabel: string): Promise<ForecastRunResult> {
@@ -224,6 +306,35 @@ async function persistForecastData(updates: { load?: TimeSeries; pv?: TimeSeries
   if (setLoad) data.load = updates.load!;
   if (setPv)   data.pv   = updates.pv!;
   await saveData(data);
+}
+
+async function loadActiveAdjustmentsAndPrune() {
+  const data = await loadData();
+  const pruned = pruneExpiredPredictionAdjustments(data);
+  if (pruned.changed) await saveData(pruned.data);
+  return { data: pruned.data, adjustments: pruned.adjustments };
+}
+
+function applyForecastAdjustments<T extends { forecast?: TimeSeries } | null>(
+  result: T,
+  series: PredictionAdjustmentSeries,
+  adjustments: ReturnType<typeof pruneExpiredPredictionAdjustments>['adjustments'],
+): (T & { rawForecast?: TimeSeries }) | T {
+  if (!result?.forecast) return result;
+  const rawForecast = result.forecast;
+  return {
+    ...result,
+    rawForecast,
+    forecast: applyPredictionAdjustmentsToSeries(rawForecast, adjustments, series),
+  };
+}
+
+async function withAdjustedForecast<T extends { forecast?: TimeSeries } | null>(
+  result: T,
+  series: PredictionAdjustmentSeries,
+): Promise<(T & { rawForecast?: TimeSeries }) | T> {
+  const { adjustments } = await loadActiveAdjustmentsAndPrune();
+  return applyForecastAdjustments(result, series, adjustments);
 }
 
 function mapPredictionError(err: unknown, isPv: boolean): Error {

--- a/api/services/config-builder.ts
+++ b/api/services/config-builder.ts
@@ -1,6 +1,7 @@
 import { HttpError } from '../http-errors.ts';
 import { loadSettings } from './settings-store.ts';
-import { loadData } from './data-store.ts';
+import { loadData, saveData } from './data-store.ts';
+import { applyPredictionAdjustmentsToData, pruneExpiredPredictionAdjustments } from './prediction-adjustments.ts';
 import { extractWindow, getQuarterStart } from '../../lib/time-series-utils.ts';
 import { fetchHaEntityState } from './ha-client.ts';
 import type { SolverConfig, TimeSeries, EvConfig } from '../../lib/types.ts';
@@ -131,8 +132,11 @@ export function buildSolverConfigFromSettings(
 }
 
 export async function getSolverInputs(): Promise<{ cfg: SolverConfig; timing: { startMs: number; stepMin: number }; data: Data; settings: Settings }> {
-  const [settings, data] = await Promise.all([loadSettings(), loadData()]);
+  const [settings, loadedData] = await Promise.all([loadSettings(), loadData()]);
   const startMs = getQuarterStart(new Date(), settings.stepSize_m);
+  const pruned = pruneExpiredPredictionAdjustments(loadedData, startMs);
+  if (pruned.changed) await saveData(pruned.data);
+  const data = pruned.data;
 
   let evState: { pluggedIn: boolean; soc_percent: number } | undefined;
   if (settings.evEnabled && settings.evSocSensor && settings.evPlugSensor) {
@@ -154,6 +158,7 @@ export async function getSolverInputs(): Promise<{ cfg: SolverConfig; timing: { 
     }
   }
 
-  const cfg = buildSolverConfigFromSettings(settings, data, startMs, evState);
+  const adjustedData = applyPredictionAdjustmentsToData(data);
+  const cfg = buildSolverConfigFromSettings(settings, adjustedData, startMs, evState);
   return { cfg, timing: { startMs, stepMin: settings.stepSize_m }, data, settings };
 }

--- a/api/services/data-store.ts
+++ b/api/services/data-store.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { resolveDataDir, readJson, writeJson } from './json-store.ts';
 import type { Data, TimeSeries } from '../types.ts';
+import { validatePredictionAdjustment } from './prediction-adjustments.ts';
 
 const DATA_DIR = resolveDataDir();
 const DATA_PATH = path.join(DATA_DIR, 'data.json');
@@ -32,6 +33,14 @@ export function validateData(d: Data): Data {
   }
   if (Number.isNaN(new Date(d.soc.timestamp).getTime())) {
     throw new Error(`Invalid soc: 'timestamp' is not a valid timestamp (${d.soc.timestamp})`);
+  }
+  if (d.predictionAdjustments !== undefined) {
+    if (!Array.isArray(d.predictionAdjustments)) {
+      throw new Error("Invalid predictionAdjustments: must be an array");
+    }
+    for (const adjustment of d.predictionAdjustments) {
+      validatePredictionAdjustment(adjustment);
+    }
   }
   return d;
 }

--- a/api/services/planner-service.ts
+++ b/api/services/planner-service.ts
@@ -4,10 +4,11 @@ import { mapRowsToDessV2 } from '../../lib/dess-mapper.ts';
 import { buildLP } from '../../lib/build-lp.ts';
 import { parseSolution, type HighsSolution } from '../../lib/parse-solution.ts';
 import { buildPlanSummary } from '../../lib/plan-summary.ts';
-import type { SolverConfig, PlanSummary } from '../../lib/types.ts';
+import type { SolverConfig, PlanSummary, PlanRow, TimeSeries } from '../../lib/types.ts';
 import { getSolverInputs, buildSolverConfigFromSettings } from './config-builder.ts';
 import { saveSettings } from './settings-store.ts';
 import { saveData } from './data-store.ts';
+import { applyPredictionAdjustmentsToData } from './prediction-adjustments.ts';
 import { refreshSeriesFromVrmAndPersist } from './vrm-refresh.ts';
 import { setDynamicEssSchedule } from './mqtt-service.ts';
 import type { PlanRowWithDess, Data } from '../types.ts';
@@ -64,6 +65,38 @@ function extractRebalanceWindow(
   return undefined;
 }
 
+function roundPower(value: number): number {
+  return Math.round(value * 1000) / 1000;
+}
+
+function valueAtTimestampPrecomputed(series: TimeSeries, timestampMs: number, startMs: number, stepMs: number): number | null {
+  if (!Number.isFinite(startMs) || !Number.isFinite(stepMs) || stepMs <= 0) return null;
+  const index = Math.floor((timestampMs - startMs) / stepMs);
+  if (index < 0 || index >= series.values.length) return null;
+  const value = Number(series.values[index]);
+  return Number.isFinite(value) ? roundPower(value) : null;
+}
+
+function attachOriginalPredictionValues(rows: PlanRow[], data: Data): PlanRow[] {
+  const loadStartMs = new Date(data.load.start).getTime();
+  const loadStepMs = (data.load.step ?? 15) * 60_000;
+  const pvStartMs = new Date(data.pv.start).getTime();
+  const pvStepMs = (data.pv.step ?? 15) * 60_000;
+
+  return rows.map(row => {
+    const originalLoad = valueAtTimestampPrecomputed(data.load, row.timestampMs, loadStartMs, loadStepMs);
+    const originalPv = valueAtTimestampPrecomputed(data.pv, row.timestampMs, pvStartMs, pvStepMs);
+    const hasLoad = originalLoad != null && Math.abs(originalLoad - row.load) > 0.001;
+    const hasPv = originalPv != null && Math.abs(originalPv - row.pv) > 0.001;
+    if (!hasLoad && !hasPv) return row;
+    return {
+      ...row,
+      ...(hasLoad ? { originalLoad } : {}),
+      ...(hasPv ? { originalPv } : {}),
+    };
+  });
+}
+
 // Cache of the last computed plan, used by /ev/* endpoints
 let lastPlan: ComputePlanResult | undefined;
 
@@ -91,7 +124,7 @@ export async function computePlan({ updateData = false } = {}): Promise<ComputeP
     settings = { ...settings, rebalanceEnabled: false };
     await Promise.all([saveSettings(settings), saveData(data)]);
     // Rebuild cfg without rebalance constraints
-    cfg = buildSolverConfigFromSettings(settings, data, timing.startMs);
+    cfg = buildSolverConfigFromSettings(settings, applyPredictionAdjustmentsToData(data), timing.startMs);
   }
 
   const lpText = buildLP(cfg);
@@ -121,7 +154,7 @@ export async function computePlan({ updateData = false } = {}): Promise<ComputeP
     solveMs: Math.round(solveMs),
   });
 
-  const rows = parseSolution(result, cfg, timing);
+  const rows = attachOriginalPredictionValues(parseSolution(result, cfg, timing), data);
 
   const { perSlot, diagnostics } = mapRowsToDessV2(rows, cfg, {
     blockFeedInOnNegativePrices: settings.blockFeedInOnNegativePrices !== false,

--- a/api/services/prediction-adjustments.ts
+++ b/api/services/prediction-adjustments.ts
@@ -130,7 +130,9 @@ export function applyPredictionAdjustmentsToSeries(
       .map(({ adj }) => adj);
     if (!matching.length) return raw;
 
-    const setAdjustment = matching.filter(adj => adj.mode === 'set').at(-1);
+    const setAdjustment = matching
+      .filter(adj => adj.mode === 'set')
+      .reduce<PredictionAdjustment | undefined>((best, adj) => !best || adj.updatedAt > best.updatedAt ? adj : best, undefined);
     const base = setAdjustment ? setAdjustment.value_W : raw;
     const delta = matching
       .filter(adj => adj.mode === 'add')

--- a/api/services/prediction-adjustments.ts
+++ b/api/services/prediction-adjustments.ts
@@ -1,0 +1,152 @@
+import { randomUUID } from 'node:crypto';
+import { HttpError } from '../http-errors.ts';
+import type {
+  Data,
+  PredictionAdjustment,
+  PredictionAdjustmentMode,
+  PredictionAdjustmentSeries,
+  TimeSeries,
+} from '../types.ts';
+
+export interface PredictionAdjustmentInput {
+  series?: unknown;
+  mode?: unknown;
+  value_W?: unknown;
+  start?: unknown;
+  end?: unknown;
+  label?: unknown;
+}
+
+const SERIES = new Set<PredictionAdjustmentSeries>(['load', 'pv']);
+const MODES = new Set<PredictionAdjustmentMode>(['set', 'add']);
+
+function toTimestamp(value: string, field: string): number {
+  const ts = new Date(value).getTime();
+  if (!Number.isFinite(ts)) throw new HttpError(400, `${field} must be a valid timestamp`);
+  return ts;
+}
+
+function normalizeLabel(value: unknown): string | undefined {
+  if (value == null) return undefined;
+  const label = String(value).trim();
+  return label ? label.slice(0, 120) : undefined;
+}
+
+function parseAdjustmentFields(
+  input: PredictionAdjustmentInput,
+  base?: PredictionAdjustment,
+  nowMs = Date.now(),
+): Omit<PredictionAdjustment, 'id' | 'createdAt' | 'updatedAt'> {
+  const series = (input.series ?? base?.series) as PredictionAdjustmentSeries;
+  if (!SERIES.has(series)) throw new HttpError(400, 'series must be "load" or "pv"');
+
+  const mode = (input.mode ?? base?.mode) as PredictionAdjustmentMode;
+  if (!MODES.has(mode)) throw new HttpError(400, 'mode must be "set" or "add"');
+
+  const valueRaw = input.value_W ?? base?.value_W;
+  const value_W = Number(valueRaw);
+  if (!Number.isFinite(value_W)) throw new HttpError(400, 'value_W must be a finite number');
+  if (mode === 'set' && value_W < 0) throw new HttpError(400, 'set adjustments require value_W >= 0');
+
+  const start = String(input.start ?? base?.start ?? '');
+  const end = String(input.end ?? base?.end ?? '');
+  const startMs = toTimestamp(start, 'start');
+  const endMs = toTimestamp(end, 'end');
+  if (endMs <= startMs) throw new HttpError(400, 'end must be after start');
+  if (endMs <= nowMs) throw new HttpError(400, 'end must be in the future');
+
+  const label = normalizeLabel(input.label ?? base?.label);
+  return {
+    series,
+    mode,
+    value_W,
+    start: new Date(startMs).toISOString(),
+    end: new Date(endMs).toISOString(),
+    ...(label ? { label } : {}),
+  };
+}
+
+export function validatePredictionAdjustment(adjustment: PredictionAdjustment): void {
+  parseAdjustmentFields(adjustment, undefined, 0);
+  if (!adjustment.id || typeof adjustment.id !== 'string') {
+    throw new Error('Invalid predictionAdjustments: id must be a string');
+  }
+  if (Number.isNaN(new Date(adjustment.createdAt).getTime())) {
+    throw new Error('Invalid predictionAdjustments: createdAt must be a valid timestamp');
+  }
+  if (Number.isNaN(new Date(adjustment.updatedAt).getTime())) {
+    throw new Error('Invalid predictionAdjustments: updatedAt must be a valid timestamp');
+  }
+}
+
+export function createPredictionAdjustment(input: PredictionAdjustmentInput, nowMs = Date.now()): PredictionAdjustment {
+  const nowIso = new Date(nowMs).toISOString();
+  return {
+    id: randomUUID(),
+    ...parseAdjustmentFields(input, undefined, nowMs),
+    createdAt: nowIso,
+    updatedAt: nowIso,
+  };
+}
+
+export function updatePredictionAdjustment(
+  existing: PredictionAdjustment,
+  input: PredictionAdjustmentInput,
+  nowMs = Date.now(),
+): PredictionAdjustment {
+  return {
+    ...existing,
+    ...parseAdjustmentFields(input, existing, nowMs),
+    updatedAt: new Date(nowMs).toISOString(),
+  };
+}
+
+export function pruneExpiredPredictionAdjustments(
+  data: Data,
+  nowMs = Date.now(),
+): { data: Data; changed: boolean; adjustments: PredictionAdjustment[] } {
+  const adjustments = data.predictionAdjustments ?? [];
+  const active = adjustments.filter(adj => toTimestamp(adj.end, 'end') > nowMs);
+  if (active.length === adjustments.length) return { data, changed: false, adjustments: active };
+  const nextData: Data = { ...data, predictionAdjustments: active };
+  return { data: nextData, changed: true, adjustments: active };
+}
+
+export function applyPredictionAdjustmentsToSeries(
+  series: TimeSeries,
+  adjustments: PredictionAdjustment[] | undefined,
+  targetSeries: PredictionAdjustmentSeries,
+): TimeSeries {
+  const relevant = (adjustments ?? []).filter(adj => adj.series === targetSeries);
+  if (!relevant.length) return series;
+
+  const startMs = new Date(series.start).getTime();
+  const stepMs = (series.step ?? 15) * 60_000;
+  const relevantMs = relevant.map(adj => ({ adj, startMs: new Date(adj.start).getTime(), endMs: new Date(adj.end).getTime() }));
+  const values = series.values.map((raw, index) => {
+    const slotMs = startMs + index * stepMs;
+    const matching = relevantMs
+      .filter(({ startMs: s, endMs: e }) => slotMs >= s && slotMs < e)
+      .map(({ adj }) => adj);
+    if (!matching.length) return raw;
+
+    const setAdjustment = matching.filter(adj => adj.mode === 'set').at(-1);
+    const base = setAdjustment ? setAdjustment.value_W : raw;
+    const delta = matching
+      .filter(adj => adj.mode === 'add')
+      .reduce((sum, adj) => sum + adj.value_W, 0);
+    return Math.max(0, base + delta);
+  });
+
+  return { ...series, values };
+}
+
+export function applyPredictionAdjustmentsToData(data: Data): Data {
+  const adjustments = data.predictionAdjustments ?? [];
+  if (!adjustments.length) return data;
+  return {
+    ...data,
+    load: applyPredictionAdjustmentsToSeries(data.load, adjustments, 'load'),
+    pv: applyPredictionAdjustmentsToSeries(data.pv, adjustments, 'pv'),
+  };
+}

--- a/api/services/vrm-refresh.ts
+++ b/api/services/vrm-refresh.ts
@@ -136,7 +136,15 @@ export async function refreshSeriesFromVrmAndPersist(): Promise<void> {
     ? { timestamp: new Date().toISOString(), value: socPercent }
     : baseData.soc;
 
-  const nextData: Data = { load, pv, importPrice, exportPrice, soc, rebalanceState: baseData.rebalanceState };
+  const nextData: Data = {
+    load,
+    pv,
+    importPrice,
+    exportPrice,
+    soc,
+    rebalanceState: baseData.rebalanceState,
+    predictionAdjustments: baseData.predictionAdjustments,
+  };
   await saveData(nextData);
 
   // Optionally keep stepSize_m in settings in sync

--- a/api/types.ts
+++ b/api/types.ts
@@ -64,6 +64,21 @@ export interface RebalanceState {
   startMs: number | null;
 }
 
+export type PredictionAdjustmentSeries = 'load' | 'pv';
+export type PredictionAdjustmentMode = 'set' | 'add';
+
+export interface PredictionAdjustment {
+  id: string;
+  series: PredictionAdjustmentSeries;
+  mode: PredictionAdjustmentMode;
+  value_W: number;
+  start: string;
+  end: string;
+  label?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface Data {
   load: TimeSeries;
   pv: TimeSeries;
@@ -71,6 +86,7 @@ export interface Data {
   exportPrice: TimeSeries;
   soc: SocData;
   rebalanceState?: RebalanceState;
+  predictionAdjustments?: PredictionAdjustment[];
 }
 
 // ----------------------------- Plan rows with DESS ----------------------

--- a/app/index.html
+++ b/app/index.html
@@ -968,7 +968,7 @@
     <section class="lg:col-span-2 space-y-6 min-w-0">
 
       <!-- Combined Forecast Chart -->
-      <section class="card">
+      <section class="card relative">
         <div class="mb-3 flex items-center justify-between gap-3">
           <h2 class="sidebar-label">Forecast</h2>
           <div class="flex items-center gap-3">
@@ -995,6 +995,88 @@
             </svg>
             <span>Run a forecast to see results</span>
           </div>
+        </div>
+        <div id="forecast-adjustment-popover"
+          autocomplete="off" data-lpignore="true" data-1p-ignore="true" data-bwignore="true" data-form-type="other"
+          class="hidden mt-4 rounded-lg border border-slate-200 bg-slate-50 p-3 dark:border-white/10 dark:bg-slate-900/70">
+          <div class="mb-3 flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <h3 id="forecast-adjustment-title" class="text-sm font-semibold text-ink dark:text-slate-100">Manual adjustment</h3>
+              <p id="forecast-adjustment-range" class="mt-0.5 text-xs text-slate-500 dark:text-slate-400"></p>
+            </div>
+            <div class="ml-auto flex items-center gap-2">
+              <div class="flex rounded-lg bg-slate-100 p-1 dark:bg-slate-800">
+                <button type="button" data-adjust-series="load"
+                  class="forecast-adjustment-series rounded-md px-3 py-1.5 text-sm font-medium">Load</button>
+                <button type="button" data-adjust-series="pv"
+                  class="forecast-adjustment-series rounded-md px-3 py-1.5 text-sm font-medium">PV</button>
+              </div>
+              <button id="forecast-adjustment-cancel" type="button" title="Close"
+                class="rounded-md p-1 text-slate-400 hover:bg-slate-100 hover:text-slate-700 dark:hover:bg-slate-800 dark:hover:text-slate-200">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 24 24" fill="none"
+                  stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <path d="M18 6 6 18" />
+                  <path d="m6 6 12 12" />
+                </svg>
+              </button>
+            </div>
+          </div>
+
+          <div class="space-y-3">
+            <div class="grid gap-2 sm:grid-cols-[auto_minmax(0,1fr)]">
+              <div class="flex rounded-lg bg-slate-100 p-1 dark:bg-slate-800">
+                <button type="button" data-adjust-mode="set"
+                  class="forecast-adjustment-mode rounded-md px-3 py-2 text-sm font-medium">Set to</button>
+                <button type="button" data-adjust-mode="add"
+                  class="forecast-adjustment-mode rounded-md px-3 py-2 text-sm font-medium">Add</button>
+              </div>
+              <label class="block text-sm">
+                <span class="sr-only">Watts</span>
+                <div class="relative">
+                  <input id="forecast-adjustment-watts" type="number" step="10" class="form-input pr-10" placeholder="0"
+                    autocomplete="off" data-lpignore="true" data-1p-ignore="true" data-bwignore="true" />
+                  <span class="pointer-events-none absolute inset-y-0 right-3 flex items-center text-sm font-medium text-slate-400 dark:text-slate-500">
+                    W
+                  </span>
+                </div>
+              </label>
+            </div>
+
+            <div class="grid grid-cols-2 gap-2">
+              <label class="block text-sm">
+                <span class="block text-xs font-medium text-slate-400 dark:text-slate-500 mb-1 tracking-wide">Start</span>
+                <input id="forecast-adjustment-start" type="datetime-local" step="900" class="form-input"
+                  autocomplete="off" data-lpignore="true" data-1p-ignore="true" data-bwignore="true" />
+              </label>
+              <label class="block text-sm">
+                <span class="block text-xs font-medium text-slate-400 dark:text-slate-500 mb-1 tracking-wide">End</span>
+                <input id="forecast-adjustment-end" type="datetime-local" step="900" class="form-input"
+                  autocomplete="off" data-lpignore="true" data-1p-ignore="true" data-bwignore="true" />
+              </label>
+            </div>
+
+            <p id="forecast-adjustment-error" class="hidden text-sm font-medium text-red-600 dark:text-red-400"></p>
+
+            <div class="flex flex-wrap items-center justify-end gap-2">
+              <div class="ml-auto flex items-center gap-2">
+                <button id="forecast-adjustment-delete" type="button"
+                  class="hidden rounded-lg border border-red-200 bg-white px-3 py-2 text-sm font-medium text-red-600 hover:bg-red-50 dark:border-red-900/60 dark:bg-slate-900 dark:text-red-400 dark:hover:bg-red-950/30">
+                  Delete
+                </button>
+                <button id="forecast-adjustment-save" type="button"
+                  class="rounded-lg bg-sky-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-sky-700 focus:outline-none focus:ring-2 focus:ring-sky-400/50">
+                  Save
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="mt-4 border-t border-slate-100 pt-3 dark:border-white/5">
+          <div class="mb-2 flex items-center justify-between">
+            <h3 class="sidebar-label">Manual adjustments</h3>
+            <span id="prediction-adjustments-count" class="text-xs font-medium text-slate-400 dark:text-slate-500"></span>
+          </div>
+          <div id="prediction-adjustments-list" class="space-y-2"></div>
         </div>
       </section>
 
@@ -1269,7 +1351,9 @@
                 class="form-input" />
             </label>
             <label class="block text-sm">Access Token
-              <input id="pred-ha-token" type="password" placeholder="eyJ…" class="form-input" />
+              <input id="pred-ha-token" type="password" placeholder="eyJ…" class="form-input"
+                autocomplete="new-password" spellcheck="false" data-lpignore="true" data-1p-ignore="true"
+                data-bwignore="true" data-form-type="other" />
             </label>
           </div>
         </section>

--- a/app/src/api/api.js
+++ b/app/src/api/api.js
@@ -18,6 +18,11 @@ export function requestRemoteSolve(body = {}) {
   return postJson("/calculate", body);
 }
 
+// --- Data ---
+export function fetchStoredData() {
+  return getJson("/data");
+}
+
 // --- VRM ---
 export function refreshVrmSettings() {
   return postJson("/vrm/refresh-settings", {});
@@ -40,3 +45,7 @@ export const runLoadForecast = () => postJson('/predictions/load/forecast', {});
 export const runPvForecast = () => postJson('/predictions/pv/forecast', {});
 export const runCombinedForecast = () => postJson('/predictions/forecast', {});
 export const fetchForecast = runCombinedForecast;
+export const fetchPredictionAdjustments = () => getJson('/predictions/adjustments');
+export const createPredictionAdjustment = (adjustment) => postJson('/predictions/adjustments', adjustment);
+export const updatePredictionAdjustment = (id, adjustment) => postJson(`/predictions/adjustments/${encodeURIComponent(id)}`, adjustment, { method: 'PATCH' });
+export const deletePredictionAdjustment = (id) => postJson(`/predictions/adjustments/${encodeURIComponent(id)}`, {}, { method: 'DELETE' });

--- a/app/src/charts.js
+++ b/app/src/charts.js
@@ -590,6 +590,7 @@ export function getBaseOptions({ ticksCb, tooltipTitleCb, gridCb, yTitle, stacke
       font: { size: 12, family: fontFamily }
     }
   };
+  const { legend: legendOverrides, tooltip: tooltipOverrides, ...pluginOverrides } = overrides.plugins || {};
 
   // Deep merge for plugins/scales is often needed, but simple spread works for this specific file structure
   const options = {
@@ -599,13 +600,21 @@ export function getBaseOptions({ ticksCb, tooltipTitleCb, gridCb, yTitle, stacke
     layout: { padding: { bottom: overrides.layout?.padding?.bottom ?? -6 } },
     ...('animation' in overrides ? { animation: overrides.animation } : {}),
     plugins: {
-      legend: legendSquare,
+      legend: {
+        ...legendSquare,
+        ...(legendOverrides || {}),
+        labels: {
+          ...legendSquare.labels,
+          ...(legendOverrides?.labels || {}),
+        },
+      },
       tooltip: {
         mode: "index",
         intersect: false,
-        callbacks: { title: tooltipTitleCb }
+        callbacks: { title: tooltipTitleCb },
+        ...(tooltipOverrides || {}),
       },
-      ...overrides.plugins
+      ...pluginOverrides
     },
     scales: {
       x: {
@@ -1009,15 +1018,10 @@ export function drawPricesStepLines(canvas, rows, _stepSize_m = 15) {
   });
 }
 
-// -----------------------------------------------------------------------------
-// 4) Forecast grouped bars (hourly aggregation)
-// -----------------------------------------------------------------------------
-
-export function drawLoadPvGrouped(canvas, rows, stepSize_m = 15) {
+export function aggregateLoadPvBuckets(rows, stepSize_m = 15) {
   const stepHours = Math.max(0.000001, Number(stepSize_m) / 60);
   const W2kWh = (x) => (x || 0) * stepHours / 1000;
 
-  // Aggregate 15min slots into hourly buckets
   const hourMap = new Map();
 
   for (const row of rows) {
@@ -1026,21 +1030,42 @@ export function drawLoadPvGrouped(canvas, rows, stepSize_m = 15) {
     const hourMs = dt.getTime();
 
     if (!hourMap.has(hourMs)) {
-      hourMap.set(hourMs, { dtHour: dt, loadKWh: 0, pvKWh: 0 });
+      hourMap.set(hourMs, {
+        dtHour: dt,
+        loadKWh: 0,
+        pvKWh: 0,
+        originalLoadKWh: 0,
+        originalPvKWh: 0,
+        hasOriginalLoad: false,
+        hasOriginalPv: false,
+      });
     }
     const bucket = hourMap.get(hourMs);
     bucket.loadKWh += W2kWh(row.load);
     bucket.pvKWh += W2kWh(row.pv);
+    bucket.originalLoadKWh += W2kWh(row.originalLoad ?? row.load);
+    bucket.originalPvKWh += W2kWh(row.originalPv ?? row.pv);
+    bucket.hasOriginalLoad ||= row.originalLoad != null;
+    bucket.hasOriginalPv ||= row.originalPv != null;
   }
 
-  const buckets = [...hourMap.values()].sort((a, b) => a.dtHour - b.dtHour);
+  return [...hourMap.values()].sort((a, b) => a.dtHour - b.dtHour);
+}
+
+// -----------------------------------------------------------------------------
+// 4) Forecast grouped bars (hourly aggregation)
+// -----------------------------------------------------------------------------
+
+export function drawLoadPvGrouped(canvas, rows, stepSize_m = 15) {
+  const buckets = aggregateLoadPvBuckets(rows, stepSize_m);
 
   // Build axis based on aggregated timestamps
   const axis = buildTimeAxisFromTimestamps(buckets.map(b => b.dtHour.getTime()));
 
   const stripe = (c) => window.pattern?.draw("diagonal", c) || c;
-  const ds = (label, data, color) => ({
+  const ds = (label, data, color, series) => ({
     label, data,
+    series,
     backgroundColor: stripe(color),
     borderColor: color,
     borderWidth: 1,
@@ -1052,8 +1077,8 @@ export function drawLoadPvGrouped(canvas, rows, stepSize_m = 15) {
     data: {
       labels: axis.labels,
       datasets: [
-        ds("Consumption forecast", buckets.map(b => b.loadKWh), SOLUTION_COLORS.g2l),
-        ds("Solar forecast", buckets.map(b => b.pvKWh), SOLUTION_COLORS.pv2g)
+        ds("Consumption forecast", buckets.map(b => b.loadKWh), SOLUTION_COLORS.g2l, "load"),
+        ds("Solar forecast", buckets.map(b => b.pvKWh), SOLUTION_COLORS.pv2g, "pv")
       ]
     },
     options: getBaseOptions({ ...axis, yTitle: "kWh" }, {
@@ -1070,6 +1095,16 @@ export function drawLoadPvGrouped(canvas, rows, stepSize_m = 15) {
               for (const pt of (tooltip.dataPoints ?? [])) {
                 if (pt.raw == null) continue;
                 html += ttRow(pt.dataset.borderColor, pt.dataset.label, `${fmtKwh(pt.raw)} kWh`);
+                const bucket = buckets[pt.dataIndex];
+                const original = pt.dataset.series === "pv" ? bucket?.originalPvKWh : bucket?.originalLoadKWh;
+                const hasOriginal = pt.dataset.series === "pv" ? bucket?.hasOriginalPv : bucket?.hasOriginalLoad;
+                if (hasOriginal && original != null && Math.abs(original - pt.raw) > 0.001) {
+                  html += ttRow(
+                    toRGBA(pt.dataset.borderColor, 0.45),
+                    `Original ${pt.dataset.label.toLowerCase()}`,
+                    `${fmtKwh(original)} kWh`,
+                  );
+                }
               }
               return html;
             },

--- a/app/src/predictions.js
+++ b/app/src/predictions.js
@@ -5,21 +5,34 @@
  */
 
 import {
+  createPredictionAdjustment,
+  deletePredictionAdjustment,
+  fetchPredictionAdjustments,
   fetchPredictionConfig,
+  fetchStoredData,
   savePredictionConfig,
+  updatePredictionAdjustment,
   runPvForecast,
   runCombinedForecast,
 } from './api/api.js';
-import { debounce } from './utils.js';
+import { debounce, escapeHtml } from './utils.js';
 import { buildTimeAxisFromTimestamps, getBaseOptions, renderChart, toRGBA, SOLUTION_COLORS } from './charts.js';
 import { createTooltipHandler, fmtKwh, getChartAnimations, ttHeader, ttRow, ttDivider } from './chart-tooltip.js';
 import { initValidation } from './predictions-validation.js';
 
 let lastLoadForecast = null;
 let lastPvForecast = null;
+let lastLoadForecastRaw = null;
+let lastPvForecastRaw = null;
+let predictionAdjustments = [];
+let forecastChartSelection = null;
+let forecastChartDrag = null;
+let adjustmentDraft = null;
 
 export async function initPredictionsTab() {
   await hydrateForm();
+  await loadAdjustments();
+  await hydrateForecastsFromStoredData();
   wireForm();
   onForecastAll();
 }
@@ -48,6 +61,143 @@ function aggregateForecastKwh(forecast, stepMinutes = 60) {
   const timestamps = [...timeMap.keys()].sort((a, b) => a - b);
   const aggregatedKwh = timestamps.map(k => timeMap.get(k) / 1000);
   return { timestamps, values: aggregatedKwh };
+}
+
+export function applyAdjustmentsToForecastSeries(forecast, adjustments, series) {
+  if (!forecast || !Array.isArray(forecast.values)) return forecast;
+  const nowMs = Date.now();
+  const relevant = (adjustments || []).filter(adj => adj.series === series && new Date(adj.end).getTime() > nowMs);
+  if (!relevant.length) return forecast;
+
+  const startTs = new Date(forecast.start).getTime();
+  const stepMs = (forecast.step || 15) * 60 * 1000;
+  return {
+    ...forecast,
+    values: forecast.values.map((raw, index) => {
+      const slotTs = startTs + index * stepMs;
+      const matching = relevant.filter(adj => slotTs >= new Date(adj.start).getTime() && slotTs < new Date(adj.end).getTime());
+      if (!matching.length) return raw;
+
+      const setAdjustment = matching.filter(adj => adj.mode === 'set').at(-1);
+      const base = setAdjustment ? Number(setAdjustment.value_W) : raw;
+      const delta = matching
+        .filter(adj => adj.mode === 'add')
+        .reduce((sum, adj) => sum + Number(adj.value_W || 0), 0);
+      return Math.max(0, base + delta);
+    }),
+  };
+}
+
+export function buildForecastSelectionRange(startIndex, endIndex, timestamps, stepMinutes) {
+  if (!timestamps.length) return null;
+  const low = Math.min(startIndex, endIndex);
+  const high = Math.max(startIndex, endIndex);
+  const first = Math.max(0, Math.min(timestamps.length - 1, low));
+  const last = Math.max(0, Math.min(timestamps.length - 1, high));
+  const stepMs = stepMinutes * 60 * 1000;
+  return {
+    startIndex: first,
+    endIndex: last,
+    start: new Date(timestamps[first]).toISOString(),
+    end: new Date(timestamps[last] + stepMs).toISOString(),
+  };
+}
+
+export function forecastSeriesFromCategoryX(x, bounds) {
+  if (!bounds || !Number.isFinite(x)) return 'load';
+  const mid = (bounds.left + bounds.right) / 2;
+  return x >= mid ? 'pv' : 'load';
+}
+
+export function futureForecastSeries(series, nowMs = Date.now()) {
+  if (!series || !Array.isArray(series.values) || !series.values.length) return null;
+  const startMs = new Date(series.start).getTime();
+  if (!Number.isFinite(startMs)) return null;
+  const step = Number(series.step || 15);
+  if (!Number.isFinite(step) || step <= 0) return null;
+
+  const stepMs = step * 60 * 1000;
+  const offset = Math.max(0, Math.floor((nowMs - startMs) / stepMs));
+  if (offset >= series.values.length) return null;
+  return {
+    ...series,
+    start: new Date(startMs + offset * stepMs).toISOString(),
+    step,
+    values: series.values.slice(offset),
+  };
+}
+
+function refreshAdjustedForecastsFromRaw() {
+  lastLoadForecast = lastLoadForecastRaw
+    ? applyAdjustmentsToForecastSeries(lastLoadForecastRaw, predictionAdjustments, 'load')
+    : null;
+  lastPvForecast = lastPvForecastRaw
+    ? applyAdjustmentsToForecastSeries(lastPvForecastRaw, predictionAdjustments, 'pv')
+    : null;
+}
+
+async function loadAdjustments() {
+  try {
+    const result = await fetchPredictionAdjustments();
+    predictionAdjustments = Array.isArray(result?.adjustments) ? result.adjustments : [];
+    renderAdjustmentList();
+  } catch (err) {
+    console.error('Failed to load prediction adjustments:', err);
+  }
+}
+
+async function hydrateForecastsFromStoredData() {
+  try {
+    const data = await fetchStoredData();
+    const load = futureForecastSeries(data?.load);
+    const pv = futureForecastSeries(data?.pv);
+    if (!load && !pv) return;
+
+    lastLoadForecastRaw = load;
+    lastPvForecastRaw = pv;
+    refreshAdjustedForecastsFromRaw();
+    renderCombinedForecastChart();
+    if (load) updateStoredForecastMetrics('load', load, lastLoadForecast);
+    if (pv) updateStoredForecastMetrics('pv', pv, lastPvForecast);
+  } catch (err) {
+    console.error('Failed to load stored forecast data:', err);
+  }
+}
+
+function setAdjustments(nextAdjustments) {
+  predictionAdjustments = Array.isArray(nextAdjustments) ? nextAdjustments : [];
+  refreshAdjustedForecastsFromRaw();
+  renderCombinedForecastChart();
+  renderAdjustmentList();
+}
+
+function formatAdjustmentTime(value) {
+  return new Date(value).toLocaleString([], {
+    weekday: 'short',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function formatRange(start, end) {
+  return `${formatAdjustmentTime(start)} – ${formatAdjustmentTime(end)}`;
+}
+
+function toDatetimeLocalValue(value) {
+  const d = new Date(value);
+  const pad = (n) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function fromDatetimeLocalValue(value) {
+  const ts = new Date(value).getTime();
+  return Number.isFinite(ts) ? new Date(ts).toISOString() : '';
+}
+
+function adjustmentSummary(adj) {
+  const modeText = adj.mode === 'set' ? 'set to' : 'add';
+  const sign = adj.mode === 'add' && adj.value_W > 0 ? '+' : '';
+  return `${adj.series === 'pv' ? 'PV' : 'Load'} ${modeText} ${sign}${Math.round(adj.value_W).toLocaleString()} W`;
 }
 
 // ---------------------------------------------------------------------------
@@ -119,6 +269,8 @@ function wireForm() {
     ?.addEventListener('click', onPvForecast);
   document.getElementById('forecast-chart-15m')
     ?.addEventListener('change', renderCombinedForecastChart);
+
+  wireAdjustmentPopover();
 
   const settingsToggle = document.getElementById('pred-settings-toggle');
   const settingsBody = document.getElementById('pred-settings-body');
@@ -233,12 +385,15 @@ function updateForecastUI(type, result) {
   const label = type === 'load' ? 'Load' : 'PV';
   if (result) {
     if (type === 'load') {
+      lastLoadForecastRaw = result.rawForecast ?? result.forecast ?? null;
       lastLoadForecast = result.forecast ?? null;
       renderLoadAccuracyChart(result.recent);
     } else {
+      lastPvForecastRaw = result.rawForecast ?? result.forecast ?? null;
       lastPvForecast = result.forecast ?? null;
       renderPvAccuracyChart(result.recent);
     }
+    refreshAdjustedForecastsFromRaw();
     renderCombinedForecastChart();
     updateMetrics(type, result);
     updateStatus(type, `${label} forecast updated`);
@@ -280,6 +435,175 @@ function updateMetrics(prefix, resultObject) {
   }
 }
 
+function updateStoredForecastMetrics(prefix, rawForecast, adjustedForecast) {
+  updateMetrics(prefix, { forecast: adjustedForecast ?? rawForecast, metrics: { mae: NaN } });
+  setEl(`${prefix}-summary-error`, '--');
+  updateStatus(prefix, 'Stored data loaded');
+}
+
+function adjustmentOverlapsBucket(adj, bucketStartMs, bucketEndMs) {
+  return new Date(adj.start).getTime() < bucketEndMs && new Date(adj.end).getTime() > bucketStartMs;
+}
+
+function findAdjustmentAtBucket(bucketStartMs, bucketEndMs, series = null) {
+  return predictionAdjustments.findLast(adj => (!series || adj.series === series) && adjustmentOverlapsBucket(adj, bucketStartMs, bucketEndMs)) ?? null;
+}
+
+function findAdjustmentIndexes(adj, timestamps, stepMinutes) {
+  const stepMs = stepMinutes * 60 * 1000;
+  const adjEndMs = new Date(adj.end).getTime();
+  const first = timestamps.findIndex(ts => adjustmentOverlapsBucket(adj, ts, ts + stepMs));
+  if (first < 0) return null;
+  let last = first;
+  for (let i = first + 1; i < timestamps.length; i++) {
+    if (timestamps[i] >= adjEndMs) break;
+    if (adjustmentOverlapsBucket(adj, timestamps[i], timestamps[i] + stepMs)) last = i;
+  }
+  return { first, last };
+}
+
+function categoryBounds(chart, index) {
+  const x = chart.scales.x;
+  const labels = chart.data.labels || [];
+  const center = x.getPixelForValue(index);
+  const prev = index > 0 ? x.getPixelForValue(index - 1) : null;
+  const next = index < labels.length - 1 ? x.getPixelForValue(index + 1) : null;
+  const half = next != null
+    ? Math.abs(next - center) / 2
+    : prev != null
+      ? Math.abs(center - prev) / 2
+      : (chart.chartArea.right - chart.chartArea.left) / 2;
+  return {
+    left: Math.max(chart.chartArea.left, center - half),
+    right: Math.min(chart.chartArea.right, center + half),
+  };
+}
+
+function seriesLaneBounds(bounds, series) {
+  const width = bounds.right - bounds.left;
+  const gap = Math.min(2, width * 0.05);
+  const mid = (bounds.left + bounds.right) / 2;
+  if (series === 'pv') {
+    return {
+      left: Math.min(bounds.right, mid + gap),
+      right: bounds.right,
+    };
+  }
+  return {
+    left: bounds.left,
+    right: Math.max(bounds.left, mid - gap),
+  };
+}
+
+function drawSeriesLane(chart, index, series, draw) {
+  const bounds = seriesLaneBounds(categoryBounds(chart, index), series);
+  const width = bounds.right - bounds.left;
+  if (width <= 0) return;
+  draw(bounds.left, width);
+}
+
+function makeAdjustmentOverlayPlugin(timestamps, stepMinutes) {
+  return {
+    id: 'predictionAdjustmentOverlay',
+    beforeDatasetsDraw(chart) {
+      const { ctx, chartArea } = chart;
+      if (!chartArea || !timestamps.length) return;
+
+      ctx.save();
+      for (const adj of predictionAdjustments) {
+        const range = findAdjustmentIndexes(adj, timestamps, stepMinutes);
+        if (!range) continue;
+        const color = adj.series === 'pv' ? SOLUTION_COLORS.pv2g : SOLUTION_COLORS.g2l;
+        ctx.fillStyle = toRGBA(color, 0.10);
+        for (let i = range.first; i <= range.last; i++) {
+          drawSeriesLane(chart, i, adj.series, (left, width) => {
+            ctx.fillRect(left, chartArea.top, width, chartArea.bottom - chartArea.top);
+          });
+        }
+      }
+
+      if (forecastChartSelection) {
+        ctx.fillStyle = 'rgba(14, 165, 233, 0.10)';
+        ctx.strokeStyle = 'rgba(14, 165, 233, 0.75)';
+        ctx.lineWidth = 1.5;
+        ctx.setLineDash([]);
+        for (let i = forecastChartSelection.startIndex; i <= forecastChartSelection.endIndex; i++) {
+          drawSeriesLane(chart, i, forecastChartSelection.series, (left, width) => {
+            ctx.fillRect(left, chartArea.top, width, chartArea.bottom - chartArea.top);
+            ctx.strokeRect(left, chartArea.top + 1, width, chartArea.bottom - chartArea.top - 2);
+          });
+        }
+      }
+      ctx.restore();
+    },
+  };
+}
+
+function makeForecastOriginalMarkersPlugin(timestamps, rawSeriesMaps) {
+  return {
+    id: 'forecastOriginalMarkers',
+    afterDatasetsDraw(chart) {
+      const { ctx, chartArea, scales } = chart;
+      if (!chartArea || !timestamps.length || !scales.y) return;
+      const isDark = document.documentElement.classList.contains('dark');
+      const markerFill = isDark ? 'rgba(226, 232, 240, 0.96)' : 'rgba(71, 85, 105, 0.92)';
+      const markerStroke = isDark ? 'rgba(15, 23, 42, 0.95)' : 'rgba(255, 255, 255, 0.95)';
+
+      ctx.save();
+      ctx.beginPath();
+      ctx.rect(chartArea.left, chartArea.top, chartArea.right - chartArea.left, chartArea.bottom - chartArea.top);
+      ctx.clip();
+
+      for (let datasetIndex = 0; datasetIndex < chart.data.datasets.length; datasetIndex++) {
+        const dataset = chart.data.datasets[datasetIndex];
+        const rawMap = rawSeriesMaps[dataset.series];
+        if (!rawMap) continue;
+
+        const meta = chart.getDatasetMeta(datasetIndex);
+        ctx.setLineDash([]);
+        ctx.lineJoin = 'round';
+
+        for (let i = 0; i < timestamps.length; i++) {
+          const raw = rawMap.get(timestamps[i]);
+          const adjusted = dataset.data[i];
+          const bar = meta.data[i];
+          if (raw == null || adjusted == null || !bar || Math.abs(raw - adjusted) <= 0.001) continue;
+
+          const props = bar.getProps(['x', 'width'], true);
+          const rawY = scales.y.getPixelForValue(raw);
+          const markerSize = Math.max(3.5, Math.min(5, props.width * 0.22));
+          ctx.beginPath();
+          ctx.moveTo(props.x, rawY - markerSize);
+          ctx.lineTo(props.x + markerSize, rawY);
+          ctx.lineTo(props.x, rawY + markerSize);
+          ctx.lineTo(props.x - markerSize, rawY);
+          ctx.closePath();
+          ctx.fillStyle = markerFill;
+          ctx.strokeStyle = markerStroke;
+          ctx.lineWidth = 2;
+          ctx.fill();
+          ctx.stroke();
+        }
+      }
+      ctx.restore();
+    },
+  };
+}
+
+function makeForecastDataset(label, data, color, series) {
+  return {
+    label,
+    data,
+    series,
+    backgroundColor: stripe(color),
+    borderColor: color,
+    borderWidth: 1,
+    hoverBackgroundColor: stripe(toRGBA(color, 0.6)),
+    barPercentage: 0.9,
+    categoryPercentage: 0.8,
+  };
+}
+
 function renderCombinedForecastChart() {
   const canvas = document.getElementById('forecast-chart');
   if (!canvas) return;
@@ -289,38 +613,36 @@ function renderCombinedForecastChart() {
 
   const loadAgg = lastLoadForecast ? aggregateForecastKwh(lastLoadForecast, stepMinutes) : { timestamps: [], values: [] };
   const pvAgg = lastPvForecast ? aggregateForecastKwh(lastPvForecast, stepMinutes) : { timestamps: [], values: [] };
+  const rawLoadAgg = lastLoadForecastRaw ? aggregateForecastKwh(lastLoadForecastRaw, stepMinutes) : { timestamps: [], values: [] };
+  const rawPvAgg = lastPvForecastRaw ? aggregateForecastKwh(lastPvForecastRaw, stepMinutes) : { timestamps: [], values: [] };
 
-  const allTs = [...new Set([...loadAgg.timestamps, ...pvAgg.timestamps])].sort((a, b) => a - b);
+  const allTs = [...new Set([
+    ...loadAgg.timestamps,
+    ...pvAgg.timestamps,
+    ...rawLoadAgg.timestamps,
+    ...rawPvAgg.timestamps,
+  ])].sort((a, b) => a - b);
   const axis = buildTimeAxisFromTimestamps(allTs);
 
   const loadMap = new Map(loadAgg.timestamps.map((t, i) => [t, loadAgg.values[i]]));
   const pvMap = new Map(pvAgg.timestamps.map((t, i) => [t, pvAgg.values[i]]));
+  const rawLoadMap = new Map(rawLoadAgg.timestamps.map((t, i) => [t, rawLoadAgg.values[i]]));
+  const rawPvMap = new Map(rawPvAgg.timestamps.map((t, i) => [t, rawPvAgg.values[i]]));
 
   renderChart(canvas, {
     type: 'bar',
     data: {
       labels: axis.labels,
       datasets: [
-        {
-          label: 'Load',
-          data: allTs.map(t => loadMap.get(t) ?? null),
-          backgroundColor: stripe(SOLUTION_COLORS.g2l),
-          borderColor: SOLUTION_COLORS.g2l,
-          borderWidth: 1,
-          hoverBackgroundColor: stripe(toRGBA(SOLUTION_COLORS.g2l, 0.6)),
-        },
-        {
-          label: 'Solar',
-          data: allTs.map(t => pvMap.get(t) ?? null),
-          backgroundColor: stripe(SOLUTION_COLORS.pv2g),
-          borderColor: SOLUTION_COLORS.pv2g,
-          borderWidth: 1,
-          hoverBackgroundColor: stripe(toRGBA(SOLUTION_COLORS.pv2g, 0.6)),
-        },
+        makeForecastDataset('Load', allTs.map(t => loadMap.get(t) ?? null), SOLUTION_COLORS.g2l, 'load'),
+        makeForecastDataset('Solar', allTs.map(t => pvMap.get(t) ?? null), SOLUTION_COLORS.pv2g, 'pv'),
       ],
     },
     options: getBaseOptions({ ...axis, yTitle: 'kWh' }, {
       ...getChartAnimations('bar', allTs.length),
+      onHover: (_event, _elements, chart) => {
+        chart.canvas.style.cursor = allTs.length ? 'crosshair' : '';
+      },
       plugins: {
         tooltip: {
           mode: 'index',
@@ -333,6 +655,11 @@ function renderCombinedForecastChart() {
               for (const pt of (tooltip.dataPoints ?? [])) {
                 if (pt.raw == null) continue;
                 html += ttRow(pt.dataset.borderColor, pt.dataset.label, `${fmtKwh(pt.raw)} kWh`);
+                const rawMap = pt.dataset.series === 'pv' ? rawPvMap : rawLoadMap;
+                const raw = rawMap.get(allTs[pt.dataIndex]);
+                if (raw != null && Math.abs(raw - pt.raw) > 0.001) {
+                  html += ttRow(toRGBA(pt.dataset.borderColor, 0.45), `Original ${pt.dataset.label.toLowerCase()}`, `${fmtKwh(raw)} kWh`);
+                }
               }
               return html;
             },
@@ -340,8 +667,300 @@ function renderCombinedForecastChart() {
           callbacks: { title: axis.tooltipTitleCb },
         },
       },
+      scales: {
+        x: { stacked: false },
+        y: { stacked: false },
+      },
     }),
+    plugins: [
+      makeAdjustmentOverlayPlugin(allTs, stepMinutes),
+      makeForecastOriginalMarkersPlugin(allTs, { load: rawLoadMap, pv: rawPvMap }),
+    ],
   });
+
+  wireForecastChartEditing(canvas, allTs, stepMinutes);
+}
+
+function pickForecastBucket(event, canvas, timestamps, stepMinutes) {
+  const chart = canvas._chart;
+  if (!chart || !timestamps.length) return null;
+  const rect = canvas.getBoundingClientRect();
+  const x = event.clientX - rect.left;
+  const y = event.clientY - rect.top;
+  const area = chart.chartArea;
+  if (!area || x < area.left || x > area.right || y < area.top || y > area.bottom) return null;
+
+  const rawIndex = chart.scales.x.getValueForPixel(x);
+  const index = Math.max(0, Math.min(timestamps.length - 1, Math.round(Number(rawIndex))));
+  const hit = chart.getElementsAtEventForMode(event, 'nearest', { intersect: true }, true)[0];
+  const series = hit
+    ? chart.data.datasets[hit.datasetIndex]?.series || 'load'
+    : forecastSeriesFromCategoryX(x, categoryBounds(chart, index));
+  const range = buildForecastSelectionRange(index, index, timestamps, stepMinutes);
+  return { index, series, range };
+}
+
+function wireForecastChartEditing(canvas, timestamps, stepMinutes) {
+  if (typeof canvas._forecastEditCleanup === 'function') canvas._forecastEditCleanup();
+
+  const onPointerDown = (event) => {
+    if (event.button !== 0) return;
+    const picked = pickForecastBucket(event, canvas, timestamps, stepMinutes);
+    if (!picked) return;
+    forecastChartDrag = {
+      startIndex: picked.index,
+      endIndex: picked.index,
+      series: picked.series,
+      startX: event.clientX,
+      startY: event.clientY,
+      moved: false,
+    };
+    forecastChartSelection = { ...picked.range, series: picked.series };
+    canvas.setPointerCapture?.(event.pointerId);
+    canvas._chart?.update('none');
+  };
+
+  const onPointerMove = (event) => {
+    if (!forecastChartDrag) return;
+    const picked = pickForecastBucket(event, canvas, timestamps, stepMinutes);
+    if (!picked) return;
+    const distance = Math.hypot(event.clientX - forecastChartDrag.startX, event.clientY - forecastChartDrag.startY);
+    forecastChartDrag.moved = forecastChartDrag.moved || distance > 4 || picked.index !== forecastChartDrag.startIndex;
+    forecastChartDrag.endIndex = picked.index;
+    const range = buildForecastSelectionRange(forecastChartDrag.startIndex, forecastChartDrag.endIndex, timestamps, stepMinutes);
+    forecastChartSelection = range ? { ...range, series: forecastChartDrag.series } : null;
+    canvas._chart?.update('none');
+  };
+
+  const onPointerUp = (event) => {
+    if (!forecastChartDrag) return;
+    const drag = forecastChartDrag;
+    forecastChartDrag = null;
+    canvas.releasePointerCapture?.(event.pointerId);
+
+    const range = buildForecastSelectionRange(drag.startIndex, drag.endIndex, timestamps, stepMinutes);
+    if (!range) return;
+    forecastChartSelection = { ...range, series: drag.series };
+    canvas._chart?.update('none');
+
+    const stepMs = stepMinutes * 60 * 1000;
+    const clickedAdjustment = !drag.moved
+      ? findAdjustmentAtBucket(timestamps[range.startIndex], timestamps[range.startIndex] + stepMs, drag.series)
+      : null;
+
+    if (clickedAdjustment) {
+      openAdjustmentPopover({ adjustment: clickedAdjustment, anchorEvent: event });
+    } else {
+      openAdjustmentPopover({ selection: forecastChartSelection, anchorEvent: event });
+    }
+  };
+
+  const onPointerCancel = () => {
+    forecastChartDrag = null;
+    forecastChartSelection = null;
+    canvas._chart?.update('none');
+  };
+
+  canvas.addEventListener('pointerdown', onPointerDown);
+  canvas.addEventListener('pointermove', onPointerMove);
+  canvas.addEventListener('pointerup', onPointerUp);
+  canvas.addEventListener('pointercancel', onPointerCancel);
+  canvas._forecastEditCleanup = () => {
+    canvas.removeEventListener('pointerdown', onPointerDown);
+    canvas.removeEventListener('pointermove', onPointerMove);
+    canvas.removeEventListener('pointerup', onPointerUp);
+    canvas.removeEventListener('pointercancel', onPointerCancel);
+  };
+}
+
+function activeSegmentClass(isActive) {
+  return isActive
+    ? 'bg-white text-sky-700 shadow-sm dark:bg-slate-700 dark:text-sky-200'
+    : 'text-slate-500 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-100';
+}
+
+function seriesSegmentClass(series, isActive) {
+  if (!isActive) return 'text-slate-500 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-100';
+  if (series === 'pv') return 'bg-amber-100 text-amber-800 shadow-sm dark:bg-amber-400/20 dark:text-amber-200';
+  return 'bg-rose-100 text-rose-800 shadow-sm dark:bg-rose-400/20 dark:text-rose-200';
+}
+
+function refreshPopoverSegments() {
+  for (const btn of document.querySelectorAll('.forecast-adjustment-series')) {
+    const series = btn.dataset.adjustSeries || 'load';
+    const active = series === adjustmentDraft?.series;
+    btn.className = `forecast-adjustment-series rounded-md px-3 py-1.5 text-sm font-medium ${seriesSegmentClass(series, active)}`;
+  }
+  for (const btn of document.querySelectorAll('.forecast-adjustment-mode')) {
+    const active = btn.dataset.adjustMode === adjustmentDraft?.mode;
+    btn.className = `forecast-adjustment-mode rounded-md px-3 py-2 text-sm font-medium ${activeSegmentClass(active)}`;
+  }
+}
+
+function setPopoverError(message = '') {
+  const el = document.getElementById('forecast-adjustment-error');
+  if (!el) return;
+  el.textContent = message;
+  el.classList.toggle('hidden', !message);
+}
+
+function showAdjustmentEditor() {
+  const popover = document.getElementById('forecast-adjustment-popover');
+  if (!popover) return;
+  popover.classList.remove('hidden');
+  popover.style.left = '';
+  popover.style.top = '';
+  popover.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+}
+
+function openAdjustmentPopover({ selection = null, adjustment = null } = {}) {
+  const popover = document.getElementById('forecast-adjustment-popover');
+  if (!popover) return;
+
+  if (adjustment) {
+    adjustmentDraft = {
+      id: adjustment.id,
+      series: adjustment.series,
+      mode: adjustment.mode,
+      value_W: adjustment.value_W,
+      start: adjustment.start,
+      end: adjustment.end,
+    };
+    forecastChartSelection = null;
+  } else {
+    const series = selection?.series || 'load';
+    adjustmentDraft = {
+      id: null,
+      series,
+      mode: series === 'pv' ? 'set' : 'add',
+      value_W: series === 'pv' ? 0 : '',
+      start: selection?.start || new Date().toISOString(),
+      end: selection?.end || new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+    };
+  }
+
+  setVal('forecast-adjustment-watts', adjustmentDraft.value_W);
+  setVal('forecast-adjustment-start', toDatetimeLocalValue(adjustmentDraft.start));
+  setVal('forecast-adjustment-end', toDatetimeLocalValue(adjustmentDraft.end));
+  setEl('forecast-adjustment-title', adjustmentDraft.id ? 'Edit adjustment' : 'Manual adjustment');
+  setEl('forecast-adjustment-range', formatRange(adjustmentDraft.start, adjustmentDraft.end));
+  document.getElementById('forecast-adjustment-delete')?.classList.toggle('hidden', !adjustmentDraft.id);
+  setPopoverError('');
+  refreshPopoverSegments();
+  showAdjustmentEditor();
+}
+
+function hideAdjustmentPopover() {
+  document.getElementById('forecast-adjustment-popover')?.classList.add('hidden');
+  adjustmentDraft = null;
+  forecastChartSelection = null;
+  document.getElementById('forecast-chart')?._chart?.update('none');
+}
+
+function readAdjustmentPayload() {
+  if (!adjustmentDraft) return null;
+  const start = fromDatetimeLocalValue(getVal('forecast-adjustment-start'));
+  const end = fromDatetimeLocalValue(getVal('forecast-adjustment-end'));
+  const value_W = Number(getVal('forecast-adjustment-watts'));
+  if (!start || !end) throw new Error('Start and end must be valid.');
+  if (new Date(end).getTime() <= new Date(start).getTime()) throw new Error('End must be after start.');
+  if (!Number.isFinite(value_W)) throw new Error('Watts must be a number.');
+  if (adjustmentDraft.mode === 'set' && value_W < 0) throw new Error('Set values cannot be negative.');
+  return {
+    series: adjustmentDraft.series,
+    mode: adjustmentDraft.mode,
+    value_W,
+    start,
+    end,
+  };
+}
+
+async function saveAdjustmentFromPopover() {
+  try {
+    const payload = readAdjustmentPayload();
+    if (!payload || !adjustmentDraft) return;
+    const result = adjustmentDraft.id
+      ? await updatePredictionAdjustment(adjustmentDraft.id, payload)
+      : await createPredictionAdjustment(payload);
+    setAdjustments(result.adjustments);
+    hideAdjustmentPopover();
+  } catch (err) {
+    setPopoverError(err.message || String(err));
+  }
+}
+
+async function deleteAdjustmentFromPopover() {
+  if (!adjustmentDraft?.id) return;
+  try {
+    const result = await deletePredictionAdjustment(adjustmentDraft.id);
+    setAdjustments(result.adjustments);
+    hideAdjustmentPopover();
+  } catch (err) {
+    setPopoverError(err.message || String(err));
+  }
+}
+
+function wireAdjustmentPopover() {
+  document.getElementById('forecast-adjustment-cancel')?.addEventListener('click', hideAdjustmentPopover);
+  document.getElementById('forecast-adjustment-save')?.addEventListener('click', saveAdjustmentFromPopover);
+  document.getElementById('forecast-adjustment-delete')?.addEventListener('click', deleteAdjustmentFromPopover);
+  for (const btn of document.querySelectorAll('.forecast-adjustment-series')) {
+    btn.addEventListener('click', () => {
+      if (!adjustmentDraft) return;
+      adjustmentDraft.series = btn.dataset.adjustSeries || 'load';
+      if (!adjustmentDraft.id) {
+        adjustmentDraft.mode = adjustmentDraft.series === 'pv' ? 'set' : 'add';
+        setVal('forecast-adjustment-watts', adjustmentDraft.series === 'pv' ? 0 : '');
+      }
+      refreshPopoverSegments();
+    });
+  }
+  for (const btn of document.querySelectorAll('.forecast-adjustment-mode')) {
+    btn.addEventListener('click', () => {
+      if (!adjustmentDraft) return;
+      adjustmentDraft.mode = btn.dataset.adjustMode || 'set';
+      refreshPopoverSegments();
+    });
+  }
+  for (const id of ['forecast-adjustment-start', 'forecast-adjustment-end']) {
+    document.getElementById(id)?.addEventListener('change', () => {
+      if (!adjustmentDraft) return;
+      adjustmentDraft.start = fromDatetimeLocalValue(getVal('forecast-adjustment-start')) || adjustmentDraft.start;
+      adjustmentDraft.end = fromDatetimeLocalValue(getVal('forecast-adjustment-end')) || adjustmentDraft.end;
+      setEl('forecast-adjustment-range', formatRange(adjustmentDraft.start, adjustmentDraft.end));
+    });
+  }
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') hideAdjustmentPopover();
+  });
+}
+
+function renderAdjustmentList() {
+  const list = document.getElementById('prediction-adjustments-list');
+  const count = document.getElementById('prediction-adjustments-count');
+  if (!list) return;
+  const sorted = [...predictionAdjustments].sort((a, b) => new Date(a.start).getTime() - new Date(b.start).getTime());
+  if (count) count.textContent = sorted.length ? `${sorted.length} active` : '';
+  if (!sorted.length) {
+    list.innerHTML = '<div class="rounded-lg border border-dashed border-slate-200 px-3 py-2 text-sm text-slate-500 dark:border-white/10 dark:text-slate-400">No active adjustments</div>';
+    return;
+  }
+  list.innerHTML = '';
+  for (const adj of sorted) {
+    const item = document.createElement('button');
+    item.type = 'button';
+    item.className = 'flex w-full items-center justify-between gap-3 rounded-lg border border-slate-200 bg-white px-3 py-2 text-left text-sm hover:bg-slate-50 dark:border-white/10 dark:bg-slate-900 dark:hover:bg-slate-800';
+    const colorClass = adj.series === 'pv' ? 'text-amber-600 dark:text-amber-300' : 'text-rose-600 dark:text-rose-300';
+    item.innerHTML = `
+      <span class="min-w-0">
+        <span class="block truncate font-medium ${colorClass}">${escapeHtml(adjustmentSummary(adj))}</span>
+        <span class="block truncate text-xs text-slate-500 dark:text-slate-400">${escapeHtml(formatRange(adj.start, adj.end))}${adj.label ? ` · ${escapeHtml(adj.label)}` : ''}</span>
+      </span>
+      <span class="shrink-0 text-xs font-medium text-slate-400 dark:text-slate-500">Edit</span>
+    `;
+    item.addEventListener('click', (event) => openAdjustmentPopover({ adjustment: adj, anchorEvent: event }));
+    list.appendChild(item);
+  }
 }
 
 function renderLoadAccuracyChart(recentData) {

--- a/app/src/predictions.js
+++ b/app/src/predictions.js
@@ -78,7 +78,9 @@ export function applyAdjustmentsToForecastSeries(forecast, adjustments, series) 
       const matching = relevant.filter(adj => slotTs >= new Date(adj.start).getTime() && slotTs < new Date(adj.end).getTime());
       if (!matching.length) return raw;
 
-      const setAdjustment = matching.filter(adj => adj.mode === 'set').at(-1);
+      const setAdjustment = matching
+        .filter(adj => adj.mode === 'set')
+        .reduce((best, adj) => !best || adj.updatedAt > best.updatedAt ? adj : best, null);
       const base = setAdjustment ? Number(setAdjustment.value_W) : raw;
       const delta = matching
         .filter(adj => adj.mode === 'add')

--- a/app/src/table.js
+++ b/app/src/table.js
@@ -1,4 +1,5 @@
 import { SOLUTION_COLORS } from "./charts.js";
+import { escapeHtml } from "./utils.js";
 
 /**
  * Render the results table and unit label.
@@ -280,13 +281,4 @@ export function renderTable({ rows, cfg, targets, showKwh, rebalanceWindow, evSe
     return parts.length > 1 ? `${neg}${intPart}.${parts[1]}` : `${neg}${intPart}`;
   }
 
-  function escapeHtml(str) {
-    return String(str).replace(/[&<>"']/g, m => ({
-      "&": "&amp;",
-      "<": "&lt;",
-      ">": "&gt;",
-      "\"": "&quot;",
-      "'": "&#039;"
-    }[m]));
-  }
 }

--- a/app/src/utils.js
+++ b/app/src/utils.js
@@ -1,3 +1,12 @@
+export function escapeHtml(value) {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#039;');
+}
+
 export function debounce(fn, wait = 250) {
   let timer = null;
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -85,6 +85,8 @@ export interface PlanRow {
   timestampMs: number;
   load: number;       // expected load W
   pv: number;         // expected PV W
+  originalLoad?: number; // unadjusted prediction W when a manual adjustment changed the slot
+  originalPv?: number;   // unadjusted prediction W when a manual adjustment changed the slot
   ic: number;  // import price c€/kWh
   ec: number;  // export price c€/kWh
   g2l: number;   // grid → load W

--- a/tests/api/predictions.test.js
+++ b/tests/api/predictions.test.js
@@ -68,6 +68,73 @@ describe('POST /predictions/config', () => {
   });
 });
 
+describe('/predictions/adjustments', () => {
+  const baseData = {
+    load: { start: '2099-01-01T00:00:00.000Z', step: 15, values: [100, 100] },
+    pv: { start: '2099-01-01T00:00:00.000Z', step: 15, values: [200, 200] },
+    importPrice: { start: '2099-01-01T00:00:00.000Z', step: 15, values: [10, 10] },
+    exportPrice: { start: '2099-01-01T00:00:00.000Z', step: 15, values: [5, 5] },
+    soc: { timestamp: '2099-01-01T00:00:00.000Z', value: 50 },
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    loadData.mockResolvedValue(baseData);
+    saveData.mockResolvedValue();
+  });
+
+  it('creates a prediction adjustment', async () => {
+    const res = await request(app)
+      .post('/predictions/adjustments')
+      .send({
+        series: 'pv',
+        mode: 'set',
+        value_W: 0,
+        start: '2099-01-01T00:00:00.000Z',
+        end: '2099-01-01T01:00:00.000Z',
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.adjustment.series).toBe('pv');
+    expect(saveData).toHaveBeenCalledWith(expect.objectContaining({
+      predictionAdjustments: [expect.objectContaining({ series: 'pv', mode: 'set', value_W: 0 })],
+    }));
+  });
+
+  it('returns active adjustments and prunes expired ones', async () => {
+    loadData.mockResolvedValue({
+      ...baseData,
+      predictionAdjustments: [
+        { id: 'expired', series: 'load', mode: 'add', value_W: 50, start: '2024-01-01T00:00:00.000Z', end: '2024-01-01T01:00:00.000Z', createdAt: '2024-01-01T00:00:00.000Z', updatedAt: '2024-01-01T00:00:00.000Z' },
+        { id: 'future', series: 'load', mode: 'add', value_W: 50, start: '2099-01-01T00:00:00.000Z', end: '2099-01-01T01:00:00.000Z', createdAt: '2099-01-01T00:00:00.000Z', updatedAt: '2099-01-01T00:00:00.000Z' },
+      ],
+    });
+
+    const res = await request(app).get('/predictions/adjustments');
+
+    expect(res.status).toBe(200);
+    expect(res.body.adjustments.map(adj => adj.id)).toEqual(['future']);
+    expect(saveData).toHaveBeenCalledWith(expect.objectContaining({
+      predictionAdjustments: [expect.objectContaining({ id: 'future' })],
+    }));
+  });
+
+  it('updates and deletes prediction adjustments', async () => {
+    const existing = { id: 'adj-1', series: 'load', mode: 'add', value_W: 50, start: '2099-01-01T00:00:00.000Z', end: '2099-01-01T01:00:00.000Z', createdAt: '2099-01-01T00:00:00.000Z', updatedAt: '2099-01-01T00:00:00.000Z' };
+    loadData.mockResolvedValue({ ...baseData, predictionAdjustments: [existing] });
+
+    const patch = await request(app)
+      .patch('/predictions/adjustments/adj-1')
+      .send({ value_W: 125 });
+    expect(patch.status).toBe(200);
+    expect(patch.body.adjustment.value_W).toBe(125);
+
+    const del = await request(app).delete('/predictions/adjustments/adj-1').send({});
+    expect(del.status).toBe(200);
+    expect(del.body.adjustments).toEqual([]);
+  });
+});
+
 describe('POST /predictions/validate', () => {
   beforeEach(() => {
     vi.resetAllMocks();
@@ -228,6 +295,37 @@ describe('POST /predictions/forecast (combined) - persistence', () => {
     expect(saveData).toHaveBeenCalledTimes(1);
     expect(saveData.mock.calls[0][0].load).toEqual(loadForecast);
     expect(saveData.mock.calls[0][0].pv).toEqual(pvForecast);
+  });
+
+  it('returns adjusted forecasts while persisting raw forecasts', async () => {
+    const futureLoadForecast = { start: '2099-01-01T00:00:00.000Z', step: 15, values: [100, 100, 100, 100] };
+    const adjustment = {
+      id: 'adj-1',
+      series: 'load',
+      mode: 'add',
+      value_W: 50,
+      start: '2099-01-01T00:15:00.000Z',
+      end: '2099-01-01T00:45:00.000Z',
+      createdAt: '2099-01-01T00:00:00.000Z',
+      updatedAt: '2099-01-01T00:00:00.000Z',
+    };
+    runForecast.mockResolvedValue({ forecast: futureLoadForecast, recent: [] });
+    runPvForecast.mockResolvedValue(null);
+    loadData.mockResolvedValue({
+      load: { start: '2099-01-01T00:00:00.000Z', step: 15, values: [] },
+      pv: { start: '2099-01-01T00:00:00.000Z', step: 15, values: [] },
+      importPrice: { start: '2099-01-01T00:00:00.000Z', step: 15, values: [] },
+      exportPrice: { start: '2099-01-01T00:00:00.000Z', step: 15, values: [] },
+      soc: { timestamp: '2099-01-01T00:00:00.000Z', value: 50 },
+      predictionAdjustments: [adjustment],
+    });
+
+    const res = await request(app).post('/predictions/forecast').send({});
+
+    expect(res.status).toBe(200);
+    expect(saveData.mock.calls[0][0].load).toEqual(futureLoadForecast);
+    expect(res.body.load.rawForecast.values).toEqual([100, 100, 100, 100]);
+    expect(res.body.load.forecast.values).toEqual([100, 150, 150, 100]);
   });
 
   it('saves only load when dataSources.pv is vrm', async () => {

--- a/tests/api/services/config-builder.adjustments.test.js
+++ b/tests/api/services/config-builder.adjustments.test.js
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getSolverInputs } from '../../../api/services/config-builder.ts';
+import { loadData, saveData } from '../../../api/services/data-store.ts';
+import { loadSettings } from '../../../api/services/settings-store.ts';
+
+vi.mock('../../../api/services/data-store.ts');
+vi.mock('../../../api/services/settings-store.ts');
+vi.mock('../../../api/services/ha-client.ts');
+
+const NOW = '2099-01-01T00:05:00.000Z';
+
+const settings = {
+  stepSize_m: 15,
+  batteryCapacity_Wh: 10000,
+  minSoc_percent: 20,
+  maxSoc_percent: 90,
+  maxChargePower_W: 1000,
+  maxDischargePower_W: 1000,
+  maxGridImport_W: 2000,
+  maxGridExport_W: 2000,
+  chargeEfficiency_percent: 95,
+  dischargeEfficiency_percent: 95,
+  batteryCost_cent_per_kWh: 0,
+  idleDrain_W: 0,
+  terminalSocValuation: 'zero',
+  terminalSocCustomPrice_cents_per_kWh: 0,
+  dataSources: { load: 'vrm', pv: 'vrm', prices: 'vrm', soc: 'mqtt' },
+  rebalanceEnabled: false,
+  rebalanceHoldHours: 3,
+  evEnabled: false,
+};
+
+describe('getSolverInputs — prediction adjustments', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(NOW));
+    vi.clearAllMocks();
+    loadSettings.mockResolvedValue(settings);
+    saveData.mockResolvedValue();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('applies prediction adjustments to solver inputs without mutating returned raw data', async () => {
+    loadData.mockResolvedValue({
+      load: { start: '2099-01-01T00:00:00.000Z', step: 15, values: [100, 100, 100, 100] },
+      pv: { start: '2099-01-01T00:00:00.000Z', step: 15, values: [200, 200, 200, 200] },
+      importPrice: { start: '2099-01-01T00:00:00.000Z', step: 15, values: [10, 10, 10, 10] },
+      exportPrice: { start: '2099-01-01T00:00:00.000Z', step: 15, values: [5, 5, 5, 5] },
+      soc: { timestamp: '2099-01-01T00:00:00.000Z', value: 50 },
+      predictionAdjustments: [
+        { id: 'load-add', series: 'load', mode: 'add', value_W: 50, start: '2099-01-01T00:15:00.000Z', end: '2099-01-01T00:45:00.000Z', createdAt: '2099-01-01T00:00:00.000Z', updatedAt: '2099-01-01T00:00:00.000Z' },
+        { id: 'pv-off', series: 'pv', mode: 'set', value_W: 0, start: '2099-01-01T00:30:00.000Z', end: '2099-01-01T01:00:00.000Z', createdAt: '2099-01-01T00:00:00.000Z', updatedAt: '2099-01-01T00:00:00.000Z' },
+      ],
+    });
+
+    const { cfg, data } = await getSolverInputs();
+
+    expect(cfg.load_W).toEqual([100, 150, 150, 100]);
+    expect(cfg.pv_W).toEqual([200, 200, 0, 0]);
+    expect(data.load.values).toEqual([100, 100, 100, 100]);
+    expect(data.pv.values).toEqual([200, 200, 200, 200]);
+    expect(saveData).not.toHaveBeenCalled();
+  });
+});

--- a/tests/api/services/planner-service.test.js
+++ b/tests/api/services/planner-service.test.js
@@ -115,4 +115,45 @@ describe('computePlan — rebalance bookkeeping', () => {
 
     expect(result.rows[0].dess.feedin).toBe(FeedIn.allowed);
   });
+
+  it('includes original prediction values on rows when manual adjustments changed them', async () => {
+    loadSettings.mockResolvedValue(baseSettings);
+    loadData.mockResolvedValue({
+      ...baseData,
+      pv: { start: NOW_STRING, step: 60, values: [100, 0, 0, 0, 0] },
+      predictionAdjustments: [
+        {
+          id: 'load-add',
+          series: 'load',
+          mode: 'add',
+          value_W: 100,
+          start: NOW_STRING,
+          end: '2024-01-01T01:00:00.000Z',
+          createdAt: NOW_STRING,
+          updatedAt: NOW_STRING,
+        },
+        {
+          id: 'pv-off',
+          series: 'pv',
+          mode: 'set',
+          value_W: 0,
+          start: NOW_STRING,
+          end: '2024-01-01T01:00:00.000Z',
+          createdAt: NOW_STRING,
+          updatedAt: NOW_STRING,
+        },
+      ],
+    });
+
+    const result = await computePlan();
+
+    expect(result.rows[0]).toMatchObject({
+      load: 600,
+      originalLoad: 500,
+      pv: 0,
+      originalPv: 100,
+    });
+    expect(result.rows[1].originalLoad).toBeUndefined();
+    expect(result.rows[1].originalPv).toBeUndefined();
+  });
 });

--- a/tests/api/services/prediction-adjustments.test.js
+++ b/tests/api/services/prediction-adjustments.test.js
@@ -38,12 +38,14 @@ describe('prediction adjustments', () => {
     expect(adjusted.values).toEqual([0, 0, 300, 400, 500]);
   });
 
-  it('uses the latest set adjustment as the baseline and stacks add adjustments', () => {
+  it('uses the most recently updated set adjustment as the baseline and stacks add adjustments', () => {
     const adjusted = applyPredictionAdjustmentsToSeries(series, [
-      adjustment({ id: 'set-1', mode: 'set', value_W: 900, start: '2026-01-01T00:15:00.000Z', end: '2026-01-01T01:00:00.000Z' }),
-      adjustment({ id: 'set-2', mode: 'set', value_W: 700, start: '2026-01-01T00:30:00.000Z', end: '2026-01-01T00:45:00.000Z' }),
+      // set-2 has a later updatedAt so it wins as the baseline at the overlapping slot
+      adjustment({ id: 'set-1', mode: 'set', value_W: 900, start: '2026-01-01T00:15:00.000Z', end: '2026-01-01T01:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z' }),
+      adjustment({ id: 'set-2', mode: 'set', value_W: 700, start: '2026-01-01T00:30:00.000Z', end: '2026-01-01T00:45:00.000Z', updatedAt: '2026-01-01T00:01:00.000Z' }),
       adjustment({ id: 'add-1', mode: 'add', value_W: 25, start: '2026-01-01T00:30:00.000Z', end: '2026-01-01T00:45:00.000Z' }),
     ], 'load');
+    // slot 1: only set-1 → 900; slot 2: set-2 wins (latest updatedAt) → 700 + 25 = 725; slot 3: only set-1 → 900
     expect(adjusted.values).toEqual([100, 900, 725, 900, 500]);
   });
 

--- a/tests/api/services/prediction-adjustments.test.js
+++ b/tests/api/services/prediction-adjustments.test.js
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import {
+  applyPredictionAdjustmentsToData,
+  applyPredictionAdjustmentsToSeries,
+  pruneExpiredPredictionAdjustments,
+} from '../../../api/services/prediction-adjustments.ts';
+
+const series = {
+  start: '2026-01-01T00:00:00.000Z',
+  step: 15,
+  values: [100, 200, 300, 400, 500],
+};
+
+function adjustment(overrides = {}) {
+  return {
+    id: 'adj-1',
+    series: 'load',
+    mode: 'add',
+    value_W: 50,
+    start: '2026-01-01T00:15:00.000Z',
+    end: '2026-01-01T00:45:00.000Z',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('prediction adjustments', () => {
+  it('adds watts across the half-open selected range', () => {
+    const adjusted = applyPredictionAdjustmentsToSeries(series, [adjustment()], 'load');
+    expect(adjusted.values).toEqual([100, 250, 350, 400, 500]);
+  });
+
+  it('sets PV to zero across the selected range', () => {
+    const adjusted = applyPredictionAdjustmentsToSeries(series, [
+      adjustment({ series: 'pv', mode: 'set', value_W: 0, start: '2026-01-01T00:00:00.000Z', end: '2026-01-01T00:30:00.000Z' }),
+    ], 'pv');
+    expect(adjusted.values).toEqual([0, 0, 300, 400, 500]);
+  });
+
+  it('uses the latest set adjustment as the baseline and stacks add adjustments', () => {
+    const adjusted = applyPredictionAdjustmentsToSeries(series, [
+      adjustment({ id: 'set-1', mode: 'set', value_W: 900, start: '2026-01-01T00:15:00.000Z', end: '2026-01-01T01:00:00.000Z' }),
+      adjustment({ id: 'set-2', mode: 'set', value_W: 700, start: '2026-01-01T00:30:00.000Z', end: '2026-01-01T00:45:00.000Z' }),
+      adjustment({ id: 'add-1', mode: 'add', value_W: 25, start: '2026-01-01T00:30:00.000Z', end: '2026-01-01T00:45:00.000Z' }),
+    ], 'load');
+    expect(adjusted.values).toEqual([100, 900, 725, 900, 500]);
+  });
+
+  it('clamps negative adjusted values to zero', () => {
+    const adjusted = applyPredictionAdjustmentsToSeries(series, [
+      adjustment({ mode: 'add', value_W: -500, start: '2026-01-01T00:00:00.000Z', end: '2026-01-01T00:30:00.000Z' }),
+    ], 'load');
+    expect(adjusted.values).toEqual([0, 0, 300, 400, 500]);
+  });
+
+  it('applies load and PV adjustments independently to data', () => {
+    const data = {
+      load: series,
+      pv: series,
+      importPrice: series,
+      exportPrice: series,
+      soc: { timestamp: '2026-01-01T00:00:00.000Z', value: 50 },
+      predictionAdjustments: [
+        adjustment({ series: 'load', mode: 'add', value_W: 100 }),
+        adjustment({ series: 'pv', mode: 'set', value_W: 0 }),
+      ],
+    };
+    const adjusted = applyPredictionAdjustmentsToData(data);
+    expect(adjusted.load.values).toEqual([100, 300, 400, 400, 500]);
+    expect(adjusted.pv.values).toEqual([100, 0, 0, 400, 500]);
+  });
+
+  it('prunes expired adjustments', () => {
+    const data = {
+      load: series,
+      pv: series,
+      importPrice: series,
+      exportPrice: series,
+      soc: { timestamp: '2026-01-01T00:00:00.000Z', value: 50 },
+      predictionAdjustments: [
+        adjustment({ id: 'old', end: '2026-01-01T00:15:00.000Z' }),
+        adjustment({ id: 'active', end: '2026-01-01T01:00:00.000Z' }),
+      ],
+    };
+    const result = pruneExpiredPredictionAdjustments(data, new Date('2026-01-01T00:30:00.000Z').getTime());
+    expect(result.changed).toBe(true);
+    expect(result.adjustments.map(adj => adj.id)).toEqual(['active']);
+  });
+});

--- a/tests/app/charts.test.js
+++ b/tests/app/charts.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { getBuyPriceColor } from '../../app/src/charts.js';
+import { aggregateLoadPvBuckets, getBuyPriceColor } from '../../app/src/charts.js';
 
 describe('getBuyPriceColor', () => {
   it('uses fixed colors at scale stops', () => {
@@ -33,5 +33,44 @@ describe('getBuyPriceColor', () => {
   it('treats invalid prices as neutral zero', () => {
     expect(getBuyPriceColor(null)).toBe('rgb(226, 232, 240)');
     expect(getBuyPriceColor(Number.NaN)).toBe('rgb(226, 232, 240)');
+  });
+});
+
+describe('aggregateLoadPvBuckets', () => {
+  it('keeps original hourly load and pv totals when adjusted slots are present', () => {
+    const buckets = aggregateLoadPvBuckets([
+      {
+        timestampMs: Date.parse('2099-01-01T10:00:00.000Z'),
+        load: 150,
+        originalLoad: 100,
+        pv: 20,
+      },
+      {
+        timestampMs: Date.parse('2099-01-01T10:15:00.000Z'),
+        load: 100,
+        pv: 0,
+        originalPv: 30,
+      },
+      {
+        timestampMs: Date.parse('2099-01-01T10:30:00.000Z'),
+        load: 100,
+        pv: 10,
+      },
+      {
+        timestampMs: Date.parse('2099-01-01T10:45:00.000Z'),
+        load: 100,
+        pv: 10,
+      },
+    ], 15);
+
+    expect(buckets).toHaveLength(1);
+    expect(buckets[0]).toMatchObject({
+      hasOriginalLoad: true,
+      hasOriginalPv: true,
+    });
+    expect(buckets[0].loadKWh).toBeCloseTo(0.1125);
+    expect(buckets[0].originalLoadKWh).toBeCloseTo(0.1);
+    expect(buckets[0].pvKWh).toBeCloseTo(0.01);
+    expect(buckets[0].originalPvKWh).toBeCloseTo(0.0175);
   });
 });

--- a/tests/app/predictions-adjustments.test.js
+++ b/tests/app/predictions-adjustments.test.js
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  applyAdjustmentsToForecastSeries,
+  buildForecastSelectionRange,
+  forecastSeriesFromCategoryX,
+  futureForecastSeries,
+} from '../../app/src/predictions.js';
+
+describe('prediction adjustment UI helpers', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2099-01-01T00:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('maps a dragged hourly range to whole-hour ISO bounds', () => {
+    const timestamps = [
+      Date.parse('2099-01-01T18:00:00.000Z'),
+      Date.parse('2099-01-01T19:00:00.000Z'),
+      Date.parse('2099-01-01T20:00:00.000Z'),
+    ];
+
+    expect(buildForecastSelectionRange(2, 1, timestamps, 60)).toEqual({
+      startIndex: 1,
+      endIndex: 2,
+      start: '2099-01-01T19:00:00.000Z',
+      end: '2099-01-01T21:00:00.000Z',
+    });
+  });
+
+  it('maps a 15-minute slot click to one 15-minute interval', () => {
+    const timestamps = [
+      Date.parse('2099-01-01T19:00:00.000Z'),
+      Date.parse('2099-01-01T19:15:00.000Z'),
+    ];
+
+    expect(buildForecastSelectionRange(1, 1, timestamps, 15)).toEqual({
+      startIndex: 1,
+      endIndex: 1,
+      start: '2099-01-01T19:15:00.000Z',
+      end: '2099-01-01T19:30:00.000Z',
+    });
+  });
+
+  it('maps empty grouped-chart bucket clicks to load and pv lanes', () => {
+    const bounds = { left: 100, right: 180 };
+
+    expect(forecastSeriesFromCategoryX(112, bounds)).toBe('load');
+    expect(forecastSeriesFromCategoryX(168, bounds)).toBe('pv');
+  });
+
+  it('applies active manual adjustments to raw forecast copies', () => {
+    const forecast = {
+      start: '2099-01-01T19:00:00.000Z',
+      step: 15,
+      values: [100, 100, 100],
+    };
+
+    const adjusted = applyAdjustmentsToForecastSeries(forecast, [
+      { series: 'load', mode: 'add', value_W: 75, start: '2099-01-01T19:15:00.000Z', end: '2099-01-01T19:45:00.000Z' },
+    ], 'load');
+
+    expect(adjusted.values).toEqual([100, 175, 175]);
+    expect(forecast.values).toEqual([100, 100, 100]);
+  });
+
+  it('slices stored data to the current forecast slot for dev/default data hydration', () => {
+    const series = {
+      start: '2099-01-01T18:00:00.000Z',
+      step: 15,
+      values: [10, 20, 30, 40, 50],
+    };
+
+    expect(futureForecastSeries(series, Date.parse('2099-01-01T18:32:00.000Z'))).toEqual({
+      start: '2099-01-01T18:30:00.000Z',
+      step: 15,
+      values: [30, 40, 50],
+    });
+  });
+
+  it('returns null when stored data has no future slots', () => {
+    const series = {
+      start: '2099-01-01T18:00:00.000Z',
+      step: 15,
+      values: [10, 20],
+    };
+
+    expect(futureForecastSeries(series, Date.parse('2099-01-01T19:00:00.000Z'))).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a CRUD API (`GET/POST/PATCH/DELETE /predictions/adjustments`) for persisting manual load/PV forecast overrides in `data.json`
- Adjustments are applied to LP solver inputs before each plan computation and to forecast responses (raw forecast preserved separately as `rawForecast`)
- Exposes `originalLoad`/`originalPv` on `PlanRow` entries where adjustments changed the solver inputs
- Adds a drag-to-select UI on the forecast chart: click or drag a bar to open an adjustment popover (series, mode set/add, watt value, time range); existing adjustments highlighted as overlays
- Shows original-value markers (diamonds) and tooltip rows for adjusted bars in forecast and plan charts

<img width="1526" height="1550" alt="image" src="https://github.com/user-attachments/assets/7e4e917f-ab19-4d70-9a09-5bb2e147acc0" />


## Test plan

- [ ] Create, edit, and delete adjustments via the popover; verify they appear in the adjustment list
- [ ] Verify adjusted forecast bars show original values in tooltip (raw vs adjusted)
- [ ] Verify `POST /calculate` uses adjusted load/PV and plan rows carry `originalLoad`/`originalPv`
- [ ] Verify expired adjustments are pruned on VRM refresh and solver runs
- [ ] `npx vitest run` — all 314 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)