### PR TITLE
Add optimizer quick settings panel

### DIFF
--- a/api/defaults/default-settings.json
+++ b/api/defaults/default-settings.json
@@ -14,6 +14,7 @@
   "blockFeedInOnNegativePrices": true,
   "terminalSocValuation": "zero",
   "terminalSocCustomPrice_cents_per_kWh": 0,
+  "optimizerQuickSettings": [],
   "dataSources": {
     "prices": "vrm",
     "load": "vrm",

--- a/api/services/settings-store.ts
+++ b/api/services/settings-store.ts
@@ -31,6 +31,12 @@ function validateSettings(s: Settings): Settings {
     [s.minSoc_percent, s.maxSoc_percent] = [s.maxSoc_percent, s.minSoc_percent];
   }
 
+  if (!Array.isArray(s.optimizerQuickSettings)) {
+    s.optimizerQuickSettings = [];
+  } else {
+    s.optimizerQuickSettings = s.optimizerQuickSettings.filter((id): id is string => typeof id === 'string');
+  }
+
   return s;
 }
 

--- a/api/types.ts
+++ b/api/types.ts
@@ -37,6 +37,7 @@ export interface Settings {
   blockFeedInOnNegativePrices: boolean;
   terminalSocValuation: TerminalSocValuation;
   terminalSocCustomPrice_cents_per_kWh: number;
+  optimizerQuickSettings: string[];
   dataSources: DataSources;
   rebalanceEnabled: boolean;
   rebalanceHoldHours: number;

--- a/app/index.html
+++ b/app/index.html
@@ -268,6 +268,74 @@
       color: #e2e8f0;
     }
 
+    .quick-setting-source-label {
+      position: relative;
+      display: block;
+    }
+
+    .quick-setting-pin {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 1.25rem;
+      height: 1.25rem;
+      border-radius: 9999px;
+      border: 0;
+      color: #cbd5e1;
+      background: transparent;
+      cursor: pointer;
+      transition: background-color 0.15s, color 0.15s;
+      flex-shrink: 0;
+    }
+
+    .quick-setting-source-label>.quick-setting-pin {
+      position: absolute;
+      top: 0.0625rem;
+      right: 0.125rem;
+      z-index: 1;
+    }
+
+    .quick-setting-toggle-label>.quick-setting-pin {
+      margin-left: -0.25rem;
+    }
+
+    .quick-setting-pin:hover,
+    .quick-setting-pin:focus-visible {
+      color: #0284c7;
+      background: #f0f9ff;
+    }
+
+    .quick-setting-pin[aria-pressed="true"] {
+      color: #0284c7;
+      background: transparent;
+    }
+
+    .quick-setting-pin[aria-pressed="true"]:hover,
+    .quick-setting-pin[aria-pressed="true"]:focus-visible {
+      background: #f0f9ff;
+    }
+
+    .quick-setting-pin:focus-visible {
+      outline: 2px solid #38bdf8;
+      outline-offset: 2px;
+    }
+
+    :root.dark .quick-setting-pin {
+      color: #64748b;
+      background: transparent;
+    }
+
+    :root.dark .quick-setting-pin:hover,
+    :root.dark .quick-setting-pin:focus-visible,
+    :root.dark .quick-setting-pin[aria-pressed="true"] {
+      color: #7dd3fc;
+      background: rgba(14, 165, 233, 0.12);
+    }
+
+    :root.dark .quick-setting-pin[aria-pressed="true"] {
+      background: transparent;
+    }
+
     /* === Status text transition === */
     #status {
       transition: color 0.3s ease;
@@ -568,6 +636,11 @@
               <span class="toggle-knob"></span>
               <span class="text-sm text-slate-600 dark:text-slate-400">Schedule battery rebalancing</span>
             </label>
+          </div>
+
+          <div id="optimizer-quick-settings" class="hidden mt-4 pt-4 border-t border-slate-100 dark:border-white/5">
+            <div id="optimizer-quick-settings-body" class="grid grid-cols-1 md:grid-cols-2 gap-3"></div>
+            <input id="optimizer-quick-settings-selection" type="hidden" value="[]" data-no-autosolve />
           </div>
 
           <!-- Run options as toggles -->

--- a/app/main.js
+++ b/app/main.js
@@ -12,6 +12,7 @@ import { loadInitialConfig, saveConfig } from "./src/config-store.js";
 import { requestRemoteSolve, fetchHaEntityState } from "./src/api/api.js";
 import { initPredictionsTab } from "./src/predictions.js";
 import { updateEvPanel } from "./src/ev-tab.js";
+import { initOptimizerQuickSettings } from "./src/optimizer-quick-settings.js";
 
 // Import new modules
 import {
@@ -42,6 +43,7 @@ function revealCards(panel) {
 // or just initialize it at the top level since DOM content is likely ready (module scripts defer).
 // However, safer to call getElements() when needed or at top level if we trust DOMContentLoaded.
 const els = getElements();
+let optimizerQuickSettings = null;
 
 // ---------- State ----------
 const debounceRun = debounce(onRun, 250);
@@ -121,6 +123,14 @@ async function boot() {
   const { config: initialConfig, source } = await loadInitialConfig();
 
   hydrateUI(els, initialConfig);
+  optimizerQuickSettings = initOptimizerQuickSettings({
+    selectionInput: els.optimizerQuickSettingsSelection,
+    section: els.optimizerQuickSettingsSection,
+    body: els.optimizerQuickSettingsBody,
+    onSelectionChange: () => {
+      void persistConfig();
+    },
+  });
 
   setupTabSwitcher();
   await initPredictionsTab();
@@ -167,6 +177,7 @@ async function onRefreshVrmSettings() {
     const payload = await refreshVrmSettings();
     const saved = payload?.settings || {};
     hydrateUI(els, saved);
+    optimizerQuickSettings?.refresh();
     if (els.status) els.status.textContent = "System settings saved from VRM.";
   } catch (err) {
     console.error(err);

--- a/app/src/charts.js
+++ b/app/src/charts.js
@@ -35,6 +35,7 @@ const FLOWS_TOOLTIP_LABELS = {
 
 const NEGATIVE_INJECTION_EPSILON_W = 1;
 const NEGATIVE_INJECTION_ICON_SIZE = 13;
+const NEGATIVE_INJECTION_ICON_MIN_SIZE = 7;
 const NEGATIVE_INJECTION_DETAIL_LIMIT = 12;
 const BUY_PRICE_STRIP_HEIGHT = 7;
 const BUY_PRICE_STRIP_GAP = 4;
@@ -346,8 +347,9 @@ function getNegativeInjectionRanges(rows, h) {
   return ranges;
 }
 
-function drawNegativeInjectionIcon(ctx, x, y, dark) {
-  const radius = NEGATIVE_INJECTION_ICON_SIZE / 2;
+function drawNegativeInjectionIcon(ctx, x, y, dark, size = NEGATIVE_INJECTION_ICON_SIZE) {
+  const radius = size / 2;
+  const fontSize = Math.max(6, Math.round(size * 0.7));
 
   ctx.save();
   ctx.beginPath();
@@ -359,10 +361,10 @@ function drawNegativeInjectionIcon(ctx, x, y, dark) {
   ctx.stroke();
 
   ctx.fillStyle = dark ? 'rgba(251, 191, 36, 0.60)' : 'rgba(180, 83, 9, 0.55)';
-  ctx.font = '500 9px system-ui, sans-serif';
+  ctx.font = `500 ${fontSize}px system-ui, sans-serif`;
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
-  ctx.fillText('i', x, y + 0.5);
+  ctx.fillText('i', x, y + Math.max(0.25, size * 0.04));
   ctx.restore();
 }
 
@@ -487,18 +489,26 @@ function makeNegativePriceInjectionPlugin(rows, h) {
         ctx.fillStyle = fillStyle;
         ctx.fillRect(x0, chartArea.top, x1 - x0, chartArea.height);
 
-        const iconX = Math.min(
-          Math.max(x0 + 13, chartArea.left + NEGATIVE_INJECTION_ICON_SIZE),
-          x1 - NEGATIVE_INJECTION_ICON_SIZE / 2,
-          chartArea.right - NEGATIVE_INJECTION_ICON_SIZE
+        const rangeWidth = x1 - x0;
+        const iconSize = Math.max(
+          NEGATIVE_INJECTION_ICON_MIN_SIZE,
+          Math.min(NEGATIVE_INJECTION_ICON_SIZE, rangeWidth - 2)
         );
-        drawNegativeInjectionIcon(ctx, iconX, iconY, dark);
+        const halfIcon = iconSize / 2;
+        const iconX = rangeWidth < NEGATIVE_INJECTION_ICON_SIZE * 1.5
+          ? (x0 + x1) / 2
+          : Math.min(
+              Math.max(x0 + NEGATIVE_INJECTION_ICON_SIZE, chartArea.left + halfIcon),
+              x1 - halfIcon,
+              chartArea.right - halfIcon
+            );
+        drawNegativeInjectionIcon(ctx, iconX, iconY, dark, iconSize);
         iconHits.push({
           ...range,
-          left: iconX - NEGATIVE_INJECTION_ICON_SIZE,
-          right: iconX + NEGATIVE_INJECTION_ICON_SIZE,
-          top: iconY - NEGATIVE_INJECTION_ICON_SIZE,
-          bottom: iconY + NEGATIVE_INJECTION_ICON_SIZE,
+          left: iconX - iconSize,
+          right: iconX + iconSize,
+          top: iconY - iconSize,
+          bottom: iconY + iconSize,
         });
       }
 

--- a/app/src/optimizer-quick-settings.js
+++ b/app/src/optimizer-quick-settings.js
@@ -1,0 +1,266 @@
+export const QUICK_SETTING_DEFS = [
+  { id: "batteryCapacity_Wh", selector: "#cap", label: "Battery capacity (Wh)", kind: "number" },
+  { id: "batteryCost_cent_per_kWh", selector: "#bwear", label: "Battery cost (c€/kWh)", kind: "number" },
+  { id: "minSoc_percent", selector: "#minsoc", label: "Min SoC (%)", kind: "number" },
+  { id: "maxSoc_percent", selector: "#maxsoc", label: "Max SoC (%)", kind: "number" },
+  { id: "maxChargePower_W", selector: "#pchg", label: "Max charge (W)", kind: "number" },
+  { id: "maxDischargePower_W", selector: "#pdis", label: "Max discharge (W)", kind: "number" },
+  { id: "maxGridImport_W", selector: "#gimp", label: "Max grid import (W)", kind: "number" },
+  { id: "maxGridExport_W", selector: "#gexp", label: "Max grid export (W)", kind: "number" },
+  { id: "chargeEfficiency_percent", selector: "#etaC", label: "Charge efficiency (%)", kind: "number" },
+  { id: "dischargeEfficiency_percent", selector: "#etaD", label: "Discharge efficiency (%)", kind: "number" },
+  { id: "stepSize_m", selector: "#step", label: "Step (min)", kind: "number" },
+  { id: "idleDrain_W", selector: "#idle-drain", label: "Idle drain (W)", kind: "number" },
+  { id: "rebalanceHoldHours", selector: "#rebalance-hold-hours", label: "Rebalance hold (h)", kind: "number" },
+  {
+    id: "blockFeedInOnNegativePrices",
+    selector: "#block-feedin-negative-prices",
+    label: "Block negative feed-in",
+    kind: "checkbox",
+  },
+  { id: "evMinChargeCurrent_A", selector: "#ev-min-charge-current", label: "EV min current (A)", kind: "number" },
+  { id: "evMaxChargeCurrent_A", selector: "#ev-max-charge-current", label: "EV max current (A)", kind: "number" },
+  { id: "evBatteryCapacity_kWh", selector: "#ev-battery-capacity", label: "EV capacity (kWh)", kind: "number" },
+  { id: "evChargeEfficiency_percent", selector: "#ev-charge-efficiency", label: "EV efficiency (%)", kind: "number" },
+];
+
+const FIELD_LABEL_CLASS = "block text-xs font-medium text-slate-400 dark:text-slate-500 mb-1 tracking-wide";
+
+export function normalizeQuickSettingIds(ids, definitions = QUICK_SETTING_DEFS) {
+  const allowedIds = new Set(definitions.map((def) => def.id));
+  const seen = new Set();
+  const result = [];
+  for (const id of Array.isArray(ids) ? ids : []) {
+    if (typeof id !== "string" || !allowedIds.has(id) || seen.has(id)) continue;
+    seen.add(id);
+    result.push(id);
+  }
+  return result;
+}
+
+export function parseQuickSettingSelection(raw, definitions = QUICK_SETTING_DEFS) {
+  if (Array.isArray(raw)) return normalizeQuickSettingIds(raw, definitions);
+  if (typeof raw !== "string" || raw.trim() === "") return [];
+
+  try {
+    return normalizeQuickSettingIds(JSON.parse(raw), definitions);
+  } catch {
+    return normalizeQuickSettingIds(raw.split(",").map((id) => id.trim()), definitions);
+  }
+}
+
+export function writeQuickSettingSelection(selectionInput, ids, definitions = QUICK_SETTING_DEFS) {
+  if (!selectionInput) return;
+  selectionInput.value = JSON.stringify(normalizeQuickSettingIds(ids, definitions));
+}
+
+export function initOptimizerQuickSettings({
+  selectionInput,
+  section,
+  body,
+  definitions = QUICK_SETTING_DEFS,
+  onSelectionChange = () => {},
+} = {}) {
+  const doc = section?.ownerDocument || body?.ownerDocument || selectionInput?.ownerDocument || document;
+  const state = {
+    body,
+    definitions,
+    doc,
+    mirrorsById: new Map(),
+    pinButtonsById: new Map(),
+    section,
+    selectedIds: [],
+    selectionInput,
+    onSelectionChange,
+    sourceControlsById: new Map(),
+  };
+
+  for (const def of definitions) {
+    const source = doc.querySelector(def.selector);
+    if (!source) continue;
+
+    state.sourceControlsById.set(def.id, source);
+    installPinButton(state, def, source, (id) => {
+      const selected = state.selectedIds.includes(id)
+        ? state.selectedIds.filter((item) => item !== id)
+        : [...state.selectedIds, id];
+      setSelectedIds(state, selected, { notify: true });
+    });
+
+    const syncMirror = () => syncMirrorFromSource(state, def.id);
+    source.addEventListener("input", syncMirror);
+    source.addEventListener("change", syncMirror);
+  }
+
+  function refresh() {
+    const ids = parseQuickSettingSelection(state.selectionInput?.value, definitions);
+    setSelectedIds(state, ids, { notify: false });
+  }
+
+  refresh();
+
+  return {
+    getSelectedIds: () => [...state.selectedIds],
+    refresh,
+    setSelectedIds: (ids, opts = {}) => setSelectedIds(state, ids, opts),
+  };
+}
+
+function setSelectedIds(state, ids, { notify = false } = {}) {
+  state.selectedIds = normalizeQuickSettingIds(ids, state.definitions);
+  writeQuickSettingSelection(state.selectionInput, state.selectedIds, state.definitions);
+  renderMirrors(state);
+  updatePinButtons(state);
+  if (notify) state.onSelectionChange([...state.selectedIds]);
+}
+
+function installPinButton(state, def, source, onToggle) {
+  const label = source.closest("label");
+  if (!label) return;
+
+  const existing = label.querySelector(`[data-quick-setting-pin="${def.id}"]`);
+  if (existing) {
+    state.pinButtonsById.set(def.id, existing);
+    return;
+  }
+
+  const isToggle = label.classList.contains("toggle");
+  label.classList.add(isToggle ? "quick-setting-toggle-label" : "quick-setting-source-label");
+
+  const button = state.doc.createElement("button");
+  button.type = "button";
+  button.className = "quick-setting-pin";
+  button.dataset.quickSettingPin = def.id;
+  button.innerHTML = pinIconSvg();
+  button.addEventListener("click", (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    onToggle(def.id);
+  });
+
+  if (isToggle) {
+    label.appendChild(button);
+  } else {
+    label.insertBefore(button, label.firstChild);
+  }
+  state.pinButtonsById.set(def.id, button);
+}
+
+function updatePinButtons(state) {
+  for (const [id, button] of state.pinButtonsById) {
+    const pressed = state.selectedIds.includes(id);
+    const label = state.definitions.find((def) => def.id === id)?.label || "setting";
+    button.setAttribute("aria-pressed", String(pressed));
+    button.setAttribute("aria-label", pressed ? `Remove ${label} from optimizer quick settings` : `Pin ${label} to optimizer quick settings`);
+    button.title = pressed ? "Remove from optimizer quick settings" : "Pin to optimizer quick settings";
+  }
+}
+
+function renderMirrors(state) {
+  if (!state.body || !state.section) return;
+
+  state.body.replaceChildren();
+  state.mirrorsById.clear();
+
+  let rendered = 0;
+  for (const id of state.selectedIds) {
+    const def = state.definitions.find((item) => item.id === id);
+    const source = state.sourceControlsById.get(id);
+    if (!def || !source) continue;
+
+    state.body.appendChild(createMirrorField(state, def, source));
+    rendered += 1;
+  }
+
+  state.section.classList.toggle("hidden", rendered === 0);
+}
+
+function createMirrorField(state, def, source) {
+  const mirror = source.cloneNode(true);
+  mirror.id = `optimizer-quick-${def.id}`;
+  mirror.removeAttribute("name");
+  mirror.dataset.optimizerQuickMirror = def.id;
+  syncControl(source, mirror);
+
+  mirror.addEventListener(inputEventName(mirror), () => {
+    syncControl(mirror, source);
+    source.dispatchEvent(new Event(inputEventName(source), { bubbles: true }));
+  });
+
+  state.mirrorsById.set(def.id, mirror);
+
+  if (isCheckbox(source)) {
+    const label = state.doc.createElement("label");
+    label.className = "toggle";
+
+    const knob = state.doc.createElement("span");
+    knob.className = "toggle-knob";
+
+    const text = state.doc.createElement("span");
+    text.className = "text-sm text-slate-600 dark:text-slate-400";
+    text.textContent = def.label;
+
+    label.append(mirror, knob, text, createUnpinButton(state, def));
+    return label;
+  }
+
+  const label = state.doc.createElement("label");
+  label.className = "text-sm";
+
+  const labelRow = state.doc.createElement("span");
+  labelRow.className = "flex items-center justify-between gap-2";
+
+  const text = state.doc.createElement("span");
+  text.className = FIELD_LABEL_CLASS;
+  text.textContent = def.label;
+
+  labelRow.append(text, createUnpinButton(state, def));
+  label.append(labelRow, mirror);
+  return label;
+}
+
+function createUnpinButton(state, def) {
+  const button = state.doc.createElement("button");
+  button.type = "button";
+  button.className = "quick-setting-pin";
+  button.dataset.quickSettingUnpin = def.id;
+  button.setAttribute("aria-pressed", "true");
+  button.setAttribute("aria-label", `Remove ${def.label} from optimizer quick settings`);
+  button.title = "Remove from optimizer quick settings";
+  button.innerHTML = pinIconSvg();
+  button.addEventListener("click", (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    setSelectedIds(state, state.selectedIds.filter((id) => id !== def.id), { notify: true });
+  });
+  return button;
+}
+
+function syncMirrorFromSource(state, id) {
+  const source = state.sourceControlsById.get(id);
+  const mirror = state.mirrorsById.get(id);
+  if (!source || !mirror) return;
+  syncControl(source, mirror);
+}
+
+function syncControl(from, to) {
+  if (isCheckbox(from)) {
+    to.checked = from.checked;
+  } else {
+    to.value = from.value;
+  }
+  to.disabled = from.disabled;
+}
+
+function inputEventName(control) {
+  if (isCheckbox(control) || control.tagName === "SELECT") return "change";
+  return "input";
+}
+
+function isCheckbox(control) {
+  return control instanceof HTMLInputElement && control.type === "checkbox";
+}
+
+function pinIconSvg() {
+  return `<svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M16 12V4h1V2H7v2h1v8l-2 2v2h5.2v6h1.6v-6H18v-2l-2-2Z"/></svg>`;
+}

--- a/app/src/predictions.js
+++ b/app/src/predictions.js
@@ -642,9 +642,6 @@ function renderCombinedForecastChart() {
     },
     options: getBaseOptions({ ...axis, yTitle: 'kWh' }, {
       ...getChartAnimations('bar', allTs.length),
-      onHover: (_event, _elements, chart) => {
-        chart.canvas.style.cursor = allTs.length ? 'crosshair' : '';
-      },
       plugins: {
         tooltip: {
           mode: 'index',
@@ -705,6 +702,10 @@ function pickForecastBucket(event, canvas, timestamps, stepMinutes) {
 function wireForecastChartEditing(canvas, timestamps, stepMinutes) {
   if (typeof canvas._forecastEditCleanup === 'function') canvas._forecastEditCleanup();
 
+  const updateCursor = (event) => {
+    canvas.style.cursor = pickForecastBucket(event, canvas, timestamps, stepMinutes) ? 'copy' : '';
+  };
+
   const onPointerDown = (event) => {
     if (event.button !== 0) return;
     const picked = pickForecastBucket(event, canvas, timestamps, stepMinutes);
@@ -723,7 +724,10 @@ function wireForecastChartEditing(canvas, timestamps, stepMinutes) {
   };
 
   const onPointerMove = (event) => {
-    if (!forecastChartDrag) return;
+    if (!forecastChartDrag) {
+      updateCursor(event);
+      return;
+    }
     const picked = pickForecastBucket(event, canvas, timestamps, stepMinutes);
     if (!picked) return;
     const distance = Math.hypot(event.clientX - forecastChartDrag.startX, event.clientY - forecastChartDrag.startY);
@@ -760,18 +764,28 @@ function wireForecastChartEditing(canvas, timestamps, stepMinutes) {
   const onPointerCancel = () => {
     forecastChartDrag = null;
     forecastChartSelection = null;
+    canvas.style.cursor = '';
     canvas._chart?.update('none');
   };
 
+  const onPointerLeave = () => {
+    if (!forecastChartDrag) canvas.style.cursor = '';
+  };
+
+  canvas.addEventListener('pointerenter', updateCursor);
   canvas.addEventListener('pointerdown', onPointerDown);
   canvas.addEventListener('pointermove', onPointerMove);
   canvas.addEventListener('pointerup', onPointerUp);
   canvas.addEventListener('pointercancel', onPointerCancel);
+  canvas.addEventListener('pointerleave', onPointerLeave);
   canvas._forecastEditCleanup = () => {
+    canvas.style.cursor = '';
+    canvas.removeEventListener('pointerenter', updateCursor);
     canvas.removeEventListener('pointerdown', onPointerDown);
     canvas.removeEventListener('pointermove', onPointerMove);
     canvas.removeEventListener('pointerup', onPointerUp);
     canvas.removeEventListener('pointercancel', onPointerCancel);
+    canvas.removeEventListener('pointerleave', onPointerLeave);
   };
 }
 
@@ -944,7 +958,7 @@ function renderAdjustmentList() {
   const sorted = [...predictionAdjustments].sort((a, b) => new Date(a.start).getTime() - new Date(b.start).getTime());
   if (count) count.textContent = sorted.length ? `${sorted.length} active` : '';
   if (!sorted.length) {
-    list.innerHTML = '<div class="rounded-lg border border-dashed border-slate-200 px-3 py-2 text-sm text-slate-500 dark:border-white/10 dark:text-slate-400">No active adjustments</div>';
+    list.innerHTML = '<div class="rounded-lg border border-dashed border-slate-200 px-3 py-2 text-sm text-slate-500 dark:border-white/10 dark:text-slate-400">No active adjustments. Click or drag on the forecast chart to add one.</div>';
     return;
   }
   list.innerHTML = '';

--- a/app/src/state.js
+++ b/app/src/state.js
@@ -1,4 +1,5 @@
 import { SOLUTION_COLORS } from "./charts.js";
+import { parseQuickSettingSelection, writeQuickSettingSelection } from "./optimizer-quick-settings.js";
 
 // ---------- UI <-> settings snapshot ----------
 export function snapshotUI(els) {
@@ -21,6 +22,7 @@ export function snapshotUI(els) {
     // ALGORITHM
     terminalSocValuation: els.terminal?.value || "zero",
     terminalSocCustomPrice_cents_per_kWh: num(els.terminalCustom?.value),
+    optimizerQuickSettings: parseQuickSettingSelection(els.optimizerQuickSettingsSelection?.value),
 
     // DATA
     dataSources: {
@@ -81,6 +83,9 @@ export function hydrateUI(els, obj = {}) {
     els.terminal.value = String(obj.terminalSocValuation);
   }
   setIfDef(els.terminalCustom, obj.terminalSocCustomPrice_cents_per_kWh);
+  if (obj.optimizerQuickSettings !== undefined) {
+    writeQuickSettingSelection(els.optimizerQuickSettingsSelection, obj.optimizerQuickSettings);
+  }
 
   // DATA
   if (els.sourcePrices && obj.dataSources?.prices) els.sourcePrices.value = obj.dataSources.prices;

--- a/app/src/ui-binding.js
+++ b/app/src/ui-binding.js
@@ -6,6 +6,9 @@ export function getElements() {
     run: $("#run"),
     updateDataBeforeRun: $("#update-data-before-run"),
     pushToVictron: $("#push-to-victron"),
+    optimizerQuickSettingsSection: $("#optimizer-quick-settings"),
+    optimizerQuickSettingsBody: $("#optimizer-quick-settings-body"),
+    optimizerQuickSettingsSelection: $("#optimizer-quick-settings-selection"),
     sourcePrices: $("#source-prices"),
     sourceLoad: $("#source-load"),
     sourcePv: $("#source-pv"),
@@ -116,6 +119,8 @@ export function wireGlobalInputs(els, { onInput, onSave = onInput, onRun, update
     if (el === els.tableKwh) continue;
     if (el === els.updateDataBeforeRun) continue; // Checkbox doesn't trigger auto-save
     if (el === els.pushToVictron) continue; // Checkbox doesn't trigger auto-save
+    if (el === els.optimizerQuickSettingsSelection) continue; // Managed by quick-settings pins
+    if (el.dataset.optimizerQuickMirror) continue; // Mirrors dispatch changes through their source input
     if (el.dataset.predictionsOnly) continue; // Predictions tab inputs handled separately
     const handler = el.hasAttribute('data-no-autosolve') ? onSave : onInput;
     el.addEventListener("input", handler);

--- a/tests/app/optimizer-quick-settings.test.js
+++ b/tests/app/optimizer-quick-settings.test.js
@@ -1,0 +1,156 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  initOptimizerQuickSettings,
+  parseQuickSettingSelection,
+} from '../../app/src/optimizer-quick-settings.js';
+
+const definitions = [
+  { id: 'minSoc_percent', selector: '#minsoc', label: 'Min SoC (%)', kind: 'number' },
+  { id: 'mode', selector: '#mode', label: 'Mode', kind: 'select' },
+  { id: 'blockFeedInOnNegativePrices', selector: '#block-feedin-negative-prices', label: 'Block feed-in', kind: 'checkbox' },
+];
+
+function setupDom(selection = '[]') {
+  document.body.innerHTML = `
+    <section id="optimizer-quick-settings" class="hidden">
+      <div id="optimizer-quick-settings-body"></div>
+      <input id="optimizer-quick-settings-selection" value='${selection}' />
+    </section>
+    <label class="text-sm">Min SoC (%)
+      <input id="minsoc" type="number" class="form-input" value="20" min="0" max="100" />
+    </label>
+    <label class="text-sm">Mode
+      <select id="mode" class="form-select">
+        <option value="zero">zero</option>
+        <option value="max">max</option>
+      </select>
+    </label>
+    <label class="toggle">
+      <input id="block-feedin-negative-prices" type="checkbox" />
+      <span class="toggle-knob"></span>
+      <span>Block feed-in</span>
+    </label>
+  `;
+
+  return {
+    body: document.querySelector('#optimizer-quick-settings-body'),
+    section: document.querySelector('#optimizer-quick-settings'),
+    selectionInput: document.querySelector('#optimizer-quick-settings-selection'),
+  };
+}
+
+describe('optimizer quick settings', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('pins and unpins settings without triggering a recompute callback', () => {
+    const els = setupDom();
+    const onSelectionChange = vi.fn();
+    const controller = initOptimizerQuickSettings({ ...els, definitions, onSelectionChange });
+
+    document.querySelector('[data-quick-setting-pin="minSoc_percent"]').click();
+
+    expect(controller.getSelectedIds()).toEqual(['minSoc_percent']);
+    expect(JSON.parse(els.selectionInput.value)).toEqual(['minSoc_percent']);
+    expect(els.section.classList.contains('hidden')).toBe(false);
+    expect(els.body.querySelector('#optimizer-quick-minSoc_percent')).toBeTruthy();
+    expect(onSelectionChange).toHaveBeenCalledWith(['minSoc_percent']);
+
+    document.querySelector('[data-quick-setting-pin="minSoc_percent"]').click();
+
+    expect(controller.getSelectedIds()).toEqual([]);
+    expect(JSON.parse(els.selectionInput.value)).toEqual([]);
+    expect(els.section.classList.contains('hidden')).toBe(true);
+    expect(onSelectionChange).toHaveBeenCalledTimes(2);
+  });
+
+  it('places toggle pins after the toggle text', () => {
+    const els = setupDom();
+    initOptimizerQuickSettings({ ...els, definitions });
+
+    const toggleLabel = document.querySelector('#block-feedin-negative-prices').closest('label');
+
+    expect(toggleLabel.lastElementChild).toBe(document.querySelector('[data-quick-setting-pin="blockFeedInOnNegativePrices"]'));
+  });
+
+  it('can unpin a setting from its optimizer mirror', () => {
+    const els = setupDom('["minSoc_percent"]');
+    const onSelectionChange = vi.fn();
+    const controller = initOptimizerQuickSettings({ ...els, definitions, onSelectionChange });
+
+    document.querySelector('[data-quick-setting-unpin="minSoc_percent"]').click();
+
+    expect(controller.getSelectedIds()).toEqual([]);
+    expect(JSON.parse(els.selectionInput.value)).toEqual([]);
+    expect(els.section.classList.contains('hidden')).toBe(true);
+    expect(onSelectionChange).toHaveBeenCalledWith([]);
+  });
+
+  it('syncs number, select, and checkbox mirrors in both directions', () => {
+    const els = setupDom('["minSoc_percent","mode","blockFeedInOnNegativePrices"]');
+    initOptimizerQuickSettings({ ...els, definitions });
+
+    const minSoc = document.querySelector('#minsoc');
+    const minSocMirror = document.querySelector('#optimizer-quick-minSoc_percent');
+    const mode = document.querySelector('#mode');
+    const modeMirror = document.querySelector('#optimizer-quick-mode');
+    const block = document.querySelector('#block-feedin-negative-prices');
+    const blockMirror = document.querySelector('#optimizer-quick-blockFeedInOnNegativePrices');
+
+    minSocMirror.value = '35';
+    minSocMirror.dispatchEvent(new Event('input', { bubbles: true }));
+    expect(minSoc.value).toBe('35');
+
+    modeMirror.value = 'max';
+    modeMirror.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(mode.value).toBe('max');
+
+    blockMirror.checked = true;
+    blockMirror.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(block.checked).toBe(true);
+
+    minSoc.value = '42';
+    minSoc.dispatchEvent(new Event('input', { bubbles: true }));
+    expect(minSocMirror.value).toBe('42');
+
+    mode.value = 'zero';
+    mode.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(modeMirror.value).toBe('zero');
+
+    block.checked = false;
+    block.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(blockMirror.checked).toBe(false);
+  });
+
+  it('routes mirror edits through the source input event path', () => {
+    const els = setupDom('["minSoc_percent"]');
+    initOptimizerQuickSettings({ ...els, definitions });
+
+    const onInput = vi.fn();
+    const minSoc = document.querySelector('#minsoc');
+    const minSocMirror = document.querySelector('#optimizer-quick-minSoc_percent');
+    minSoc.addEventListener('input', onInput);
+
+    minSocMirror.value = '30';
+    minSocMirror.dispatchEvent(new Event('input', { bubbles: true }));
+
+    expect(minSoc.value).toBe('30');
+    expect(onInput).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores unknown saved IDs safely', () => {
+    const els = setupDom('["missing","minSoc_percent","minSoc_percent"]');
+    const controller = initOptimizerQuickSettings({ ...els, definitions });
+
+    expect(controller.getSelectedIds()).toEqual(['minSoc_percent']);
+    expect(JSON.parse(els.selectionInput.value)).toEqual(['minSoc_percent']);
+    expect(els.body.querySelector('#optimizer-quick-missing')).toBeNull();
+  });
+
+  it('parses JSON and comma-separated selection values', () => {
+    expect(parseQuickSettingSelection('["minSoc_percent","missing"]', definitions)).toEqual(['minSoc_percent']);
+    expect(parseQuickSettingSelection('mode, missing, mode', definitions)).toEqual(['mode']);
+  });
+});

--- a/tests/app/state.test.js
+++ b/tests/app/state.test.js
@@ -1,0 +1,27 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { hydrateUI, snapshotUI } from '../../app/src/state.js';
+
+describe('settings state', () => {
+  it('round-trips optimizer quick settings through hydrate and snapshot', () => {
+    const optimizerQuickSettingsSelection = document.createElement('input');
+    const terminal = document.createElement('select');
+    terminal.innerHTML = '<option value="zero">zero</option>';
+    const terminalCustom = document.createElement('input');
+
+    const els = {
+      optimizerQuickSettingsSelection,
+      terminal,
+      terminalCustom,
+    };
+
+    hydrateUI(els, {
+      optimizerQuickSettings: ['minSoc_percent', 'blockFeedInOnNegativePrices'],
+      terminalSocValuation: 'zero',
+      terminalSocCustomPrice_cents_per_kWh: 0,
+    });
+
+    expect(optimizerQuickSettingsSelection.value).toBe('["minSoc_percent","blockFeedInOnNegativePrices"]');
+    expect(snapshotUI(els).optimizerQuickSettings).toEqual(['minSoc_percent', 'blockFeedInOnNegativePrices']);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a collapsible quick-access panel at the top of the Algorithm section where any setting can be pinned with a pushpin button next to its label
- Mirror controls in the panel sync bidirectionally with their source inputs and dispatch events through the normal input path (no double-firing)
- Selection is persisted in settings as `optimizerQuickSettings: string[]`, validated server-side in `settings-store.ts`
- Also fixes the negative-injection icon scaling on narrow price strips, and improves forecast chart cursor feedback (shows a `copy` cursor when hovering an editable bucket instead of `crosshair`)

## Test plan

- [ ] Pin a setting via its pushpin button — mirror appears in the quick panel, value syncs both ways
- [ ] Unpin from the pin button in the source label — mirror disappears
- [ ] Unpin from the mirror panel itself (second pin button) — same result
- [ ] Edit value in the mirror — source input updates and the optimizer re-runs (or saves, for no-autosolve fields)
- [ ] Reload page — pinned settings are restored from persisted settings
- [ ] Refresh VRM settings — quick panel re-renders with the new values
- [ ] Dark mode — pin buttons and panel render correctly
- [ ] `npx vitest run tests/app/` passes (27 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)