### PR TITLE
Add rebalance nudge: prompt users when battery hasn't reached 100% in 10+ days

### DIFF
--- a/api/defaults/default-data.json
+++ b/api/defaults/default-data.json
@@ -58,5 +58,6 @@
   "soc": {
     "timestamp": "2024-01-01T00:00:00.000Z",
     "value": 72
-  }
+  },
+  "lastFullSocAt": null
 }

--- a/api/routes/calculate.ts
+++ b/api/routes/calculate.ts
@@ -16,7 +16,7 @@ router.post('/', async (req: Request, res: Response, next: NextFunction) => {
       writeToVictron: shouldWriteToVictron,
     });
 
-    const { cfg, timing, result, rows, summary, rebalanceWindow } =
+    const { cfg, timing, result, rows, summary, rebalanceWindow, rebalanceNudge } =
       await planAndMaybeWrite({
         updateData: shouldUpdateData,
         writeToVictron: shouldWriteToVictron,
@@ -30,6 +30,7 @@ router.post('/', async (req: Request, res: Response, next: NextFunction) => {
       tsStart: new Date(timing.startMs).toISOString(),
       summary,
       rebalanceWindow,
+      rebalanceNudge,
     });
   } catch (error) {
     logCalculateError(error);

--- a/api/routes/data.ts
+++ b/api/routes/data.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import type { Request, Response, NextFunction } from 'express';
 import { loadData, saveData, validateData } from '../services/data-store.ts';
 import { loadSettings } from '../services/settings-store.ts';
+import { recordFullSocObservation } from '../services/rebalance-nudge.ts';
 import { assertCondition, toHttpError } from '../http-errors.ts';
 import type { TimeSeries, SocData, Data } from '../types.ts';
 
@@ -46,7 +47,7 @@ router.post('/', async (req: Request, res: Response, next: NextFunction) => {
       'No valid data keys provided or settings are not set to API',
     );
 
-    const nextData: Data = { ...currentData };
+    let nextData: Data = { ...currentData };
 
     for (const key of keysToUpdate) {
       const value = payload[key];
@@ -57,6 +58,7 @@ router.post('/', async (req: Request, res: Response, next: NextFunction) => {
       );
       if (key === 'soc') {
         nextData.soc = value as SocData;
+        nextData = recordFullSocObservation(nextData);
       } else if (key === 'load' || key === 'pv' || key === 'importPrice' || key === 'exportPrice') {
         nextData[key] = value as TimeSeries;
       }

--- a/api/services/config-builder.ts
+++ b/api/services/config-builder.ts
@@ -2,6 +2,7 @@ import { HttpError } from '../http-errors.ts';
 import { loadSettings } from './settings-store.ts';
 import { loadData, saveData } from './data-store.ts';
 import { applyPredictionAdjustmentsToData, pruneExpiredPredictionAdjustments } from './prediction-adjustments.ts';
+import { recordFullSocObservation } from './rebalance-nudge.ts';
 import { extractWindow, getQuarterStart } from '../../lib/time-series-utils.ts';
 import { fetchHaEntityState } from './ha-client.ts';
 import type { SolverConfig, TimeSeries, EvConfig } from '../../lib/types.ts';
@@ -135,8 +136,16 @@ export async function getSolverInputs(): Promise<{ cfg: SolverConfig; timing: { 
   const [settings, loadedData] = await Promise.all([loadSettings(), loadData()]);
   const startMs = getQuarterStart(new Date(), settings.stepSize_m);
   const pruned = pruneExpiredPredictionAdjustments(loadedData, startMs);
-  if (pruned.changed) await saveData(pruned.data);
-  const data = pruned.data;
+  let data = pruned.data;
+  let shouldSaveData = pruned.changed;
+
+  const observedData = recordFullSocObservation(data);
+  if (observedData !== data) {
+    data = observedData;
+    shouldSaveData = true;
+  }
+
+  if (shouldSaveData) await saveData(data);
 
   let evState: { pluggedIn: boolean; soc_percent: number } | undefined;
   if (settings.evEnabled && settings.evSocSensor && settings.evPlugSensor) {

--- a/api/services/data-store.ts
+++ b/api/services/data-store.ts
@@ -34,6 +34,11 @@ export function validateData(d: Data): Data {
   if (Number.isNaN(new Date(d.soc.timestamp).getTime())) {
     throw new Error(`Invalid soc: 'timestamp' is not a valid timestamp (${d.soc.timestamp})`);
   }
+  if (d.lastFullSocAt !== undefined && d.lastFullSocAt !== null) {
+    if (typeof d.lastFullSocAt !== 'string' || Number.isNaN(new Date(d.lastFullSocAt).getTime())) {
+      throw new Error(`Invalid lastFullSocAt: must be null or a valid timestamp (${d.lastFullSocAt})`);
+    }
+  }
   if (d.predictionAdjustments !== undefined) {
     if (!Array.isArray(d.predictionAdjustments)) {
       throw new Error("Invalid predictionAdjustments: must be an array");

--- a/api/services/planner-service.ts
+++ b/api/services/planner-service.ts
@@ -11,6 +11,7 @@ import { saveData } from './data-store.ts';
 import { applyPredictionAdjustmentsToData } from './prediction-adjustments.ts';
 import { refreshSeriesFromVrmAndPersist } from './vrm-refresh.ts';
 import { setDynamicEssSchedule } from './mqtt-service.ts';
+import { getRebalanceNudge, type RebalanceNudge } from './rebalance-nudge.ts';
 import type { PlanRowWithDess, Data } from '../types.ts';
 
 // How many slots we push into Dynamic ESS
@@ -43,6 +44,7 @@ export interface ComputePlanResult {
   rows: PlanRowWithDess[];
   summary: PlanSummary;
   rebalanceWindow?: RebalanceWindow;
+  rebalanceNudge: RebalanceNudge;
 }
 
 /**
@@ -183,7 +185,9 @@ export async function computePlan({ updateData = false } = {}): Promise<ComputeP
     cfg.rebalanceRemainingSlots ?? 0,
   );
 
-  lastPlan = { cfg, data, timing, result, rows: rowsWithDess, summary, rebalanceWindow };
+  const rebalanceNudge = getRebalanceNudge(data);
+
+  lastPlan = { cfg, data, timing, result, rows: rowsWithDess, summary, rebalanceWindow, rebalanceNudge };
   return lastPlan;
 }
 

--- a/api/services/rebalance-nudge.ts
+++ b/api/services/rebalance-nudge.ts
@@ -1,0 +1,54 @@
+import type { Data, SocData } from '../types.ts';
+
+export const FULL_SOC_PERCENT = 100;
+export const REBALANCE_NUDGE_AFTER_DAYS = 10;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export interface RebalanceNudge {
+  lastFullSocAt: string | null;
+  daysSinceLastFullSoc: number | null;
+  rebalanceRecommended: boolean;
+  thresholdDays: number;
+}
+
+function parseTimestampMs(value: unknown): number | null {
+  if (typeof value !== 'string' || value.trim() === '') return null;
+  const ms = new Date(value).getTime();
+  return Number.isFinite(ms) ? ms : null;
+}
+
+export function recordFullSocObservation(data: Data, soc: SocData = data.soc): Data {
+  if (!Number.isFinite(soc.value) || soc.value < FULL_SOC_PERCENT) return data;
+
+  const observedMs = parseTimestampMs(soc.timestamp);
+  if (observedMs == null) return data;
+
+  const existingMs = parseTimestampMs(data.lastFullSocAt);
+  if (existingMs != null && existingMs >= observedMs) return data;
+
+  return {
+    ...data,
+    lastFullSocAt: new Date(observedMs).toISOString(),
+  };
+}
+
+export function getRebalanceNudge(data: Data, nowMs = Date.now()): RebalanceNudge {
+  const lastFullMs = parseTimestampMs(data.lastFullSocAt);
+  if (lastFullMs == null) {
+    return {
+      lastFullSocAt: null,
+      daysSinceLastFullSoc: null,
+      rebalanceRecommended: false,
+      thresholdDays: REBALANCE_NUDGE_AFTER_DAYS,
+    };
+  }
+
+  const elapsedMs = Math.max(0, nowMs - lastFullMs);
+  return {
+    lastFullSocAt: new Date(lastFullMs).toISOString(),
+    daysSinceLastFullSoc: Math.floor(elapsedMs / DAY_MS),
+    rebalanceRecommended: elapsedMs > REBALANCE_NUDGE_AFTER_DAYS * DAY_MS,
+    thresholdDays: REBALANCE_NUDGE_AFTER_DAYS,
+  };
+}

--- a/api/services/vrm-refresh.ts
+++ b/api/services/vrm-refresh.ts
@@ -3,6 +3,7 @@ import type { VRMForecasts, VRMPrices } from '../../lib/vrm-api.ts';
 import { loadSettings, saveSettings } from './settings-store.ts';
 import { loadData, saveData } from './data-store.ts';
 import { readVictronSocPercent, readVictronSocLimits } from './mqtt-service.ts';
+import { recordFullSocObservation } from './rebalance-nudge.ts';
 import type { Data } from '../types.ts';
 
 function createClientFromEnv(): VRMClient {
@@ -136,15 +137,21 @@ export async function refreshSeriesFromVrmAndPersist(): Promise<void> {
     ? { timestamp: new Date().toISOString(), value: socPercent }
     : baseData.soc;
 
-  const nextData: Data = {
+  let nextData: Data = {
     load,
     pv,
     importPrice,
     exportPrice,
     soc,
+    lastFullSocAt: baseData.lastFullSocAt,
     rebalanceState: baseData.rebalanceState,
     predictionAdjustments: baseData.predictionAdjustments,
   };
+
+  if (shouldFetchSoc && socPercent !== null) {
+    nextData = recordFullSocObservation(nextData);
+  }
+
   await saveData(nextData);
 
   // Optionally keep stepSize_m in settings in sync

--- a/api/types.ts
+++ b/api/types.ts
@@ -86,6 +86,7 @@ export interface Data {
   importPrice: TimeSeries;
   exportPrice: TimeSeries;
   soc: SocData;
+  lastFullSocAt?: string | null;
   rebalanceState?: RebalanceState;
   predictionAdjustments?: PredictionAdjustment[];
 }

--- a/app/index.html
+++ b/app/index.html
@@ -632,11 +632,15 @@
 
           <!-- Rebalancing toggle -->
           <div class="mt-4">
-            <label class="toggle">
+            <label id="rebalance-toggle-label" class="toggle">
               <input id="rebalance-enabled" type="checkbox" data-settings-input>
               <span class="toggle-knob"></span>
               <span class="text-sm text-slate-600 dark:text-slate-400">Schedule battery rebalancing</span>
             </label>
+            <p id="rebalance-nudge"
+              class="hidden mt-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs font-medium text-amber-700 dark:border-amber-400/20 dark:bg-amber-400/10 dark:text-amber-200">
+              Battery has not reached 100% recently. Consider scheduling battery rebalancing.
+            </p>
           </div>
 
           <div id="optimizer-quick-settings" class="hidden mt-4 pt-4 border-t border-slate-100 dark:border-white/5">

--- a/app/src/optimizer-controller.js
+++ b/app/src/optimizer-controller.js
@@ -13,6 +13,7 @@ import { updateEvDepartureQuickSet } from "./ev-settings.js";
 import {
   snapshotUI,
   updatePlanMeta,
+  updateRebalanceNudgeUI,
   updateSummaryUI,
 } from "./state.js";
 
@@ -30,6 +31,7 @@ export function createOptimizerController({ els, services = {} }) {
     updateEvDepartureQuickSet,
     updateEvPanel,
     updatePlanMeta,
+    updateRebalanceNudgeUI,
     updateSummaryUI,
     ...services,
   };
@@ -71,6 +73,7 @@ export function createOptimizerController({ els, services = {} }) {
 
       deps.updatePlanMeta(els, result.initialSoc_percent, result.tsStart);
       deps.updateSummaryUI(els, result.summary);
+      deps.updateRebalanceNudgeUI(els, result.rebalanceNudge);
       updateRunStatus(solverStatus, writeToVictron);
 
       const cfgForViz = getVizConfig();

--- a/app/src/state.js
+++ b/app/src/state.js
@@ -125,6 +125,7 @@ export function hydrateUI(els, obj = {}) {
   }
 
   updateTerminalCustomUI(els);
+  updateRebalanceNudgeUI(els, obj.rebalanceNudge);
 }
 
 // Plan metadata helper
@@ -296,6 +297,27 @@ function updateRebalanceStatus(els, status) {
   }
 }
 
+export function updateRebalanceNudgeUI(els, nudge) {
+  const lastFullText = formatLastFullSoc(nudge?.lastFullSocAt);
+  const title = `Schedule battery rebalancing. Last 100% SoC: ${lastFullText}.`;
+  if (els.rebalanceToggleLabel) els.rebalanceToggleLabel.title = title;
+
+  if (!els.rebalanceNudge) return;
+
+  const recommended = !!nudge?.rebalanceRecommended;
+  const alreadyEnabled = !!els.rebalanceEnabled?.checked;
+  const shouldShow = recommended && !alreadyEnabled;
+  els.rebalanceNudge.classList.toggle("hidden", !shouldShow);
+
+  if (shouldShow) {
+    const days = nudge.daysSinceLastFullSoc;
+    const threshold = nudge.thresholdDays;
+    els.rebalanceNudge.textContent = days == null
+      ? `Battery has not reached 100% in over ${threshold} days. Consider scheduling battery rebalancing.`
+      : `Battery last reached 100% ${days} days ago. Consider scheduling battery rebalancing.`;
+  }
+}
+
 export function updateTerminalCustomUI(els) {
   const isCustom = els.terminal?.value === "custom";
   if (els.terminalCustom) els.terminalCustom.disabled = !isCustom;
@@ -360,6 +382,19 @@ function setText(el, txt) {
     }
     el._fadeTimer = null;
   }, 150);
+}
+
+function formatLastFullSoc(value) {
+  if (!value) return "not recorded yet";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "not recorded yet";
+  return date.toLocaleString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
 }
 
 export function formatKWh(v) {

--- a/app/src/ui-binding.js
+++ b/app/src/ui-binding.js
@@ -13,7 +13,9 @@ export function getElements() {
     sourceLoad: $("#source-load"),
     sourcePv: $("#source-pv"),
     sourceSoc: $("#source-soc"),
+    rebalanceToggleLabel: $("#rebalance-toggle-label"),
     rebalanceEnabled: $("#rebalance-enabled"),
+    rebalanceNudge: $("#rebalance-nudge"),
     rebalanceHoldHours: $("#rebalance-hold-hours"),
     blockFeedInOnNegativePrices: $("#block-feedin-negative-prices"),
 

--- a/tests/api/api.test.js
+++ b/tests/api/api.test.js
@@ -98,6 +98,12 @@ describe('Integration: API', () => {
     expect(res.status).toBe(200);
     expect(res.body.solverStatus).toBe('Optimal');
     expect(res.body.rows).toHaveLength(5);
+    expect(res.body.rebalanceNudge).toEqual({
+      lastFullSocAt: null,
+      daysSinceLastFullSoc: null,
+      rebalanceRecommended: false,
+      thresholdDays: 10,
+    });
     expect(loadSettings).toHaveBeenCalled();
     expect(loadData).toHaveBeenCalled();
   });

--- a/tests/api/custom-data.test.js
+++ b/tests/api/custom-data.test.js
@@ -85,6 +85,18 @@ describe('Custom Data Injection', () => {
     }));
   });
 
+  it('POST /data records lastFullSocAt when API SoC reaches 100%', async () => {
+    const res = await request(app)
+      .post('/data')
+      .send({ soc: { value: 100, timestamp: '2024-02-01T12:00:00.000Z' } });
+
+    expect(res.status).toBe(200);
+    expect(saveData).toHaveBeenCalledWith(expect.objectContaining({
+      soc: { value: 100, timestamp: '2024-02-01T12:00:00.000Z' },
+      lastFullSocAt: '2024-02-01T12:00:00.000Z',
+    }));
+  });
+
   it('POST /data should reject invalid keys', async () => {
     const res = await request(app)
       .post('/data')

--- a/tests/api/services/planner-service.test.js
+++ b/tests/api/services/planner-service.test.js
@@ -86,6 +86,23 @@ describe('computePlan — rebalance bookkeeping', () => {
     );
   });
 
+  it('returns a rebalance nudge in the computed plan', async () => {
+    loadSettings.mockResolvedValue(baseSettings);
+    loadData.mockResolvedValue({
+      ...baseData,
+      lastFullSocAt: '2023-12-20T00:00:00.000Z',
+    });
+
+    const result = await computePlan();
+
+    expect(result.rebalanceNudge).toMatchObject({
+      lastFullSocAt: '2023-12-20T00:00:00.000Z',
+      daysSinceLastFullSoc: 12,
+      rebalanceRecommended: true,
+      thresholdDays: 10,
+    });
+  });
+
   it('clears startMs and disables rebalancing when cycle is complete (remainingSlots = 0)', async () => {
     // holdHours=2, stepSize=60min → holdSlots=2; started 2h ago → remainingSlots=0
     const startMs = NOW_MS - 2 * 60 * 60_000;

--- a/tests/api/services/rebalance-nudge.test.js
+++ b/tests/api/services/rebalance-nudge.test.js
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getRebalanceNudge,
+  recordFullSocObservation,
+} from '../../../api/services/rebalance-nudge.ts';
+import { validateData } from '../../../api/services/data-store.ts';
+
+const baseData = {
+  load: { start: '2024-01-01T00:00:00.000Z', values: [] },
+  pv: { start: '2024-01-01T00:00:00.000Z', values: [] },
+  importPrice: { start: '2024-01-01T00:00:00.000Z', values: [] },
+  exportPrice: { start: '2024-01-01T00:00:00.000Z', values: [] },
+  soc: { timestamp: '2024-01-01T00:00:00.000Z', value: 50 },
+};
+
+describe('rebalance nudge helpers', () => {
+  it('records the SoC timestamp when the battery reaches 100%', () => {
+    const data = {
+      ...baseData,
+      soc: { timestamp: '2024-01-02T03:04:05Z', value: 100 },
+    };
+
+    expect(recordFullSocObservation(data)).toEqual({
+      ...data,
+      lastFullSocAt: '2024-01-02T03:04:05.000Z',
+    });
+  });
+
+  it('does not record when the observed SoC is below 100%', () => {
+    const data = {
+      ...baseData,
+      soc: { timestamp: '2024-01-02T03:04:05Z', value: 99.9 },
+    };
+
+    expect(recordFullSocObservation(data)).toBe(data);
+  });
+
+  it('does not move the last full timestamp backwards', () => {
+    const data = {
+      ...baseData,
+      lastFullSocAt: '2024-01-05T00:00:00.000Z',
+      soc: { timestamp: '2024-01-02T00:00:00.000Z', value: 100 },
+    };
+
+    expect(recordFullSocObservation(data)).toBe(data);
+  });
+
+  it('recommends rebalancing after more than 10 days without a full charge', () => {
+    const nudge = getRebalanceNudge(
+      { ...baseData, lastFullSocAt: '2024-01-01T00:00:00.000Z' },
+      new Date('2024-01-12T00:00:01.000Z').getTime(),
+    );
+
+    expect(nudge).toMatchObject({
+      daysSinceLastFullSoc: 11,
+      rebalanceRecommended: true,
+      thresholdDays: 10,
+    });
+  });
+
+  it('does not recommend rebalancing when full-charge history is unknown', () => {
+    expect(getRebalanceNudge(baseData)).toEqual({
+      lastFullSocAt: null,
+      daysSinceLastFullSoc: null,
+      rebalanceRecommended: false,
+      thresholdDays: 10,
+    });
+  });
+
+  it('accepts missing and null lastFullSocAt in persisted data', () => {
+    expect(validateData(baseData)).toBe(baseData);
+    expect(validateData({ ...baseData, lastFullSocAt: null })).toMatchObject({
+      lastFullSocAt: null,
+    });
+  });
+});

--- a/tests/api/services/vrm-refresh.custom-data.test.js
+++ b/tests/api/services/vrm-refresh.custom-data.test.js
@@ -57,6 +57,7 @@ describe('vrm-refresh logic with custom data', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     delete process.env.VRM_INSTALLATION_ID;
     delete process.env.VRM_TOKEN;
   });
@@ -121,6 +122,29 @@ describe('vrm-refresh logic with custom data', () => {
     expect(mqttService.readVictronSocPercent).not.toHaveBeenCalled();
     expect(saveData).toHaveBeenCalledWith(expect.objectContaining({
       soc: expect.objectContaining({ value: 50, timestamp: '2024-01-01T00:00:00.000Z' }) // Strictly Preserved
+    }));
+  });
+
+  it('records the last full SoC timestamp when MQTT reports 100%', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-01-13T12:34:56.000Z'));
+    mqttService.readVictronSocPercent.mockResolvedValue(100);
+    mockFetchForecasts.mockResolvedValue({ timestamps: ['2024-01-13T10:00:00.000Z'], load_W: [1], pv_W: [2] });
+    mockFetchPrices.mockResolvedValue({ timestamps: ['2024-01-13T10:00:00.000Z'], importPrice_cents_per_kwh: [3], exportPrice_cents_per_kwh: [4] });
+    loadData.mockResolvedValue({
+      load: { start: '2024-01-01T00:00:00.000Z', values: [] },
+      pv: { start: '2024-01-01T00:00:00.000Z', values: [] },
+      importPrice: { start: '2024-01-01T00:00:00.000Z', values: [] },
+      exportPrice: { start: '2024-01-01T00:00:00.000Z', values: [] },
+      soc: { value: 50, timestamp: '2024-01-01T00:00:00.000Z' },
+      lastFullSocAt: '2024-01-01T00:00:00.000Z',
+    });
+
+    await refreshSeriesFromVrmAndPersist();
+
+    expect(saveData).toHaveBeenCalledWith(expect.objectContaining({
+      soc: { timestamp: '2024-01-13T12:34:56.000Z', value: 100 },
+      lastFullSocAt: '2024-01-13T12:34:56.000Z',
     }));
   });
 });

--- a/tests/app/optimizer-controller.test.js
+++ b/tests/app/optimizer-controller.test.js
@@ -64,6 +64,7 @@ function setupController() {
     updateEvDepartureQuickSet: vi.fn(),
     updateEvPanel: vi.fn(),
     updatePlanMeta: vi.fn(),
+    updateRebalanceNudgeUI: vi.fn(),
     updateSummaryUI: vi.fn(),
   };
 
@@ -99,6 +100,7 @@ describe('optimizer controller', () => {
       '2026-05-01T12:00:00.000Z',
     );
     expect(services.updateSummaryUI).toHaveBeenCalledWith(els, summary);
+    expect(services.updateRebalanceNudgeUI).toHaveBeenCalledWith(els, undefined);
 
     const tableArgs = services.renderTable.mock.calls[0][0];
     expect(tableArgs.rows).toBe(rows);

--- a/tests/app/state.test.js
+++ b/tests/app/state.test.js
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { hydrateUI, snapshotUI, updateSummaryUI } from '../../app/src/state.js';
+import { hydrateUI, snapshotUI, updateRebalanceNudgeUI, updateSummaryUI } from '../../app/src/state.js';
 
 afterEach(() => {
   vi.useRealTimers();
@@ -91,5 +91,51 @@ describe('settings state', () => {
     vi.runAllTimers();
 
     expect(els.netCost.textContent).toBe('—');
+  });
+
+  it('shows tooltip text when the last full SoC timestamp is unknown', () => {
+    const els = {
+      rebalanceToggleLabel: document.createElement('label'),
+      rebalanceEnabled: document.createElement('input'),
+      rebalanceNudge: document.createElement('p'),
+    };
+    els.rebalanceEnabled.type = 'checkbox';
+
+    updateRebalanceNudgeUI(els, null);
+
+    expect(els.rebalanceToggleLabel.title).toContain('Last 100% SoC: not recorded yet');
+    expect(els.rebalanceNudge.classList.contains('hidden')).toBe(true);
+  });
+
+  it('shows the inline rebalance nudge only when recommended and not already enabled', () => {
+    const els = {
+      rebalanceToggleLabel: document.createElement('label'),
+      rebalanceEnabled: document.createElement('input'),
+      rebalanceNudge: document.createElement('p'),
+    };
+    els.rebalanceEnabled.type = 'checkbox';
+    els.rebalanceNudge.className = 'hidden';
+
+    updateRebalanceNudgeUI(els, {
+      lastFullSocAt: '2024-01-01T00:00:00.000Z',
+      daysSinceLastFullSoc: 12,
+      rebalanceRecommended: true,
+      thresholdDays: 10,
+    });
+
+    expect(els.rebalanceToggleLabel.title).toContain('Last 100% SoC:');
+    expect(els.rebalanceToggleLabel.title).not.toContain('not recorded yet');
+    expect(els.rebalanceNudge.classList.contains('hidden')).toBe(false);
+    expect(els.rebalanceNudge.textContent).toContain('12 days ago');
+
+    els.rebalanceEnabled.checked = true;
+    updateRebalanceNudgeUI(els, {
+      lastFullSocAt: '2024-01-01T00:00:00.000Z',
+      daysSinceLastFullSoc: 12,
+      rebalanceRecommended: true,
+      thresholdDays: 10,
+    });
+
+    expect(els.rebalanceNudge.classList.contains('hidden')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- Tracks `lastFullSocAt` in `data.json`, updated whenever SoC hits 100% via VRM/MQTT refresh, API data push, or config-builder on each plan cycle
- New `rebalance-nudge.ts` service: `recordFullSocObservation` (idempotent, never moves timestamp backwards) and `getRebalanceNudge` (computes days since last full charge, recommends rebalancing after 10 days)
- `/calculate` response includes `rebalanceNudge` with `lastFullSocAt`, `daysSinceLastFullSoc`, `rebalanceRecommended`, and `thresholdDays`
- UI shows an amber inline hint below the rebalancing toggle and a tooltip on hover when `rebalanceRecommended` is true and rebalancing is not already enabled

## Test plan

- [ ] Run `npm run test:run` — all 358 tests pass
- [ ] Trigger a VRM refresh with SoC at 100% and confirm `lastFullSocAt` is written to `data.json`
- [ ] Let more than 10 days pass (or set `lastFullSocAt` to an old date manually) and confirm the amber nudge appears in the UI when rebalancing is off
- [ ] Enable rebalancing and confirm the nudge disappears
- [ ] Confirm tooltip on the rebalancing toggle shows the last full-SoC date in all cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)