### PR TITLE
Add robust linear PV forecast model (direct + diffuse radiation)

### DIFF
--- a/api/defaults/default-prediction-config.json
+++ b/api/defaults/default-prediction-config.json
@@ -39,6 +39,7 @@
     "latitude": 51.05,
     "longitude": 3.71,
     "historyDays": 14,
-    "pvSensor": "Solar Generation"
+    "pvSensor": "Solar Generation",
+    "pvModel": "clearSkyRatio"
   }
 }

--- a/api/services/prediction-config-store.ts
+++ b/api/services/prediction-config-store.ts
@@ -40,7 +40,15 @@ export async function loadPredictionConfig(): Promise<PredictionConfig> {
 
   // Strip activeConfig from userConfig (guard for stored configs that have both activeConfig and historicalPredictor)
   const { activeConfig: _ac, ...cleanUserConfig } = userConfig;
-  const merged = { ...defaults, ...(cleanUserConfig as Partial<PredictionConfig>) };
+  const cleanConfig = cleanUserConfig as Partial<PredictionConfig>;
+  const pvConfig: PredictionConfig['pvConfig'] = defaults.pvConfig || cleanConfig.pvConfig
+    ? { ...defaults.pvConfig, ...cleanConfig.pvConfig }
+    : undefined;
+  const merged = {
+    ...defaults,
+    ...cleanConfig,
+    ...(pvConfig ? { pvConfig } : {}),
+  };
   const { validationWindow: _vw, ...rest } = merged;
 
   // Always recompute validationWindow — never trust a persisted value

--- a/api/services/prediction-config-store.ts
+++ b/api/services/prediction-config-store.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { resolveDataDir, readJson, writeJson } from './json-store.ts';
-import type { PredictionConfig } from '../types.ts';
+import type { PredictionConfig, PvPredictionConfig } from '../types.ts';
 
 const DATA_DIR = resolveDataDir();
 const PREDICTION_CONFIG_PATH = path.join(DATA_DIR, 'prediction-config.json');
@@ -42,7 +42,7 @@ export async function loadPredictionConfig(): Promise<PredictionConfig> {
   const { activeConfig: _ac, ...cleanUserConfig } = userConfig;
   const cleanConfig = cleanUserConfig as Partial<PredictionConfig>;
   const pvConfig: PredictionConfig['pvConfig'] = (defaults.pvConfig || cleanConfig.pvConfig)
-    ? { ...defaults.pvConfig, ...cleanConfig.pvConfig }
+    ? { ...defaults.pvConfig, ...cleanConfig.pvConfig } as PvPredictionConfig
     : undefined;
   const merged = {
     ...defaults,

--- a/api/services/prediction-config-store.ts
+++ b/api/services/prediction-config-store.ts
@@ -41,7 +41,7 @@ export async function loadPredictionConfig(): Promise<PredictionConfig> {
   // Strip activeConfig from userConfig (guard for stored configs that have both activeConfig and historicalPredictor)
   const { activeConfig: _ac, ...cleanUserConfig } = userConfig;
   const cleanConfig = cleanUserConfig as Partial<PredictionConfig>;
-  const pvConfig: PredictionConfig['pvConfig'] = defaults.pvConfig || cleanConfig.pvConfig
+  const pvConfig: PredictionConfig['pvConfig'] = (defaults.pvConfig || cleanConfig.pvConfig)
     ? { ...defaults.pvConfig, ...cleanConfig.pvConfig }
     : undefined;
   const merged = {

--- a/api/services/pv-prediction-service.ts
+++ b/api/services/pv-prediction-service.ts
@@ -15,13 +15,15 @@ import {
   calculateMaxRatioPerHour,
   estimateHourlyCapacity,
   estimateSlotCapacity,
+  estimateRobustLinearPvModels,
   forecastPv,
+  forecastPvLinear,
   forecastPvSlot,
   slotOfDay,
   validatePvForecast,
 } from '../../lib/predict-pv.ts';
 import type { PvProductionRecord, PvForecastPoint } from '../../lib/predict-pv.ts';
-import type { PredictionRunConfig, PvMode } from '../types.ts';
+import type { PredictionRunConfig, PvMode, PvModel } from '../types.ts';
 import { getForecastTimeRange, buildForecastSeries, type ForecastSeries } from '../../lib/time-series-utils.ts';
 
 export interface PvForecastRunResult {
@@ -29,6 +31,7 @@ export interface PvForecastRunResult {
   points: PvForecastPoint[];
   recent: PvForecastPoint[];
   metrics: { mae: number; rmse: number; n: number };
+  model: PvModel;
 }
 
 /**
@@ -47,6 +50,7 @@ export async function runPvForecast(config: PredictionRunConfig): Promise<PvFore
   // @deprecated fallback: forecastResolution === 15 → 'hybrid', else 'hourly'
   const pvMode: PvMode = pvConfig.pvMode
     ?? (pvConfig.forecastResolution === 15 ? 'hybrid' : 'hourly');
+  const pvModel: PvModel = pvConfig.pvModel ?? 'clearSkyRatio';
 
   const is15MinMode = pvMode === '15min';
   const forecastResolution = pvMode === 'hourly' ? 60 : 15;
@@ -87,15 +91,18 @@ export async function runPvForecast(config: PredictionRunConfig): Promise<PvFore
   // Wh/hour. 15-min HA data gives Wh/15min, so we scale ×4 to get Wh/hour = W.
   const productionScale = is15MinMode ? 4 : 1;
 
-  // Filter to the PV sensor and convert to PvProductionRecord[]
-  const pvRecords: PvProductionRecord[] = data
-    .filter(d => d.sensor === pvSensor && d.value > 0)
+  // Filter to the PV sensor and convert to PvProductionRecord[]. The robust
+  // model drops exact zero samples internally because daylight zeroes usually
+  // mean missing data, inverter-off, or curtailment rather than weather.
+  const pvTrainingRecords: PvProductionRecord[] = data
+    .filter(d => d.sensor === pvSensor && d.value >= 0)
     .map(d => ({
       time: d.time,
       hour: d.hour,
       ...(is15MinMode ? { slot: slotOfDay(d.time) } : {}),
       production_Wh: d.value * productionScale,
     }));
+  const pvRecords = pvTrainingRecords.filter(d => d.production_Wh > 0);
 
   // Build actual production map for validation (timestamp → scaled Wh)
   // Scale matches pvRecords so error metrics are in consistent units.
@@ -108,25 +115,41 @@ export async function runPvForecast(config: PredictionRunConfig): Promise<PvFore
 
   const maxRatio = calculateMaxRatioPerHour(archiveIrradiance, latitude, longitude);
 
-  // 4. Generate forecast and validation points, branching on mode
-  let futurePoints: PvForecastPoint[];
-  let archivePoints: PvForecastPoint[];
+  // 4. Generate the existing clear-sky ratio forecast first. The robust
+  // linear model uses it as a per-bucket fallback when data is sparse.
+  let clearSkyFuturePoints: PvForecastPoint[];
+  let clearSkyArchivePoints: PvForecastPoint[];
+  // In 15min mode this is expanded to 15-min resolution; otherwise it's the original hourly archive.
+  let trainingArchiveIrradiance = archiveIrradiance;
 
   if (is15MinMode) {
     const maxProd96 = calculateMaxProductionPerSlot(pvRecords);
     const slotCapacity = estimateSlotCapacity(maxProd96, maxRatio);
 
-    futurePoints = forecastPvSlot(slotCapacity, forecastIrradiance, latitude, longitude, actualsMap);
+    clearSkyFuturePoints = forecastPvSlot(slotCapacity, forecastIrradiance, latitude, longitude, actualsMap);
 
     // Expand hourly archive to 15-min for slot-level validation
-    const archiveIrradiance15 = expandHourlyTo15Min(archiveIrradiance);
-    archivePoints = forecastPvSlot(slotCapacity, archiveIrradiance15, latitude, longitude, actualsMap);
+    trainingArchiveIrradiance = expandHourlyTo15Min(archiveIrradiance);
+    clearSkyArchivePoints = forecastPvSlot(slotCapacity, trainingArchiveIrradiance, latitude, longitude, actualsMap);
   } else {
     const maxProd = calculateMaxProductionPerHour(pvRecords);
     const capacity = estimateHourlyCapacity(maxProd, maxRatio);
 
-    futurePoints = forecastPv(capacity, forecastIrradiance, latitude, longitude, actualsMap);
-    archivePoints = forecastPv(capacity, archiveIrradiance, latitude, longitude, actualsMap);
+    clearSkyFuturePoints = forecastPv(capacity, forecastIrradiance, latitude, longitude, actualsMap);
+    clearSkyArchivePoints = forecastPv(capacity, archiveIrradiance, latitude, longitude, actualsMap);
+  }
+
+  let futurePoints = clearSkyFuturePoints;
+  let archivePoints = clearSkyArchivePoints;
+
+  if (pvModel === 'robustLinear') {
+    const bucketCount = is15MinMode ? 96 : 24;
+    const futureFallback = new Map(clearSkyFuturePoints.map(point => [point.time, point]));
+    const archiveFallback = new Map(clearSkyArchivePoints.map(point => [point.time, point]));
+    const models = estimateRobustLinearPvModels(pvTrainingRecords, trainingArchiveIrradiance, bucketCount, archiveFallback);
+
+    futurePoints = forecastPvLinear(models, forecastIrradiance, latitude, longitude, actualsMap, futureFallback);
+    archivePoints = forecastPvLinear(models, trainingArchiveIrradiance, latitude, longitude, actualsMap, archiveFallback);
   }
 
   // 6. Build 15-min series for the solver (from future points only)
@@ -157,5 +180,5 @@ export async function runPvForecast(config: PredictionRunConfig): Promise<PvFore
   // 8. Validation metrics
   const metrics = validatePvForecast(recent);
 
-  return { forecast, points, recent, metrics };
+  return { forecast, points, recent, metrics, model: pvModel };
 }

--- a/api/types.ts
+++ b/api/types.ts
@@ -106,6 +106,7 @@ export interface PredictionValidationWindow {
 
 /** Prediction mode for PV forecasting. Replaces the deprecated forecastResolution field. */
 export type PvMode = 'hourly' | 'hybrid' | '15min';
+export type PvModel = 'clearSkyRatio' | 'robustLinear';
 
 export interface PvPredictionConfig {
   latitude: number;
@@ -113,6 +114,7 @@ export interface PvPredictionConfig {
   historyDays: number;
   pvSensor: string;
   pvMode?: PvMode;
+  pvModel?: PvModel;
   /** @deprecated Use pvMode instead. 60 → 'hourly', 15 → 'hybrid'. */
   forecastResolution?: 15 | 60;
 }

--- a/app/index.html
+++ b/app/index.html
@@ -999,6 +999,14 @@
                 <option value="15min">15-min</option>
               </select>
             </label>
+            <label class="block text-sm">
+              <span
+                class="block text-xs font-medium text-slate-400 dark:text-slate-500 mb-1 tracking-wide">Model</span>
+              <select id="pred-pv-model" class="form-select" data-predictions-only="true">
+                <option value="clearSkyRatio" selected>Clear-sky ratio</option>
+                <option value="robustLinear">Robust linear</option>
+              </select>
+            </label>
           </div>
 
           <div class="mt-4">

--- a/app/src/predictions/config-form.js
+++ b/app/src/predictions/config-form.js
@@ -110,6 +110,7 @@ export function readPredictionFormValues() {
     longitude: parseFloat(getVal('pred-pv-lon')) || 0,
     historyDays: parseInt(getVal('pred-pv-history'), 10) || 14,
     pvMode: getVal('pred-pv-mode') || 'hourly',
+    pvModel: getVal('pred-pv-model') || 'clearSkyRatio',
   };
 
   return {
@@ -145,6 +146,7 @@ function renderPvConfig(pvConfig) {
   setVal('pred-pv-history', pvConfig.historyDays ?? 14);
   const pvMode = pvConfig.pvMode ?? (pvConfig.forecastResolution === 15 ? 'hybrid' : 'hourly'); // fall back for legacy forecastResolution field
   setVal('pred-pv-mode', pvMode);
+  setVal('pred-pv-model', pvConfig.pvModel ?? 'clearSkyRatio');
 }
 
 function setComparisonStatus(msg, isError = false) {

--- a/lib/open-meteo.ts
+++ b/lib/open-meteo.ts
@@ -9,6 +9,8 @@ import type { IrradianceRecord } from './predict-pv.ts';
 
 // ----------------------------- URL Builders --------------------------------
 
+const RADIATION_VARIABLES = 'shortwave_radiation,direct_radiation,diffuse_radiation';
+
 interface ArchiveUrlParams {
   latitude: number;
   longitude: number;
@@ -18,14 +20,14 @@ interface ArchiveUrlParams {
 
 /**
  * Build URL for the Open-Meteo Archive API.
- * Requests hourly shortwave_radiation in UTC (timezone=GMT).
+ * Requests hourly radiation variables in UTC (timezone=GMT).
  */
 export function buildArchiveUrl({ latitude, longitude, startDate, endDate }: ArchiveUrlParams): string {
   return (
     `https://archive-api.open-meteo.com/v1/archive`
     + `?latitude=${latitude}&longitude=${longitude}`
     + `&start_date=${startDate}&end_date=${endDate}`
-    + `&hourly=shortwave_radiation&timezone=GMT`
+    + `&hourly=${RADIATION_VARIABLES}&timezone=GMT`
   );
 }
 
@@ -41,7 +43,7 @@ interface ForecastUrlParams {
 /**
  * Build URL for the Open-Meteo Forecast API.
  * Uses the ICON D2 model by default (good European coverage).
- * Requests shortwave_radiation in UTC (timezone=GMT).
+ * Requests radiation variables in UTC (timezone=GMT).
  * When resolution=15, uses minutely_15 data; otherwise uses hourly.
  */
 export function buildForecastUrl({
@@ -53,8 +55,8 @@ export function buildForecastUrl({
   resolution = 60,
 }: ForecastUrlParams): string {
   const radiationParam = resolution === 15
-    ? `&minutely_15=shortwave_radiation`
-    : `&hourly=shortwave_radiation`;
+    ? `&minutely_15=${RADIATION_VARIABLES}`
+    : `&hourly=${RADIATION_VARIABLES}`;
   return (
     `https://api.open-meteo.com/v1/forecast`
     + `?latitude=${latitude}&longitude=${longitude}`
@@ -72,7 +74,13 @@ interface OpenMeteoHourlyResponse {
   hourly: {
     time: string[];
     shortwave_radiation: (number | null)[];
+    direct_radiation?: (number | null)[];
+    diffuse_radiation?: (number | null)[];
   };
+}
+
+function radiationValue(values: (number | null)[] | undefined, index: number): number {
+  return Math.max(0, values?.[index] ?? 0);
 }
 
 /**
@@ -89,7 +97,7 @@ interface OpenMeteoHourlyResponse {
 export function parseIrradianceResponse(data: OpenMeteoHourlyResponse): IrradianceRecord[] {
   const records: IrradianceRecord[] = [];
 
-  const { time, shortwave_radiation } = data.hourly;
+  const { time, shortwave_radiation, direct_radiation, diffuse_radiation } = data.hourly;
 
   for (let i = 0; i < time.length; i++) {
     const omDate = new Date(time[i] + 'Z');  // Append Z since timezone=GMT
@@ -99,12 +107,12 @@ export function parseIrradianceResponse(data: OpenMeteoHourlyResponse): Irradian
     const intervalStartHour = (omHour + 23) % 24;
     const intervalStartTime = omDate.getTime() - 3600000; // shift back 1 hour
 
-    const ghi = shortwave_radiation[i] ?? 0;
-
     records.push({
       time: intervalStartTime,
       hour: intervalStartHour,
-      ghi_W_per_m2: Math.max(0, ghi),
+      ghi_W_per_m2: radiationValue(shortwave_radiation, i),
+      directRadiation_W_per_m2: radiationValue(direct_radiation, i),
+      diffuseRadiation_W_per_m2: radiationValue(diffuse_radiation, i),
       intervalMinutes: 60,
     });
   }
@@ -118,6 +126,8 @@ interface OpenMeteoMinutely15Response {
   minutely_15: {
     time: string[];
     shortwave_radiation: (number | null)[];
+    direct_radiation?: (number | null)[];
+    diffuse_radiation?: (number | null)[];
   };
 }
 
@@ -132,17 +142,17 @@ interface OpenMeteoMinutely15Response {
 export function parseMinutely15Response(data: OpenMeteoMinutely15Response): IrradianceRecord[] {
   const records: IrradianceRecord[] = [];
 
-  const { time, shortwave_radiation } = data.minutely_15;
+  const { time, shortwave_radiation, direct_radiation, diffuse_radiation } = data.minutely_15;
 
   for (let i = 0; i < time.length; i++) {
     const date = new Date(time[i] + 'Z');  // Append Z since timezone=GMT
     const hour = date.getUTCHours();
-    const ghi = shortwave_radiation[i] ?? 0;
-
     records.push({
       time: date.getTime(),
       hour,
-      ghi_W_per_m2: Math.max(0, ghi),
+      ghi_W_per_m2: radiationValue(shortwave_radiation, i),
+      directRadiation_W_per_m2: radiationValue(direct_radiation, i),
+      diffuseRadiation_W_per_m2: radiationValue(diffuse_radiation, i),
       intervalMinutes: 15,
     });
   }
@@ -167,6 +177,8 @@ export function expandHourlyTo15Min(records: IrradianceRecord[]): IrradianceReco
         time: slotMs,
         hour: new Date(slotMs).getUTCHours(),
         ghi_W_per_m2: rec.ghi_W_per_m2,
+        directRadiation_W_per_m2: rec.directRadiation_W_per_m2,
+        diffuseRadiation_W_per_m2: rec.diffuseRadiation_W_per_m2,
         intervalMinutes: 15,
       });
     }

--- a/lib/predict-pv.ts
+++ b/lib/predict-pv.ts
@@ -34,6 +34,8 @@ export interface IrradianceRecord {
   time: number;          // timestamp ms (start of UTC hour interval)
   hour: number;          // 0–23 UTC hour (start of interval)
   ghi_W_per_m2: number;  // shortwave radiation (W/m²)
+  directRadiation_W_per_m2?: number;   // direct horizontal radiation (W/m²)
+  diffuseRadiation_W_per_m2?: number;  // diffuse radiation (W/m²)
   intervalMinutes: number;  // 60 for hourly, 15 for minutely_15
 }
 
@@ -61,7 +63,35 @@ export interface SlotCapacity {
 export interface PvForecastPoint extends PredictionResult {
   ghiClear_W_per_m2: number;     // Bird model clear-sky baseline
   ghiForecast_W_per_m2: number;  // Open-Meteo forecast/archive value
+  directRadiation_W_per_m2?: number;
+  diffuseRadiation_W_per_m2?: number;
   forecastRatio: number;         // ghiForecast / ghiClear
+}
+
+export interface PvLinearModel {
+  index: number;             // hour (0-23) or slot (0-95)
+  directCoeff: number;       // W PV per W/m² direct radiation
+  diffuseCoeff: number;      // W PV per W/m² diffuse radiation
+  sampleCount: number;
+  excludedCount: number;
+  fallback: boolean;
+}
+
+interface PvLinearSample {
+  direct: number;
+  diffuse: number;
+  production_W: number;
+  fallback_W?: number;
+}
+
+interface PvLinearFitOptions {
+  minSamples: number;
+  minCrossValidationSamples: number;
+  minStrongRadiation_W_per_m2: number;
+  lowOutlierRatio: number;
+  minOutlierDelta_W: number;
+  minFallbackImprovementRatio: number;
+  ridgeLambda: number;
 }
 
 // ----------------------------- Bird Clear Sky Model -----------------------
@@ -346,6 +376,275 @@ export function estimateSlotCapacity(
   return capacity;
 }
 
+// ----------------------------- Robust Linear Capacity ---------------------
+
+const DEFAULT_LINEAR_FIT_OPTIONS: PvLinearFitOptions = {
+  minSamples: 3,
+  minCrossValidationSamples: 4,
+  minStrongRadiation_W_per_m2: 120,
+  lowOutlierRatio: 0.35,
+  minOutlierDelta_W: 300,
+  minFallbackImprovementRatio: 0.05,
+  ridgeLambda: 1,
+};
+
+function fallbackLinearModel(index: number): PvLinearModel {
+  return {
+    index,
+    directCoeff: 0,
+    diffuseCoeff: 0,
+    sampleCount: 0,
+    excludedCount: 0,
+    fallback: true,
+  };
+}
+
+function getRadiationFeatures(rec: IrradianceRecord): { direct: number; diffuse: number } | null {
+  const direct = rec.directRadiation_W_per_m2;
+  const diffuse = rec.diffuseRadiation_W_per_m2;
+  if (!Number.isFinite(direct) || !Number.isFinite(diffuse)) return null;
+  return {
+    direct: Math.max(0, direct ?? 0),
+    diffuse: Math.max(0, diffuse ?? 0),
+  };
+}
+
+function fitNonNegativeRidge(samples: PvLinearSample[], options: PvLinearFitOptions): { directCoeff: number; diffuseCoeff: number } | null {
+  let sDD = options.ridgeLambda;
+  let sFF = options.ridgeLambda;
+  let sDF = 0;
+  let tD = 0;
+  let tF = 0;
+
+  for (const sample of samples) {
+    const { direct, diffuse, production_W } = sample;
+    sDD += direct * direct;
+    sFF += diffuse * diffuse;
+    sDF += direct * diffuse;
+    tD += direct * production_W;
+    tF += diffuse * production_W;
+  }
+
+  const candidates: { directCoeff: number; diffuseCoeff: number }[] = [];
+  const det = sDD * sFF - sDF * sDF;
+
+  if (Math.abs(det) > 1e-9) {
+    candidates.push({
+      directCoeff: (tD * sFF - tF * sDF) / det,
+      diffuseCoeff: (sDD * tF - sDF * tD) / det,
+    });
+  }
+
+  candidates.push({ directCoeff: tD / sDD, diffuseCoeff: 0 });
+  candidates.push({ directCoeff: 0, diffuseCoeff: tF / sFF });
+  candidates.push({ directCoeff: 0, diffuseCoeff: 0 });
+
+  let best: { directCoeff: number; diffuseCoeff: number } | null = null;
+  let bestLoss = Infinity;
+
+  for (const candidate of candidates) {
+    const directCoeff = Math.max(0, candidate.directCoeff);
+    const diffuseCoeff = Math.max(0, candidate.diffuseCoeff);
+    let loss = options.ridgeLambda * (directCoeff * directCoeff + diffuseCoeff * diffuseCoeff);
+    for (const sample of samples) {
+      const predicted = directCoeff * sample.direct + diffuseCoeff * sample.diffuse;
+      const error = sample.production_W - predicted;
+      loss += error * error;
+    }
+    if (loss < bestLoss) {
+      bestLoss = loss;
+      best = { directCoeff, diffuseCoeff };
+    }
+  }
+
+  if (!best || !Number.isFinite(best.directCoeff) || !Number.isFinite(best.diffuseCoeff)) return null;
+  if (best.directCoeff + best.diffuseCoeff <= 1e-9) return null;
+  return best;
+}
+
+function median(values: number[]): number {
+  if (!values.length) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+function predictLinear(fit: { directCoeff: number; diffuseCoeff: number }, sample: Pick<PvLinearSample, 'direct' | 'diffuse'>): number {
+  return Math.max(0, fit.directCoeff * sample.direct + fit.diffuseCoeff * sample.diffuse);
+}
+
+function fitWithOutlierPass(samples: PvLinearSample[], options: PvLinearFitOptions): {
+  fit: { directCoeff: number; diffuseCoeff: number } | null;
+  sampleCount: number;
+  excludedCount: number;
+} {
+  const initial = fitNonNegativeRidge(samples, options);
+  if (!initial) return { fit: null, sampleCount: samples.length, excludedCount: 0 };
+
+  const outliers = lowOutlierIndexes(samples, initial, options);
+  if (outliers.size > 0 && samples.length - outliers.size >= options.minSamples) {
+    const filtered = samples.filter((_sample, i) => !outliers.has(i));
+    const refit = fitNonNegativeRidge(filtered, options);
+    if (refit) return { fit: refit, sampleCount: filtered.length, excludedCount: outliers.size };
+  }
+
+  return { fit: initial, sampleCount: samples.length, excludedCount: 0 };
+}
+
+function lowOutlierIndexes(
+  samples: PvLinearSample[],
+  fit: { directCoeff: number; diffuseCoeff: number },
+  options: PvLinearFitOptions,
+): Set<number> {
+  const totals = samples.map(s => s.direct + s.diffuse);
+  const strongThreshold = Math.max(options.minStrongRadiation_W_per_m2, Math.max(...totals) * 0.35);
+  const strongRatios = samples
+    .map((sample, i) => ({ sample, total: totals[i] }))
+    .filter(({ sample, total }) => total >= strongThreshold && sample.production_W > 0)
+    .map(({ sample, total }) => sample.production_W / Math.max(1, total));
+  const medianRatio = median(strongRatios);
+  const outliers = new Set<number>();
+
+  for (let i = 0; i < samples.length; i++) {
+    const sample = samples[i];
+    const total = totals[i];
+    if (total < strongThreshold) continue;
+
+    const trainingWithoutSample = samples.filter((_other, j) => j !== i);
+    const leaveOneOutFit = trainingWithoutSample.length >= options.minSamples
+      ? fitNonNegativeRidge(trainingWithoutSample, options)
+      : null;
+    const predicted = leaveOneOutFit
+      ? predictLinear(leaveOneOutFit, sample)
+      : predictLinear(fit, sample);
+    const modelLow = predicted >= options.minOutlierDelta_W
+      && sample.production_W < predicted * options.lowOutlierRatio
+      && predicted - sample.production_W >= options.minOutlierDelta_W;
+    const ratioLow = medianRatio > 0
+      && sample.production_W / Math.max(1, total) < medianRatio * options.lowOutlierRatio
+      && medianRatio * total - sample.production_W >= options.minOutlierDelta_W;
+
+    if (modelLow || ratioLow) outliers.add(i);
+  }
+
+  return outliers;
+}
+
+function crossValidatedLinearMae(samples: PvLinearSample[], options: PvLinearFitOptions): number | null {
+  const fallbackCount = samples.filter(s => s.fallback_W != null).length;
+  if (fallbackCount < options.minCrossValidationSamples) return null;
+
+  let sumAbs = 0;
+  let count = 0;
+
+  for (let i = 0; i < samples.length; i++) {
+    const sample = samples[i];
+    if (sample.fallback_W == null) continue;
+    const training = samples.filter((_other, j) => j !== i);
+    if (training.length < options.minSamples) continue;
+
+    const fit = fitNonNegativeRidge(training, options);
+    if (!fit) continue;
+
+    sumAbs += Math.abs(sample.production_W - predictLinear(fit, sample));
+    count++;
+  }
+
+  return count >= options.minCrossValidationSamples ? sumAbs / count : null;
+}
+
+function fallbackMae(samples: PvLinearSample[]): number | null {
+  let sumAbs = 0;
+  let count = 0;
+
+  for (const sample of samples) {
+    if (sample.fallback_W == null) continue;
+    sumAbs += Math.abs(sample.production_W - sample.fallback_W);
+    count++;
+  }
+
+  return count > 0 ? sumAbs / count : null;
+}
+
+function fitRobustLinearModel(index: number, samples: PvLinearSample[], options: PvLinearFitOptions): PvLinearModel {
+  if (samples.length < options.minSamples) return fallbackLinearModel(index);
+
+  const { fit, sampleCount, excludedCount } = fitWithOutlierPass(samples, options);
+  if (!fit) return fallbackLinearModel(index);
+
+  const cvMae = crossValidatedLinearMae(samples, options);
+  const baseMae = fallbackMae(samples);
+  // baseMae exists but cvMae is null: enough fallback data to judge but not enough to cross-validate
+  // the linear model — distrust it conservatively.
+  if (baseMae != null && cvMae == null) {
+    return {
+      index,
+      ...fit,
+      sampleCount,
+      excludedCount,
+      fallback: true,
+    };
+  }
+  if (
+    cvMae != null
+    && baseMae != null
+    && cvMae >= baseMae * (1 - options.minFallbackImprovementRatio)
+  ) {
+    return {
+      index,
+      ...fit,
+      sampleCount,
+      excludedCount,
+      fallback: true,
+    };
+  }
+
+  return {
+    index,
+    ...fit,
+    sampleCount,
+    excludedCount,
+    fallback: false,
+  };
+}
+
+/**
+ * Estimate per-hour or per-15-minute-slot PV models using direct + diffuse
+ * radiation. Zero production samples are treated as invalid sensor/curtailment
+ * observations. Low non-zero outliers under strong radiation are treated as
+ * likely derating and excluded before a second fit.
+ */
+export function estimateRobustLinearPvModels(
+  productionRecords: PvProductionRecord[],
+  irradiance: IrradianceRecord[],
+  bucketCount: 24 | 96,
+  fallbackPoints?: Map<number, PvForecastPoint>,
+): PvLinearModel[] {
+  const options = DEFAULT_LINEAR_FIT_OPTIONS;
+  const productionByTime = new Map<number, number>();
+  for (const rec of productionRecords) {
+    if (Number.isFinite(rec.production_Wh) && rec.production_Wh > 0) {
+      productionByTime.set(rec.time, rec.production_Wh);
+    }
+  }
+
+  const samplesByIndex = Array.from({ length: bucketCount }, () => [] as PvLinearSample[]);
+
+  for (const rec of irradiance) {
+    const production_W = productionByTime.get(rec.time);
+    if (production_W == null) continue;
+    const features = getRadiationFeatures(rec);
+    if (!features) continue;
+    if (features.direct + features.diffuse <= 5) continue;
+
+    const index = bucketCount === 96 ? slotOfDay(rec.time) : rec.hour;
+    const fallback_W = fallbackPoints?.get(rec.time)?.predicted ?? undefined;
+    samplesByIndex[index].push({ ...features, production_W, fallback_W });
+  }
+
+  return samplesByIndex.map((samples, index) => fitRobustLinearModel(index, samples, options));
+}
+
 /**
  * Generate PV forecast points using the 96-slot capacity model.
  *
@@ -391,6 +690,8 @@ export function forecastPvSlot(
       hour: rec.hour,
       ghiClear_W_per_m2: ghiClear,
       ghiForecast_W_per_m2: rec.ghi_W_per_m2,
+      directRadiation_W_per_m2: rec.directRadiation_W_per_m2,
+      diffuseRadiation_W_per_m2: rec.diffuseRadiation_W_per_m2,
       forecastRatio,
       predicted: Math.max(0, prediction),
       actual,
@@ -451,9 +752,58 @@ export function forecastPv(
       hour: rec.hour,
       ghiClear_W_per_m2: ghiClear,
       ghiForecast_W_per_m2: rec.ghi_W_per_m2,
+      directRadiation_W_per_m2: rec.directRadiation_W_per_m2,
+      diffuseRadiation_W_per_m2: rec.diffuseRadiation_W_per_m2,
       forecastRatio,
       predicted: Math.max(0, prediction),
       actual,
+    });
+  }
+
+  return points;
+}
+
+/**
+ * Generate PV forecast points from robust per-hour or per-slot direct+diffuse
+ * radiation models. Missing or unstable model buckets fall back to the supplied
+ * clear-sky forecast point for the same timestamp.
+ */
+export function forecastPvLinear(
+  models: PvLinearModel[],
+  forecastIrradiance: IrradianceRecord[],
+  lat: number,
+  lon: number,
+  actuals?: Map<number, number>,
+  fallbackPoints?: Map<number, PvForecastPoint>,
+): PvForecastPoint[] {
+  const useSlots = models.length === 96;
+  const points: PvForecastPoint[] = [];
+
+  for (const rec of forecastIrradiance) {
+    const bucket = useSlots ? slotOfDay(rec.time) : rec.hour;
+    const model = models[bucket];
+    const features = getRadiationFeatures(rec);
+    const fallback = fallbackPoints?.get(rec.time);
+
+    const midInterval = new Date(rec.time + (rec.intervalMinutes / 2) * 60 * 1000);
+    const ghiClear = fallback?.ghiClear_W_per_m2 ?? calculateClearSkyGHI(lat, lon, midInterval);
+    const forecastRatio = ghiClear > 5 ? rec.ghi_W_per_m2 / ghiClear : 0;
+
+    let predicted = fallback?.predicted ?? 0;
+    if (features && model && !model.fallback) {
+      predicted = model.directCoeff * features.direct + model.diffuseCoeff * features.diffuse;
+    }
+
+    points.push({
+      time: rec.time,
+      hour: rec.hour,
+      ghiClear_W_per_m2: ghiClear,
+      ghiForecast_W_per_m2: rec.ghi_W_per_m2,
+      directRadiation_W_per_m2: features?.direct,
+      diffuseRadiation_W_per_m2: features?.diffuse,
+      forecastRatio,
+      predicted: Math.max(0, predicted),
+      actual: actuals?.get(rec.time) ?? null,
     });
   }
 

--- a/lib/predict-pv.ts
+++ b/lib/predict-pv.ts
@@ -402,10 +402,10 @@ function fallbackLinearModel(index: number): PvLinearModel {
 function getRadiationFeatures(rec: IrradianceRecord): { direct: number; diffuse: number } | null {
   const direct = rec.directRadiation_W_per_m2;
   const diffuse = rec.diffuseRadiation_W_per_m2;
-  if (!Number.isFinite(direct) || !Number.isFinite(diffuse)) return null;
+  if (direct == null || diffuse == null || !Number.isFinite(direct) || !Number.isFinite(diffuse)) return null;
   return {
-    direct: Math.max(0, direct ?? 0),
-    diffuse: Math.max(0, diffuse ?? 0),
+    direct: Math.max(0, direct),
+    diffuse: Math.max(0, diffuse),
   };
 }
 
@@ -475,20 +475,20 @@ function predictLinear(fit: { directCoeff: number; diffuseCoeff: number }, sampl
 
 function fitWithOutlierPass(samples: PvLinearSample[], options: PvLinearFitOptions): {
   fit: { directCoeff: number; diffuseCoeff: number } | null;
-  sampleCount: number;
+  effectiveSamples: PvLinearSample[];
   excludedCount: number;
 } {
   const initial = fitNonNegativeRidge(samples, options);
-  if (!initial) return { fit: null, sampleCount: samples.length, excludedCount: 0 };
+  if (!initial) return { fit: null, effectiveSamples: samples, excludedCount: 0 };
 
   const outliers = lowOutlierIndexes(samples, initial, options);
   if (outliers.size > 0 && samples.length - outliers.size >= options.minSamples) {
     const filtered = samples.filter((_sample, i) => !outliers.has(i));
     const refit = fitNonNegativeRidge(filtered, options);
-    if (refit) return { fit: refit, sampleCount: filtered.length, excludedCount: outliers.size };
+    if (refit) return { fit: refit, effectiveSamples: filtered, excludedCount: outliers.size };
   }
 
-  return { fit: initial, sampleCount: samples.length, excludedCount: 0 };
+  return { fit: initial, effectiveSamples: samples, excludedCount: 0 };
 }
 
 function lowOutlierIndexes(
@@ -569,18 +569,20 @@ function fallbackMae(samples: PvLinearSample[]): number | null {
 function fitRobustLinearModel(index: number, samples: PvLinearSample[], options: PvLinearFitOptions): PvLinearModel {
   if (samples.length < options.minSamples) return fallbackLinearModel(index);
 
-  const { fit, sampleCount, excludedCount } = fitWithOutlierPass(samples, options);
+  const { fit, effectiveSamples, excludedCount } = fitWithOutlierPass(samples, options);
   if (!fit) return fallbackLinearModel(index);
 
-  const cvMae = crossValidatedLinearMae(samples, options);
-  const baseMae = fallbackMae(samples);
+  // Use effectiveSamples (post-outlier-removal) for both MAEs so the gate
+  // is evaluated on the same data the returned coefficients were fitted on.
+  const cvMae = crossValidatedLinearMae(effectiveSamples, options);
+  const baseMae = fallbackMae(effectiveSamples);
   // baseMae exists but cvMae is null: enough fallback data to judge but not enough to cross-validate
   // the linear model — distrust it conservatively.
   if (baseMae != null && cvMae == null) {
     return {
       index,
       ...fit,
-      sampleCount,
+      sampleCount: effectiveSamples.length,
       excludedCount,
       fallback: true,
     };
@@ -593,7 +595,7 @@ function fitRobustLinearModel(index: number, samples: PvLinearSample[], options:
     return {
       index,
       ...fit,
-      sampleCount,
+      sampleCount: effectiveSamples.length,
       excludedCount,
       fallback: true,
     };
@@ -602,7 +604,7 @@ function fitRobustLinearModel(index: number, samples: PvLinearSample[], options:
   return {
     index,
     ...fit,
-    sampleCount,
+    sampleCount: effectiveSamples.length,
     excludedCount,
     fallback: false,
   };

--- a/tests/api/services/prediction-config-store.test.js
+++ b/tests/api/services/prediction-config-store.test.js
@@ -55,6 +55,30 @@ describe('prediction-config-store', () => {
       expect(config.validationWindow.start).toBe(expectedStart.toISOString());
       expect(config.validationWindow.end).toBe(expectedEnd.toISOString());
     });
+
+    it('defaults missing pvModel to clearSkyRatio', async () => {
+      await writeFile(
+        path.join(tmpDir, 'prediction-config.json'),
+        JSON.stringify({
+          sensors: [],
+          derived: [],
+          pvConfig: {
+            latitude: 51.1,
+            longitude: 3.7,
+            historyDays: 7,
+            pvSensor: 'Solar Generation',
+            pvMode: '15min',
+          },
+        }),
+        'utf8',
+      );
+
+      const { loadPredictionConfig } = await importStore();
+      const config = await loadPredictionConfig();
+
+      expect(config.pvConfig.pvModel).toBe('clearSkyRatio');
+      expect(config.pvConfig.pvMode).toBe('15min');
+    });
   });
 
   describe('migration: activeConfig → historicalPredictor', () => {

--- a/tests/api/services/pv-prediction-service.test.js
+++ b/tests/api/services/pv-prediction-service.test.js
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../api/services/ha-client.ts', () => ({
+  fetchHaStats: vi.fn(),
+}));
+
+vi.mock('../../../api/services/open-meteo-client.ts', () => ({
+  fetchArchiveIrradiance: vi.fn(),
+  fetchForecastIrradiance: vi.fn(),
+}));
+
+import { fetchHaStats } from '../../../api/services/ha-client.ts';
+import { fetchArchiveIrradiance, fetchForecastIrradiance } from '../../../api/services/open-meteo-client.ts';
+import { runPvForecast } from '../../../api/services/pv-prediction-service.ts';
+
+const sensors = [{ id: 'sensor.pv', name: 'Solar Generation', unit: 'Wh' }];
+
+function fiveMinutePvReadings(day, slotStartHour, watts) {
+  const start = Date.UTC(2024, 5, day, slotStartHour);
+  const whPerFiveMinutes = watts / 12;
+  return [0, 5, 10].map(minutes => ({
+    start: start + minutes * 60_000,
+    change: whPerFiveMinutes,
+  }));
+}
+
+function hourlyIrradiance(day, hour, direct, diffuse) {
+  const time = Date.UTC(2024, 5, day, hour);
+  return {
+    time,
+    hour,
+    ghi_W_per_m2: direct + diffuse,
+    directRadiation_W_per_m2: direct,
+    diffuseRadiation_W_per_m2: diffuse,
+    intervalMinutes: 60,
+  };
+}
+
+function forecastIrradiance(day, hour, direct, diffuse) {
+  return {
+    ...hourlyIrradiance(day, hour, direct, diffuse),
+    intervalMinutes: 15,
+  };
+}
+
+describe('runPvForecast', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-06-20T11:45:00Z'));
+    vi.resetAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns historical accuracy points and metrics for robustLinear 15min mode', async () => {
+    fetchHaStats.mockResolvedValue({
+      'sensor.pv': [
+        ...fiveMinutePvReadings(16, 12, 1500),
+        ...fiveMinutePvReadings(17, 12, 1800),
+        ...fiveMinutePvReadings(18, 12, 2100),
+        ...fiveMinutePvReadings(19, 12, 120),
+      ],
+    });
+    fetchArchiveIrradiance.mockResolvedValue([
+      hourlyIrradiance(16, 12, 500, 100),
+      hourlyIrradiance(17, 12, 400, 200),
+      hourlyIrradiance(18, 12, 300, 300),
+      hourlyIrradiance(19, 12, 480, 120),
+    ]);
+    fetchForecastIrradiance.mockResolvedValue([
+      forecastIrradiance(20, 12, 350, 250),
+    ]);
+
+    const result = await runPvForecast({
+      sensors,
+      derived: [],
+      activeType: 'historical',
+      historicalPredictor: { sensor: 'Grid', lookbackWeeks: 4, dayFilter: 'all', aggregation: 'mean' },
+      pvConfig: {
+        latitude: 51.05,
+        longitude: 3.71,
+        historyDays: 7,
+        pvSensor: 'Solar Generation',
+        pvMode: '15min',
+        pvModel: 'robustLinear',
+      },
+      haUrl: 'ws://ha.local/api/websocket',
+      haToken: 'token',
+    });
+
+    expect(fetchHaStats).toHaveBeenCalledWith(expect.objectContaining({ period: '5minute' }));
+    expect(result.model).toBe('robustLinear');
+    expect(result.forecast.step).toBe(15);
+    expect(result.recent.length).toBeGreaterThan(0);
+    expect(result.metrics.n).toBeGreaterThan(0);
+  });
+});

--- a/tests/app/predictions-config-form.test.js
+++ b/tests/app/predictions-config-form.test.js
@@ -48,6 +48,10 @@ function setupDom() {
       <option value="hourly">hourly</option>
       <option value="hybrid">hybrid</option>
     </select>
+    <select id="pred-pv-model" data-predictions-only="true">
+      <option value="clearSkyRatio">clearSkyRatio</option>
+      <option value="robustLinear">robustLinear</option>
+    </select>
     <button id="pred-load-forecast" type="button"></button>
     <button id="pred-pv-forecast" type="button"></button>
     <input id="forecast-chart-15m" type="checkbox" />
@@ -78,7 +82,7 @@ describe('prediction config form', () => {
       activeType: 'fixed',
       fixedPredictor: { load_W: 420 },
       historicalPredictor: { sensor: 'Grid Import', lookbackWeeks: 3, dayFilter: 'same', aggregation: 'median' },
-      pvConfig: { pvSensor: 'Total Load', latitude: 51.1, longitude: 3.7, historyDays: 9, forecastResolution: 15 },
+      pvConfig: { pvSensor: 'Total Load', latitude: 51.1, longitude: 3.7, historyDays: 9, forecastResolution: 15, pvModel: 'robustLinear' },
     });
 
     await hydratePredictionForm();
@@ -88,6 +92,7 @@ describe('prediction config form', () => {
     expect([...document.getElementById('pred-active-sensor').options].map(opt => opt.value)).toContain('Grid Import');
     expect(document.getElementById('pred-pv-sensor').value).toBe('Total Load');
     expect(document.getElementById('pred-pv-mode').value).toBe('hybrid');
+    expect(document.getElementById('pred-pv-model').value).toBe('robustLinear');
     expect(document.getElementById('pred-fixed-fields').classList.contains('hidden')).toBe(false);
     expect(document.getElementById('pred-historical-fields').classList.contains('hidden')).toBe(true);
   });
@@ -105,6 +110,7 @@ describe('prediction config form', () => {
     document.getElementById('pred-pv-lon').value = '3.7';
     document.getElementById('pred-pv-history').value = '10';
     document.getElementById('pred-pv-mode').value = 'hybrid';
+    document.getElementById('pred-pv-model').value = 'robustLinear';
     savePredictionConfig.mockResolvedValue({});
 
     const values = readPredictionFormValues();
@@ -124,6 +130,7 @@ describe('prediction config form', () => {
         longitude: 3.7,
         historyDays: 10,
         pvMode: 'hybrid',
+        pvModel: 'robustLinear',
       },
     });
     expect(values).not.toHaveProperty('derived');

--- a/tests/lib/open-meteo.test.js
+++ b/tests/lib/open-meteo.test.js
@@ -26,7 +26,7 @@ describe('buildArchiveUrl', () => {
     expect(url).toContain('longitude=3.71');
     expect(url).toContain('start_date=2024-06-01');
     expect(url).toContain('end_date=2024-06-14');
-    expect(url).toContain('hourly=shortwave_radiation');
+    expect(url).toContain('hourly=shortwave_radiation,direct_radiation,diffuse_radiation');
     expect(url).toContain('timezone=GMT');
   });
 });
@@ -46,7 +46,7 @@ describe('buildForecastUrl', () => {
     expect(url).toContain('timezone=GMT');
     expect(url).toContain('past_days=1');
     expect(url).toContain('forecast_days=2');
-    expect(url).toContain('hourly=shortwave_radiation');
+    expect(url).toContain('hourly=shortwave_radiation,direct_radiation,diffuse_radiation');
   });
 
   it('allows custom model and days', () => {
@@ -65,13 +65,13 @@ describe('buildForecastUrl', () => {
 
   it('uses hourly param when resolution=60', () => {
     const url = buildForecastUrl({ latitude: 51.05, longitude: 3.71, resolution: 60 });
-    expect(url).toContain('hourly=shortwave_radiation');
+    expect(url).toContain('hourly=shortwave_radiation,direct_radiation,diffuse_radiation');
     expect(url).not.toContain('minutely_15');
   });
 
   it('uses minutely_15 param when resolution=15', () => {
     const url = buildForecastUrl({ latitude: 51.05, longitude: 3.71, resolution: 15 });
-    expect(url).toContain('minutely_15=shortwave_radiation');
+    expect(url).toContain('minutely_15=shortwave_radiation,direct_radiation,diffuse_radiation');
     expect(url).not.toContain('hourly=');
   });
 });
@@ -87,6 +87,8 @@ describe('parseIrradianceResponse', () => {
       hourly: {
         time: ['2024-06-15T14:00'],
         shortwave_radiation: [600],
+        direct_radiation: [420],
+        diffuse_radiation: [180],
       },
     };
 
@@ -94,6 +96,8 @@ describe('parseIrradianceResponse', () => {
     expect(records).toHaveLength(1);
     expect(records[0].hour).toBe(13);
     expect(records[0].ghi_W_per_m2).toBe(600);
+    expect(records[0].directRadiation_W_per_m2).toBe(420);
+    expect(records[0].diffuseRadiation_W_per_m2).toBe(180);
     expect(records[0].intervalMinutes).toBe(60);
 
     // Timestamp should be shifted back 1 hour
@@ -172,6 +176,8 @@ describe('parseMinutely15Response', () => {
       minutely_15: {
         time: ['2024-06-15T13:00', '2024-06-15T13:15', '2024-06-15T13:30', '2024-06-15T13:45'],
         shortwave_radiation: [500, 520, 510, 480],
+        direct_radiation: [350, 360, 340, 310],
+        diffuse_radiation: [150, 160, 170, 170],
       },
     };
 
@@ -182,10 +188,14 @@ describe('parseMinutely15Response', () => {
     expect(records[0].hour).toBe(13);
     expect(records[0].time).toBe(new Date('2024-06-15T13:00:00Z').getTime());
     expect(records[0].ghi_W_per_m2).toBe(500);
+    expect(records[0].directRadiation_W_per_m2).toBe(350);
+    expect(records[0].diffuseRadiation_W_per_m2).toBe(150);
     expect(records[0].intervalMinutes).toBe(15);
 
     expect(records[1].time).toBe(new Date('2024-06-15T13:15:00Z').getTime());
     expect(records[1].ghi_W_per_m2).toBe(520);
+    expect(records[1].directRadiation_W_per_m2).toBe(360);
+    expect(records[1].diffuseRadiation_W_per_m2).toBe(160);
     expect(records[1].intervalMinutes).toBe(15);
   });
 
@@ -264,6 +274,8 @@ describe('expandHourlyTo15Min', () => {
     time: t13,
     hour: 13,
     ghi_W_per_m2: 400,
+    directRadiation_W_per_m2: 250,
+    diffuseRadiation_W_per_m2: 150,
     intervalMinutes: 60,
   };
 
@@ -284,6 +296,8 @@ describe('expandHourlyTo15Min', () => {
     const result = expandHourlyTo15Min([hourlyRecord]);
     for (const r of result) {
       expect(r.ghi_W_per_m2).toBe(400);
+      expect(r.directRadiation_W_per_m2).toBe(hourlyRecord.directRadiation_W_per_m2);
+      expect(r.diffuseRadiation_W_per_m2).toBe(hourlyRecord.diffuseRadiation_W_per_m2);
     }
   });
 

--- a/tests/lib/predict-pv.test.js
+++ b/tests/lib/predict-pv.test.js
@@ -10,6 +10,8 @@ import {
   calculateMaxProductionPerSlot,
   estimateSlotCapacity,
   forecastPvSlot,
+  estimateRobustLinearPvModels,
+  forecastPvLinear,
 } from '../../lib/predict-pv.ts';
 import { buildForecastSeries } from '../../lib/time-series-utils.ts';
 
@@ -488,5 +490,222 @@ describe('forecastPvSlot', () => {
     const irr = [{ time: t, hour: 12, ghi_W_per_m2: 400, intervalMinutes: 15 }];
     const points = forecastPvSlot(capacity, irr, lat, lon);
     expect(points[0].actual).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// robust linear PV model
+// ---------------------------------------------------------------------------
+
+describe('robust linear PV model', () => {
+  const slot = 48;
+  const hour = 12;
+
+  function sample(day, direct, diffuse, production_W) {
+    const time = Date.UTC(2024, 5, day, hour);
+    return {
+      production: { time, hour, slot, production_Wh: production_W },
+      irradiance: {
+        time,
+        hour,
+        ghi_W_per_m2: direct + diffuse,
+        directRadiation_W_per_m2: direct,
+        diffuseRadiation_W_per_m2: diffuse,
+        intervalMinutes: 15,
+      },
+    };
+  }
+
+  it('fits per-slot direct and diffuse coefficients', () => {
+    const rows = [
+      sample(10, 500, 100, 1500),
+      sample(11, 400, 200, 1800),
+      sample(12, 300, 300, 2100),
+      sample(13, 200, 400, 2400),
+    ];
+
+    const models = estimateRobustLinearPvModels(
+      rows.map(r => r.production),
+      rows.map(r => r.irradiance),
+      96,
+    );
+
+    expect(models[slot].fallback).toBe(false);
+    expect(models[slot].directCoeff).toBeCloseTo(2, 1);
+    expect(models[slot].diffuseCoeff).toBeCloseTo(5, 1);
+  });
+
+  it('excludes low strong-radiation outliers before refitting', () => {
+    const rows = [
+      sample(10, 500, 100, 1500),
+      sample(11, 400, 200, 1800),
+      sample(12, 300, 300, 2100),
+      sample(13, 200, 400, 2400),
+      sample(14, 450, 150, 1650),
+      sample(15, 480, 120, 120),
+    ];
+
+    const models = estimateRobustLinearPvModels(
+      rows.map(r => r.production),
+      rows.map(r => r.irradiance),
+      96,
+    );
+
+    expect(models[slot].excludedCount).toBe(1);
+    expect(models[slot].sampleCount).toBe(5);
+    expect(models[slot].directCoeff).toBeGreaterThan(1);
+    expect(models[slot].diffuseCoeff).toBeGreaterThan(1);
+  });
+
+  it('ignores exact zero production samples as invalid training data', () => {
+    const rows = [
+      sample(10, 500, 100, 1500),
+      sample(11, 400, 200, 1800),
+      sample(12, 300, 300, 2100),
+      sample(13, 200, 400, 2400),
+      sample(14, 500, 100, 0),
+      sample(15, 480, 120, 0),
+      sample(16, 450, 150, 0),
+    ];
+
+    const models = estimateRobustLinearPvModels(
+      rows.map(r => r.production),
+      rows.map(r => r.irradiance),
+      96,
+    );
+
+    expect(models[slot].sampleCount).toBe(4);
+    expect(models[slot].fallback).toBe(false);
+    expect(models[slot].directCoeff).toBeGreaterThan(1);
+    expect(models[slot].diffuseCoeff).toBeGreaterThan(1);
+  });
+
+  it('keeps the clear-sky fallback when cross-validation is better', () => {
+    const rows = [
+      sample(10, 500, 100, 1000),
+      sample(11, 500, 100, 2000),
+      sample(12, 500, 100, 1000),
+      sample(13, 500, 100, 2000),
+    ];
+    const fallbackPoints = new Map(rows.map(row => [row.irradiance.time, {
+      time: row.irradiance.time,
+      hour,
+      ghiClear_W_per_m2: 800,
+      ghiForecast_W_per_m2: row.irradiance.ghi_W_per_m2,
+      forecastRatio: 0.75,
+      predicted: row.production.production_Wh,
+      actual: row.production.production_Wh,
+    }]));
+
+    const models = estimateRobustLinearPvModels(
+      rows.map(r => r.production),
+      rows.map(r => r.irradiance),
+      96,
+      fallbackPoints,
+    );
+
+    expect(models[slot].fallback).toBe(true);
+  });
+
+  it('keeps the clear-sky fallback when too few non-zero samples remain to validate', () => {
+    const rows = [
+      sample(10, 500, 100, 1500),
+      sample(11, 400, 200, 1800),
+      sample(12, 300, 300, 2100),
+      sample(13, 500, 100, 0),
+      sample(14, 500, 100, 0),
+      sample(15, 500, 100, 0),
+    ];
+    const fallbackPoints = new Map(rows.map(row => [row.irradiance.time, {
+      time: row.irradiance.time,
+      hour,
+      ghiClear_W_per_m2: 800,
+      ghiForecast_W_per_m2: row.irradiance.ghi_W_per_m2,
+      forecastRatio: 0.75,
+      predicted: 1700,
+      actual: row.production.production_Wh,
+    }]));
+
+    const models = estimateRobustLinearPvModels(
+      rows.map(r => r.production),
+      rows.map(r => r.irradiance),
+      96,
+      fallbackPoints,
+    );
+
+    expect(models[slot].sampleCount).toBe(3);
+    expect(models[slot].fallback).toBe(true);
+  });
+
+  it('uses the robust model when cross-validation improves over clear-sky fallback', () => {
+    const rows = [
+      sample(10, 500, 100, 1500),
+      sample(11, 400, 200, 1800),
+      sample(12, 300, 300, 2100),
+      sample(13, 200, 400, 2400),
+    ];
+    const fallbackPoints = new Map(rows.map(row => [row.irradiance.time, {
+      time: row.irradiance.time,
+      hour,
+      ghiClear_W_per_m2: 800,
+      ghiForecast_W_per_m2: row.irradiance.ghi_W_per_m2,
+      forecastRatio: 0.75,
+      predicted: 1000,
+      actual: row.production.production_Wh,
+    }]));
+
+    const models = estimateRobustLinearPvModels(
+      rows.map(r => r.production),
+      rows.map(r => r.irradiance),
+      96,
+      fallbackPoints,
+    );
+
+    expect(models[slot].fallback).toBe(false);
+  });
+
+  it('falls back when a bucket has too few samples', () => {
+    const row = sample(10, 500, 100, 1500);
+    const models = estimateRobustLinearPvModels([row.production], [row.irradiance], 96);
+    expect(models[slot].fallback).toBe(true);
+  });
+
+  it('uses fallback points for missing robust model buckets', () => {
+    const time = Date.UTC(2024, 5, 20, hour);
+    const models = new Array(24).fill(null).map((_, index) => ({
+      index,
+      directCoeff: 0,
+      diffuseCoeff: 0,
+      sampleCount: 0,
+      excludedCount: 0,
+      fallback: true,
+    }));
+    const fallback = {
+      time,
+      hour,
+      ghiClear_W_per_m2: 800,
+      ghiForecast_W_per_m2: 500,
+      forecastRatio: 0.625,
+      predicted: 1234,
+      actual: null,
+    };
+
+    const points = forecastPvLinear(
+      models,
+      [{
+        time,
+        hour,
+        ghi_W_per_m2: 500,
+        directRadiation_W_per_m2: 300,
+        diffuseRadiation_W_per_m2: 200,
+        intervalMinutes: 60,
+      }],
+      51.05,
+      3.71,
+      undefined,
+      new Map([[time, fallback]]),
+    );
+
+    expect(points[0].predicted).toBe(1234);
   });
 });


### PR DESCRIPTION
## What this PR adds

A second PV forecast algorithm called **Robust Linear**, selectable alongside the existing **Clear-sky Ratio** model via a new dropdown in the PV prediction config form.

---

## Background: why the existing model sometimes struggles

The current **clear-sky ratio** model works like this:

1. Look at historical production to find the maximum output ever observed at each UTC hour.
2. Divide that by the Bird clear-sky GHI at the same time → this is the system's "true capacity" per hour.
3. For the forecast: `prediction = (GHI_forecast / GHI_clear) × capacity`.

This works well when the sky conditions during training closely resemble the forecast. It breaks down when:

- The training window happened to catch unusually cloudy or sunny days, skewing the capacity estimate.
- The PV system has partial shading, orientation mismatch, or a mix of south/east/west panels — factors that make the ratio between GHI and actual production non-linear and time-of-day dependent.
- Short history windows (common: 7–14 days) provide too few samples per hour bucket to fit a reliable ratio.

---

## How the new robust linear model works

Instead of a single ratio per hour, the robust linear model fits a **two-feature linear regression** per time bucket:

```
production_W = β_direct × direct_radiation + β_diffuse × diffuse_radiation
```

Direct and diffuse radiation are now fetched alongside the existing global horizontal irradiance (GHI) from Open-Meteo for both the archive and forecast endpoints.

This separates physics that behave differently:
- **Direct radiation** hits south-facing panels almost perpendicularly at noon, but grazes east/west panels. Its coefficient captures orientation and tilt efficiency.
- **Diffuse radiation** (scattered skylight) reaches all exposed panel surfaces more evenly. Its coefficient captures shading and diffuse-sky efficiency.

### Fitting pipeline per bucket (hour 0–23 or slot 0–95)

**Step 1 — Collect samples**
Each historical irradiance record that has a matching production measurement and meaningful radiation (`direct + diffuse > 5 W/m²`) becomes one training sample `(direct, diffuse, production_W)`.

**Step 2 — Non-negative ridge regression**
Fits `β_direct ≥ 0` and `β_diffuse ≥ 0` using closed-form normal equations with a small ridge penalty (λ=1) to avoid overfitting on low-data buckets. Four candidate solutions are evaluated (unconstrained 2D, two axis-aligned 1D, and zero) and the non-negative one with the lowest ridge-penalised loss is chosen.

**Step 3 — Outlier exclusion**
Low-production outliers under strong radiation (>35% of the max observed) are flagged using two independent tests:
- *Model test*: leave-one-out prediction is ≥ 300 W but actual production is less than 35% of it.
- *Ratio test*: the sample's production-to-radiation ratio is less than 35% of the median ratio across all strong-radiation days.

If outliers are found and enough clean samples remain (≥ 3), a second fit is run without them. This handles curtailment events, inverter faults, and partial shading days that would otherwise drag the coefficients down.

**Step 4 — Cross-validation gate**
Before using the fitted model, it is compared against the clear-sky ratio model (always computed first, used as a per-bucket fallback). Leave-one-out MAE is computed using plain ridge fits — only samples that also have a clear-sky fallback prediction participate so the two MAE values are on exactly the same data.

If the linear model's cross-validated MAE is not at least 5% better than the clear-sky model's MAE for the same samples, the bucket **falls back** to the clear-sky ratio prediction. This means the new model only activates where it demonstrably earns its keep — buckets with too few samples, noisy fits, or already-good clear-sky estimates automatically revert to the baseline.

### Forecast generation

`forecastPvLinear` iterates over forecast irradiance records:
- For each time bucket, if the fitted model passed the cross-validation gate: `prediction = β_direct × direct + β_diffuse × diffuse`.
- If the model is in fallback mode (too few samples, unstable fit, or CV didn't beat clear-sky): use the clear-sky ratio prediction for that bucket.

This means the two models are blended per bucket rather than switching wholesale — a system with consistent east/west data for midday buckets but sparse dawn/dusk data will use the linear model for midday and fall back to clear-sky for the edges of the day.

---

## What changes in the API / data flow

| Layer | Change |
|---|---|
| `lib/open-meteo.ts` | Requests `direct_radiation` and `diffuse_radiation` alongside `shortwave_radiation` from both archive and forecast endpoints. Both hourly and minutely_15 modes updated. |
| `lib/predict-pv.ts` | New `estimateRobustLinearPvModels()` + `forecastPvLinear()` functions. `IrradianceRecord` and `PvForecastPoint` carry the two new radiation fields (optional, backward compatible). |
| `api/types.ts` | New `PvModel = 'clearSkyRatio' \| 'robustLinear'` type; `pvModel?: PvModel` added to `PvPredictionConfig`. |
| `api/services/pv-prediction-service.ts` | Branches on `pvModel`: always runs clear-sky ratio first (used as fallback), then overlays robust linear for non-fallback buckets when selected. `PvForecastRunResult` now includes `model` so the UI can report which algorithm was active. |
| `api/defaults/default-prediction-config.json` | Default is `"pvModel": "clearSkyRatio"` — no behaviour change for existing installations. |
| `app/` | New "Model" dropdown in the PV config form; status message after a forecast run now shows which model was used. |

---

## Test plan

- [x] `tests/lib/predict-pv.test.js` — unit tests for coefficient fitting, outlier exclusion, zero-sample handling, cross-validation gate (fallback and non-fallback cases), and `forecastPvLinear` fallback-point lookup
- [x] `tests/api/services/pv-prediction-service.test.js` — integration test for `runPvForecast` with `pvModel: 'robustLinear'` end-to-end
- [x] `tests/api/services/prediction-config-store.test.js` — `pvModel` defaulting and deep-merge of `pvConfig`
- [x] `tests/app/predictions-config-form.test.js` — `pvModel` round-trips through form read/render
- [x] `tests/lib/open-meteo.test.js` — URL builder and response parser tests updated for new radiation fields
- [x] All 368 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)