### PR TITLE
Add net grid cost display and DESS detail toggle

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -694,9 +694,13 @@
                 <div class="stat-label mb-0.5">Predicted PV</div>
                 <div id="sum-pv-kwh" class="stat-value color-flow-solar">—</div>
               </div>
-              <div class="px-3 py-2.5 col-span-2">
+              <div class="px-3 py-2.5 border-r border-slate-100 dark:border-white/5">
                 <div class="stat-label mb-0.5">Avg. import price</div>
                 <div id="avg-import-cent" class="stat-value">—</div>
+              </div>
+              <div class="px-3 py-2.5">
+                <div class="stat-label mb-0.5">Net cost</div>
+                <div id="net-cost-cent" class="stat-value">—</div>
               </div>
             </div>
             <div class="summary-block border-t border-slate-100 dark:border-white/5">
@@ -819,6 +823,11 @@
         <div class="mb-4 flex items-center justify-between gap-4">
           <h3 class="sidebar-label">Schedule table</h3>
           <div class="flex items-center gap-3">
+            <label class="toggle">
+              <input id="table-dess" type="checkbox">
+              <span class="toggle-knob"></span>
+              <span class="text-sm text-slate-600 dark:text-slate-400">Show DESS details</span>
+            </label>
             <label class="toggle">
               <input id="table-kwh" type="checkbox">
               <span class="toggle-knob"></span>

--- a/app/main.js
+++ b/app/main.js
@@ -44,6 +44,8 @@ function revealCards(panel) {
 // However, safer to call getElements() when needed or at top level if we trust DOMContentLoaded.
 const els = getElements();
 let optimizerQuickSettings = null;
+let lastTableRows = [];
+let lastTableRebalanceWindow = null;
 
 // ---------- State ----------
 const debounceRun = debounce(onRun, 250);
@@ -143,6 +145,7 @@ async function boot() {
     },
     onSave: queuePersistSnapshot,
     onRun: onRun,
+    onTableDisplayChange: onTableDisplayChange,
     updateTerminalCustomUI: () => updateTerminalCustomUI(els),
   });
 
@@ -256,14 +259,9 @@ async function onRun() {
       targetSoc_percent: parseFloat(els.evTargetSoc?.value) || null,
     } : null;
 
-    renderTable({
-      rows,
-      cfg: cfgForViz,
-      targets: { table: els.table, tableUnit: els.tableUnit },
-      showKwh: !!els.tableKwh?.checked,
-      rebalanceWindow: result.rebalanceWindow ?? null,
-      evSettings,
-    });
+    lastTableRows = rows;
+    lastTableRebalanceWindow = result.rebalanceWindow ?? null;
+    renderScheduleTable();
 
     renderAllCharts(rows, cfgForViz, result.rebalanceWindow ?? null, evSettings);
 
@@ -283,6 +281,36 @@ async function onRun() {
       runBtn.disabled = false;
     }
   }
+}
+
+function onTableDisplayChange(event) {
+  if (!renderScheduleTable()) {
+    void onRun();
+    return;
+  }
+  if (event?.currentTarget === els.tableKwh) {
+    queuePersistSnapshot();
+  }
+}
+
+function renderScheduleTable() {
+  if (!lastTableRows.length) return false;
+  renderTable({
+    rows: lastTableRows,
+    cfg: {
+      stepSize_m: Number(els.step?.value),
+      batteryCapacity_Wh: Number(els.cap?.value),
+    },
+    targets: { table: els.table, tableUnit: els.tableUnit },
+    showKwh: !!els.tableKwh?.checked,
+    showDess: !!els.tableDess?.checked,
+    rebalanceWindow: lastTableRebalanceWindow,
+    evSettings: els.evEnabled?.checked ? {
+      departureTime: els.evDepartureTime?.value || null,
+      targetSoc_percent: parseFloat(els.evTargetSoc?.value) || null,
+    } : null,
+  });
+  return true;
 }
 
 function renderAllCharts(rows, cfg, rebalanceWindow = null, evSettings = null) {

--- a/app/src/state.js
+++ b/app/src/state.js
@@ -166,6 +166,7 @@ export function updateSummaryUI(els, summary) {
     setText(els.sumLoadBatt, "—");
     setText(els.sumLoadPv, "—");
     setText(els.avgImport, "—");
+    setText(els.netCost, "—");
     setText(els.gridBatteryTp, "—");
     setText(els.gridChargeTp, "—");
     setText(els.batteryExportTp, "—");
@@ -185,6 +186,7 @@ export function updateSummaryUI(els, summary) {
     loadFromBattery_kWh,
     loadFromPv_kWh,
     avgImportPrice_cents_per_kWh,
+    netGridCost_cents,
     gridBatteryTippingPoint_cents_per_kWh,
     gridChargeTippingPoint_cents_per_kWh,
     batteryExportTippingPoint_cents_per_kWh,
@@ -197,6 +199,7 @@ export function updateSummaryUI(els, summary) {
   setText(els.sumLoadBatt, formatKWh(loadFromBattery_kWh));
   setText(els.sumLoadPv, formatKWh(loadFromPv_kWh));
   setText(els.avgImport, formatCentsPerKWh(avgImportPrice_cents_per_kWh));
+  setText(els.netCost, formatCostCents(netGridCost_cents));
   setText(els.gridBatteryTp, formatTippingPoint(gridBatteryTippingPoint_cents_per_kWh, "↓"));
   setText(els.gridChargeTp, formatTippingPoint(gridChargeTippingPoint_cents_per_kWh, "↓"));
   // Show battery export tp if present, otherwise fall back to PV export tp
@@ -366,16 +369,23 @@ export function formatKWh(v) {
   return `${n.toFixed(2)} kWh`;
 }
 
-function formatCentsPerKWh(v) {
-  if (v === null || v === undefined) return "—";
+function toFinite(v) {
+  if (v === null || v === undefined) return null;
   const n = Number(v);
-  if (!Number.isFinite(n)) return "—";
-  return `${n.toFixed(2)} c€/kWh`;
+  return Number.isFinite(n) ? n : null;
+}
+
+function formatCentsPerKWh(v) {
+  const n = toFinite(v);
+  return n === null ? "—" : `${n.toFixed(2)} c€/kWh`;
+}
+
+function formatCostCents(v) {
+  const n = toFinite(v);
+  return n === null ? "—" : `${n.toFixed(2)} c€`;
 }
 
 function formatTippingPoint(v, symbol) {
-  if (v === null || v === undefined) return "—";
-  const n = Number(v);
-  if (!Number.isFinite(n)) return "—";
-  return `${symbol} ${n.toFixed(2)} c€`;
+  const n = toFinite(v);
+  return n === null ? "—" : `${symbol} ${n.toFixed(2)} c€`;
 }

--- a/app/src/table.js
+++ b/app/src/table.js
@@ -13,8 +13,9 @@ import { escapeHtml } from "./utils.js";
  * @param {HTMLElement}  opts.targets.table       - <table> element to write into
  * @param {HTMLElement}  [opts.targets.tableUnit] - element for the "Units: ..." label
  * @param {boolean}      opts.showKwh             - whether to display kWh instead of W
+ * @param {boolean}      opts.showDess            - whether to display DESS metadata columns
  */
-export function renderTable({ rows, cfg, targets, showKwh, rebalanceWindow, evSettings }) {
+export function renderTable({ rows, cfg, targets, showKwh, showDess = false, rebalanceWindow, evSettings }) {
   const { table, tableUnit } = targets || {};
   if (!table || !Array.isArray(rows) || rows.length === 0) return;
 
@@ -48,8 +49,8 @@ export function renderTable({ rows, cfg, targets, showKwh, rebalanceWindow, evSe
     }},
     { key: "load", headerHtml: "Exp.<br>load", fmt: x => fmtEnergy(x, { dash: false }), tip: "Expected Load" },
     { key: "pv", headerHtml: "Exp.<br>PV", fmt: x => fmtEnergy(x, { dash: false }), tip: "Expected PV" },
-    { key: "ic", headerHtml: "Import<br>cost", fmt: dec2Thin },
-    { key: "ec", headerHtml: "Export<br>cost", fmt: dec2Thin },
+    { key: "ic", headerHtml: "Import<br>price", fmt: dec2Thin, tip: "Import price (c€/kWh)" },
+    { key: "ec", headerHtml: "Export<br>price", fmt: dec2Thin, tip: "Export price (c€/kWh)" },
 
     { key: "g2l", headerHtml: "g2l", fmt: x => fmtEnergy(x), tip: "Grid → Load" },
     { key: "b2l", headerHtml: "b2l", fmt: x => fmtEnergy(x), tip: "Battery → Load" },
@@ -96,30 +97,34 @@ export function renderTable({ rows, cfg, targets, showKwh, rebalanceWindow, evSe
 
     { key: "imp", headerHtml: "Grid<br>import", fmt: x => fmtEnergy(x), tip: "Grid Import" },
     { key: "exp", headerHtml: "Grid<br>export", fmt: x => fmtEnergy(x), tip: "Grid Export" },
+    { key: "importCost_cents", headerHtml: "Import<br>cost", fmt: fmtCost, tip: "Import cost for this slot" },
+    { key: "exportCost_cents", headerHtml: "Export<br>cost", fmt: fmtCost, tip: "Export value for this slot" },
 
-    {
-      key: "dess_strategy",
-      headerHtml: "DESS<br>strategy",
-      fmt: (_, ri) => fmtDessStrategy(rows[ri]?.dess?.strategy),
-      tip: 'DESS strategy: TS=Target SoC, SC=Self-consumption, PB=Pro battery, PG=Pro grid',
-      cellTip: true,
-    },
-    {
-      key: "dess_restrictions",
-      headerHtml: "Restr.",
-      fmt: (_, ri) => fmtDessRestrictions(rows[ri]?.dess?.restrictions),
-      tip: 'Grid↔battery restrictions',
-      cellTip: true,
-    },
-    {
-      key: "dess_feedin",
-      headerHtml: "Feed-in",
-      fmt: (_, ri) => {
-        const d = rows[ri]?.dess;
-        return fmtDessFeedin(d?.feedin);
+    ...(showDess ? [
+      {
+        key: "dess_strategy",
+        headerHtml: "DESS<br>strategy",
+        fmt: (_, ri) => fmtDessStrategy(rows[ri]?.dess?.strategy),
+        tip: 'DESS strategy: TS=Target SoC, SC=Self-consumption, PB=Pro battery, PG=Pro grid',
+        cellTip: true,
       },
-      tip: '1=allowed, 0=blocked; "?" = unknown',
-    },
+      {
+        key: "dess_restrictions",
+        headerHtml: "Restr.",
+        fmt: (_, ri) => fmtDessRestrictions(rows[ri]?.dess?.restrictions),
+        tip: 'Grid↔battery restrictions',
+        cellTip: true,
+      },
+      {
+        key: "dess_feedin",
+        headerHtml: "Feed-in",
+        fmt: (_, ri) => {
+          const d = rows[ri]?.dess;
+          return fmtDessFeedin(d?.feedin);
+        },
+        tip: '1=allowed, 0=blocked; "?" = unknown',
+      },
+    ] : []),
     {
       key: "dess_soc_target",
       headerHtml: "Soc→",
@@ -131,7 +136,8 @@ export function renderTable({ rows, cfg, targets, showKwh, rebalanceWindow, evSe
     },
   ];
 
-  const SUMMABLE_KEYS = new Set(["load", "pv", "g2l", "b2l", "pv2l", "pv2b", "pv2g", "g2b", "b2g", "ev_charge", "imp", "exp"]);
+  const MONEY_SUMMABLE_KEYS = new Set(["importCost_cents", "exportCost_cents"]);
+  const SUMMABLE_KEYS = new Set(["load", "pv", "g2l", "b2l", "pv2l", "pv2b", "pv2g", "g2b", "b2g", "ev_charge", "imp", "exp", "importCost_cents", "exportCost_cents"]);
 
   const totals = {};
   for (const key of SUMMABLE_KEYS) {
@@ -142,13 +148,16 @@ export function renderTable({ rows, cfg, targets, showKwh, rebalanceWindow, evSe
     const baseCls = "px-2 py-1.5 border-b border-slate-200/80 dark:border-slate-700/60 bg-slate-50 dark:bg-slate-900";
     // Time column: Σ badge
     if (ci === 0) {
-      return `<th class="${baseCls}" scope="row"><span class="inline-flex items-center justify-center w-5 h-5 rounded-full bg-slate-200/80 dark:bg-slate-700/60 text-[9px] font-bold text-slate-400 dark:text-slate-500" title="Column totals (kWh)">Σ</span></th>`;
+      return `<th class="${baseCls}" scope="row"><span class="inline-flex items-center justify-center w-5 h-5 rounded-full bg-slate-200/80 dark:bg-slate-700/60 text-[9px] font-bold text-slate-400 dark:text-slate-500" title="Column totals">Σ</span></th>`;
     }
     if (!SUMMABLE_KEYS.has(c.key)) {
       return `<th class="${baseCls}"></th>`;
     }
-    // Totals are always in kWh — summing W across slots is not meaningful energy
     const total = totals[c.key];
+    if (MONEY_SUMMABLE_KEYS.has(c.key)) {
+      return `<th class="${baseCls} text-right font-mono tabular-nums text-[11px] font-semibold text-slate-500 dark:text-slate-400" scope="col">${fmtCost(total, { dash: false })}</th>`;
+    }
+    // Energy totals are always in kWh — summing W across slots is not meaningful energy
     const displayVal = dec2Thin(W2kWh(total));
     const color = SOLUTION_COLORS[c.key];
     if (color) {
@@ -253,6 +262,12 @@ export function renderTable({ rows, cfg, targets, showKwh, rebalanceWindow, evSe
     const s = n.toFixed(2);
     const [i, f] = s.split(".");
     return `${groupThin(i)}.${f}`;
+  }
+
+  function fmtCost(x, { dash = true } = {}) {
+    const n = Number(x) || 0;
+    if (dash && Math.abs(n) < 0.005) return "–";
+    return `${dec2Thin(n)} c€`;
   }
 
   // rgb(…, …, …) → rgba(…, …, …, a)

--- a/app/src/ui-binding.js
+++ b/app/src/ui-binding.js
@@ -43,6 +43,7 @@ export function getElements() {
     prices: $("#prices"),
     loadpv: $("#loadpv"),
     table: $("#table"),
+    tableDess: $("#table-dess"),
     tableKwh: $("#table-kwh"),
     tableUnit: $("#table-unit"),
     status: $("#status"),
@@ -54,6 +55,7 @@ export function getElements() {
     sumLoadBatt: $("#sum-load-batt-kwh"),
     sumLoadPv: $("#sum-load-pv-kwh"),
     avgImport: $("#avg-import-cent"),
+    netCost: $("#net-cost-cent"),
     gridBatteryTp: $("#tipping-point-cent"),
     gridChargeTp: $("#grid-charge-point-cent"),
     batteryExportTp: $("#export-point-cent"),
@@ -112,11 +114,14 @@ export function getElements() {
   };
 }
 
-export function wireGlobalInputs(els, { onInput, onSave = onInput, onRun, updateTerminalCustomUI }) {
-  // Auto-save whenever anything changes (except table toggler and run options).
+export function wireGlobalInputs(
+  els,
+  { onInput, onSave = onInput, onRun, onTableDisplayChange = onRun, updateTerminalCustomUI }
+) {
+  // Auto-save whenever anything changes (except table toggles and run options).
   // Inputs with data-no-autosolve save settings but do not trigger an auto-solve.
   for (const el of document.querySelectorAll("input, select, textarea")) {
-    if (el === els.tableKwh) continue;
+    if (el === els.tableKwh || el === els.tableDess) continue;
     if (el === els.updateDataBeforeRun) continue; // Checkbox doesn't trigger auto-save
     if (el === els.pushToVictron) continue; // Checkbox doesn't trigger auto-save
     if (el === els.optimizerQuickSettingsSelection) continue; // Managed by quick-settings pins
@@ -133,8 +138,9 @@ export function wireGlobalInputs(els, { onInput, onSave = onInput, onRun, update
   // Manual recompute
   els.run?.addEventListener("click", onRun);
 
-  // Units toggle recompute
-  els.tableKwh?.addEventListener("change", onRun);
+  // Table display toggles
+  els.tableKwh?.addEventListener("change", onTableDisplayChange);
+  els.tableDess?.addEventListener("change", onTableDisplayChange);
 
   // Keyboard shortcut: Ctrl+Enter (or Cmd+Enter) to Recompute
   document.addEventListener("keydown", (e) => {

--- a/lib/parse-solution.ts
+++ b/lib/parse-solution.ts
@@ -62,11 +62,14 @@ export function parseSolution(result: HighsSolution, cfg: SolverConfig, opts: Pa
   }
 
   // --- 2. Build rows (flows, soc, etc.) ---
+  const slotHours = opts.stepMin / 60;
   const rows: PlanRow[] = [];
   for (let t = 0; t < T; t++) {
     const imp = g2l[t] + g2b[t] + g2ev[t];
     const exp = pv2g[t] + b2g[t];
     const evW = g2ev[t] + pv2ev[t] + b2ev[t];
+    const importCost = imp * slotHours / 1000 * cfg.importPrice[t];
+    const exportCost = exp * slotHours / 1000 * cfg.exportPrice[t];
 
     rows.push({
       tIdx: t,
@@ -87,6 +90,8 @@ export function parseSolution(result: HighsSolution, cfg: SolverConfig, opts: Pa
 
       imp: round(imp),
       exp: round(exp),
+      importCost_cents: round(importCost),
+      exportCost_cents: round(exportCost),
       soc: round(soc[t]),
       soc_percent: (soc[t] / cap) * 100,
       g2ev:          round(g2ev[t]),

--- a/lib/plan-summary.ts
+++ b/lib/plan-summary.ts
@@ -28,6 +28,9 @@ export function buildPlanSummary(
       gridToBattery_kWh: 0,
       batteryToGrid_kWh: 0,
       importEnergy_kWh: 0,
+      importCost_cents: 0,
+      exportCost_cents: 0,
+      netGridCost_cents: 0,
       avgImportPrice_cents_per_kWh: null,
       gridBatteryTippingPoint_cents_per_kWh:
         dessDiagnostics.gridBatteryTippingPoint_cents_per_kWh ?? null,
@@ -59,6 +62,8 @@ export function buildPlanSummary(
   let batteryToGrid = 0;
   let importEnergy = 0;
   let priceTimesEnergy = 0;
+  let importCost = 0;
+  let exportCost = 0;
   let evFromGrid = 0;
   let evFromPv   = 0;
   let evFromBat  = 0;
@@ -72,6 +77,7 @@ export function buildPlanSummary(
     const g2bK = W2kWh(row.g2b);
     const b2gK = W2kWh(row.b2g);
     const impK = W2kWh(row.imp);
+    const expK = W2kWh(row.exp);
 
     loadTotal += loadK;
     pvTotal += pvK;
@@ -85,6 +91,8 @@ export function buildPlanSummary(
     if (impK > 0) {
       priceTimesEnergy += row.ic * impK;
     }
+    importCost += finiteOr(row.importCost_cents, impK * row.ic);
+    exportCost += finiteOr(row.exportCost_cents, expK * row.ec);
     evFromGrid += W2kWh(row.g2ev ?? 0);
     evFromPv   += W2kWh(row.pv2ev ?? 0);
     evFromBat  += W2kWh(row.b2ev ?? 0);
@@ -102,6 +110,9 @@ export function buildPlanSummary(
     gridToBattery_kWh: gridToBattery,
     batteryToGrid_kWh: batteryToGrid,
     importEnergy_kWh: importEnergy,
+    importCost_cents: importCost,
+    exportCost_cents: exportCost,
+    netGridCost_cents: importCost - exportCost,
     avgImportPrice_cents_per_kWh: avgImportPrice,
     gridBatteryTippingPoint_cents_per_kWh:
       Number.isFinite(dessDiagnostics.gridBatteryTippingPoint_cents_per_kWh)
@@ -125,4 +136,9 @@ export function buildPlanSummary(
     evChargeFromPv_kWh:      evFromPv,
     evChargeFromBattery_kWh: evFromBat,
   };
+}
+
+function finiteOr(value: unknown, fallback: number): number {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -98,6 +98,8 @@ export interface PlanRow {
   b2g: number;   // battery → grid W
   imp: number;   // total import W (g2l + g2b)
   exp: number;   // total export W (pv2g + b2g)
+  importCost_cents: number;  // import energy cost for this slot, in c€
+  exportCost_cents: number;  // export energy value for this slot, in c€
   soc: number;   // battery SoC Wh
   soc_percent: number;  // battery SoC %
   g2ev: number;         // grid → EV W
@@ -151,6 +153,9 @@ export interface PlanSummary {
   gridToBattery_kWh: number;
   batteryToGrid_kWh: number;
   importEnergy_kWh: number;
+  importCost_cents: number;
+  exportCost_cents: number;
+  netGridCost_cents: number;
   avgImportPrice_cents_per_kWh: number | null;
   gridBatteryTippingPoint_cents_per_kWh: number | null;
   gridChargeTippingPoint_cents_per_kWh: number | null;

--- a/tests/app/state.test.js
+++ b/tests/app/state.test.js
@@ -1,6 +1,11 @@
 // @vitest-environment jsdom
-import { describe, expect, it } from 'vitest';
-import { hydrateUI, snapshotUI } from '../../app/src/state.js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { hydrateUI, snapshotUI, updateSummaryUI } from '../../app/src/state.js';
+
+afterEach(() => {
+  vi.useRealTimers();
+  document.body.innerHTML = '';
+});
 
 describe('settings state', () => {
   it('round-trips optimizer quick settings through hydrate and snapshot', () => {
@@ -23,5 +28,68 @@ describe('settings state', () => {
 
     expect(optimizerQuickSettingsSelection.value).toBe('["minSoc_percent","blockFeedInOnNegativePrices"]');
     expect(snapshotUI(els).optimizerQuickSettings).toEqual(['minSoc_percent', 'blockFeedInOnNegativePrices']);
+  });
+
+  it('keeps the DESS table toggle out of persisted settings', () => {
+    const tableDess = document.createElement('input');
+    tableDess.type = 'checkbox';
+    tableDess.checked = true;
+
+    expect(snapshotUI({ tableDess })).not.toHaveProperty('tableShowDess');
+
+    tableDess.checked = false;
+    hydrateUI({ tableDess }, { tableShowDess: true });
+
+    expect(tableDess.checked).toBe(false);
+  });
+
+  it('renders and clears net grid cost in the summary panel', () => {
+    vi.useFakeTimers();
+    document.body.innerHTML = '<div id="load-split-bar"></div><div id="flow-split-bar"></div>';
+
+    const els = {
+      sumLoad: document.createElement('div'),
+      sumPv: document.createElement('div'),
+      sumLoadGrid: document.createElement('div'),
+      sumLoadBatt: document.createElement('div'),
+      sumLoadPv: document.createElement('div'),
+      avgImport: document.createElement('div'),
+      netCost: document.createElement('div'),
+      gridBatteryTp: document.createElement('div'),
+      gridChargeTp: document.createElement('div'),
+      batteryExportTp: document.createElement('div'),
+    };
+    document.body.append(...Object.values(els));
+
+    updateSummaryUI(els, {
+      loadTotal_kWh: 1,
+      pvTotal_kWh: 2,
+      loadFromGrid_kWh: 0.5,
+      loadFromBattery_kWh: 0.25,
+      loadFromPv_kWh: 0.25,
+      gridToBattery_kWh: 0,
+      batteryToGrid_kWh: 0,
+      importEnergy_kWh: 0.5,
+      avgImportPrice_cents_per_kWh: 12.345,
+      netGridCost_cents: -4.2,
+      gridBatteryTippingPoint_cents_per_kWh: null,
+      gridChargeTippingPoint_cents_per_kWh: null,
+      batteryExportTippingPoint_cents_per_kWh: null,
+      pvExportTippingPoint_cents_per_kWh: null,
+      rebalanceStatus: 'disabled',
+      evChargeTotal_kWh: 0,
+      evChargeFromGrid_kWh: 0,
+      evChargeFromPv_kWh: 0,
+      evChargeFromBattery_kWh: 0,
+    });
+    vi.runAllTimers();
+
+    expect(els.avgImport.textContent).toBe('12.35 c€/kWh');
+    expect(els.netCost.textContent).toBe('-4.20 c€');
+
+    updateSummaryUI(els, null);
+    vi.runAllTimers();
+
+    expect(els.netCost.textContent).toBe('—');
   });
 });

--- a/tests/app/table.test.js
+++ b/tests/app/table.test.js
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { renderTable } from '../../app/src/table.js';
+
+function makeRow(overrides = {}) {
+  return {
+    tIdx: 0,
+    timestampMs: 1700000000000,
+    load: 0,
+    pv: 0,
+    ic: 0,
+    ec: 0,
+    importCost_cents: 0,
+    exportCost_cents: 0,
+    g2l: 0,
+    g2b: 0,
+    pv2l: 0,
+    pv2b: 0,
+    pv2g: 0,
+    b2l: 0,
+    b2g: 0,
+    imp: 0,
+    exp: 0,
+    soc: 0,
+    soc_percent: 0,
+    g2ev: 0,
+    pv2ev: 0,
+    b2ev: 0,
+    ev_charge: 0,
+    ev_charge_A: 0,
+    ev_charge_mode: 'off',
+    ev_soc_percent: 0,
+    ...overrides,
+  };
+}
+
+describe('renderTable', () => {
+  it('shows price columns, cost columns, and summed cost totals', () => {
+    const table = document.createElement('table');
+    const rows = [
+      makeRow({ ic: 20, ec: 8, importCost_cents: 20, exportCost_cents: 5 }),
+      makeRow({ ic: 10, ec: -2, importCost_cents: 10, exportCost_cents: -2 }),
+    ];
+
+    renderTable({
+      rows,
+      cfg: { stepSize_m: 60 },
+      targets: { table },
+      showKwh: false,
+    });
+
+    expect(table.innerHTML).toContain('Import<br>price');
+    expect(table.innerHTML).toContain('Export<br>price');
+    expect(table.innerHTML).toContain('Import<br>cost');
+    expect(table.innerHTML).toContain('Export<br>cost');
+
+    const firstBodyCells = table.querySelector('tbody tr').children;
+    expect(firstBodyCells[14].textContent).toBe('20.00 c€');
+    expect(firstBodyCells[15].textContent).toBe('5.00 c€');
+
+    const totalCells = table.querySelectorAll('thead tr')[1].children;
+    expect(totalCells[14].textContent).toBe('30.00 c€');
+    expect(totalCells[15].textContent).toBe('3.00 c€');
+  });
+
+  it('hides DESS detail columns by default', () => {
+    const table = document.createElement('table');
+
+    renderTable({
+      rows: [makeRow({ dess: { strategy: 1, restrictions: 2, feedin: 1, socTarget_percent: 50 } })],
+      cfg: { stepSize_m: 60 },
+      targets: { table },
+      showKwh: false,
+    });
+
+    expect(table.innerHTML).not.toContain('DESS<br>strategy');
+    expect(table.innerHTML).not.toContain('Restr.');
+    expect(table.innerHTML).not.toContain('Feed-in');
+    expect(table.innerHTML).toContain('Soc→');
+  });
+
+  it('shows DESS detail columns when enabled', () => {
+    const table = document.createElement('table');
+
+    renderTable({
+      rows: [makeRow({ dess: { strategy: 1, restrictions: 2, feedin: 1, socTarget_percent: 50 } })],
+      cfg: { stepSize_m: 60 },
+      targets: { table },
+      showKwh: false,
+      showDess: true,
+    });
+
+    expect(table.innerHTML).toContain('DESS<br>strategy');
+    expect(table.innerHTML).toContain('Restr.');
+    expect(table.innerHTML).toContain('Feed-in');
+  });
+});

--- a/tests/lib/parse-solution.test.js
+++ b/tests/lib/parse-solution.test.js
@@ -38,6 +38,28 @@ describe('parseSolution', () => {
     expect(rows[1].timestampMs).toBe(1700000000000 + 3600000);
   });
 
+  it('computes per-slot import and export costs', () => {
+    const result = {
+      Columns: {
+        'grid_to_load_0': { Primal: 1000 },
+        'pv_to_grid_0': { Primal: 500 },
+        'grid_to_battery_1': { Primal: 500 },
+        'battery_to_grid_1': { Primal: 1000 },
+      },
+    };
+    const cfgWithSignedExport = {
+      ...cfg,
+      exportPrice: [5, -2],
+    };
+
+    const rows = parseSolution(result, cfgWithSignedExport, opts);
+
+    expect(rows[0].importCost_cents).toBeCloseTo(10);
+    expect(rows[0].exportCost_cents).toBeCloseTo(2.5);
+    expect(rows[1].importCost_cents).toBeCloseTo(10);
+    expect(rows[1].exportCost_cents).toBeCloseTo(-2);
+  });
+
 });
 
 describe('parseSolution — ev_charge_mode derivation', () => {

--- a/tests/lib/plan-summary.test.js
+++ b/tests/lib/plan-summary.test.js
@@ -23,6 +23,9 @@ describe('buildPlanSummary — EV energy totals', () => {
     expect(s.evChargeFromGrid_kWh).toBe(0);
     expect(s.evChargeFromPv_kWh).toBe(0);
     expect(s.evChargeFromBattery_kWh).toBe(0);
+    expect(s.importCost_cents).toBe(0);
+    expect(s.exportCost_cents).toBe(0);
+    expect(s.netGridCost_cents).toBe(0);
   });
 
   it('returns zero EV totals when all EV fields are zero', () => {
@@ -71,5 +74,33 @@ describe('buildPlanSummary — EV energy totals', () => {
     delete row.b2ev;
     const s = buildPlanSummary([row], cfg);
     expect(s.evChargeTotal_kWh).toBe(0);
+  });
+});
+
+describe('buildPlanSummary — grid cost totals', () => {
+  it('totals import, export, and net grid costs from slot rates and energy', () => {
+    const rows = [
+      makeRow({ imp: 1000, exp: 500, ic: 20, ec: 8 }),
+      makeRow({ imp: 500, exp: 1000, ic: 10, ec: -2 }),
+    ];
+
+    const s = buildPlanSummary(rows, cfg);
+
+    expect(s.importCost_cents).toBeCloseTo(25);
+    expect(s.exportCost_cents).toBeCloseTo(2);
+    expect(s.netGridCost_cents).toBeCloseTo(23);
+  });
+
+  it('uses parsed row costs when present', () => {
+    const rows = [
+      makeRow({ imp: 1000, exp: 1000, ic: 99, ec: 99, importCost_cents: 3, exportCost_cents: 1 }),
+      makeRow({ imp: 1000, exp: 1000, ic: 99, ec: 99, importCost_cents: 4, exportCost_cents: -2 }),
+    ];
+
+    const s = buildPlanSummary(rows, cfg);
+
+    expect(s.importCost_cents).toBeCloseTo(7);
+    expect(s.exportCost_cents).toBeCloseTo(-1);
+    expect(s.netGridCost_cents).toBeCloseTo(8);
   });
 });


### PR DESCRIPTION
## Summary

- Adds `importCost_cents` / `exportCost_cents` per slot to `PlanRow` and `PlanSummary`, with a **Net cost** stat in the summary panel (total import cost minus export value)
- Renames table's "Import/Export cost" columns to "Import/Export **price**" (they show c€/kWh rates) and adds new "Import cost" / "Export cost" columns showing actual c€ spend per slot, with summed totals in the footer
- Adds a **"Show DESS details"** toggle that hides the strategy/restrictions/feed-in columns by default; toggling either display option re-renders the table without re-running the optimizer

## Test plan

- [ ] Run optimizer — summary panel shows Net cost with correct sign (negative = net export revenue)
- [ ] Table shows Import price / Export price (rates) and Import cost / Export cost (c€) columns with correct slot values and summed totals
- [ ] "Show DESS details" toggle reveals/hides DESS columns; "kWh" toggle switches units — neither triggers a re-solve
- [ ] `npm test` passes (333 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)