### PR TITLE
Add EV SoC valuation

### DIFF
--- a/api/defaults/default-settings.json
+++ b/api/defaults/default-settings.json
@@ -33,5 +33,6 @@
   "evPlugSensor": "",
   "evDepartureTime": "",
   "evTargetSoc_percent": 80,
-  "evChargeEfficiency_percent": 90
+  "evChargeEfficiency_percent": 90,
+  "evSocValue_cents_per_kWh": 0
 }

--- a/api/services/config-builder.ts
+++ b/api/services/config-builder.ts
@@ -81,6 +81,7 @@ export function buildSolverConfigFromSettings(
     idleDrain_W:                          settings.idleDrain_W,
     terminalSocValuation:                 settings.terminalSocValuation,
     terminalSocCustomPrice_cents_per_kWh: settings.terminalSocCustomPrice_cents_per_kWh,
+    evSocValue_cents_per_kWh:             settings.evSocValue_cents_per_kWh,
     initialSoc_percent:                   data.soc.value,
   };
 
@@ -107,7 +108,12 @@ export function buildSolverConfigFromSettings(
     const capacityWh = settings.evBatteryCapacity_kWh * 1000;
     const stepHours = settings.stepSize_m / 60;
 
+    // D > 0: a valid future departure within (or just beyond) the horizon.
+    // D <= 0: no departure set or it is in the past. The EV is still modeled (so an EV SoC
+    // valuation can drive charging), but with no enforced target — evDepartureSlot is set
+    // beyond the horizon (skips c_ev_target) and the target is 0 (skips the cardinality bound).
     const D = departureTimeToSlot(settings.evDepartureTime, nowMs, settings.stepSize_m, T);
+    let targetSoc_percent: number;
     if (D > 0) {
       const initialWh = (evState.soc_percent / 100) * capacityWh;
       const requestedTargetWh = (settings.evTargetSoc_percent / 100) * capacityWh;
@@ -115,18 +121,21 @@ export function buildSolverConfigFromSettings(
       const efficiency = settings.evChargeEfficiency_percent / 100;
       const maxChargeable_Wh = maxPow_W * stepHours * chargingSlots * efficiency;
       const achievableTargetWh = Math.min(requestedTargetWh, initialWh + maxChargeable_Wh, capacityWh);
-
-      const ev: EvConfig = {
-        evMinChargePower_W: Math.min(minPow_W, maxPow_W),
-        evMaxChargePower_W: maxPow_W,
-        evBatteryCapacity_Wh: capacityWh,
-        evInitialSoc_percent: evState.soc_percent,
-        evTargetSoc_percent: (achievableTargetWh / capacityWh) * 100,
-        evDepartureSlot: D,
-        evChargeEfficiency_percent: settings.evChargeEfficiency_percent,
-      };
-      base.ev = ev;
+      targetSoc_percent = (achievableTargetWh / capacityWh) * 100;
+    } else {
+      targetSoc_percent = 0;
     }
+
+    const ev: EvConfig = {
+      evMinChargePower_W: Math.min(minPow_W, maxPow_W),
+      evMaxChargePower_W: maxPow_W,
+      evBatteryCapacity_Wh: capacityWh,
+      evInitialSoc_percent: evState.soc_percent,
+      evTargetSoc_percent: targetSoc_percent,
+      evDepartureSlot: D > 0 ? D : T + 1,
+      evChargeEfficiency_percent: settings.evChargeEfficiency_percent,
+    };
+    base.ev = ev;
   }
 
   return base;

--- a/api/services/settings-store.ts
+++ b/api/services/settings-store.ts
@@ -14,7 +14,7 @@ const NUMERIC_FIELDS: (keyof Settings)[] = [
   'dischargeEfficiency_percent', 'batteryCost_cent_per_kWh', 'idleDrain_W',
   'terminalSocCustomPrice_cents_per_kWh', 'rebalanceHoldHours',
   'evMinChargeCurrent_A', 'evMaxChargeCurrent_A', 'evBatteryCapacity_kWh',
-  'evTargetSoc_percent', 'evChargeEfficiency_percent',
+  'evTargetSoc_percent', 'evChargeEfficiency_percent', 'evSocValue_cents_per_kWh',
 ];
 
 function validateSettings(s: Settings): Settings {

--- a/api/types.ts
+++ b/api/types.ts
@@ -52,6 +52,7 @@ export interface Settings {
   evDepartureTime: string;
   evTargetSoc_percent: number;
   evChargeEfficiency_percent: number;
+  evSocValue_cents_per_kWh: number;
 }
 
 // ----------------------------- Persisted data ---------------------------

--- a/app/index.html
+++ b/app/index.html
@@ -1539,6 +1539,16 @@
               </button>
             </div>
           </label>
+          <label class="block text-sm">
+            <span class="block text-xs font-medium text-slate-400 dark:text-slate-500 mb-1 tracking-wide">SoC value</span>
+            <div class="relative mt-1">
+              <input id="ev-soc-valuation" type="number" min="0" step="0.1" placeholder="e.g. 15"
+                data-settings-input class="form-input pr-16" />
+              <span class="pointer-events-none absolute inset-y-0 right-2 flex items-center text-xs text-slate-400">
+                c€/kWh
+              </span>
+            </div>
+          </label>
         </div>
 
         <!-- Plan summary -->

--- a/app/src/state.js
+++ b/app/src/state.js
@@ -48,6 +48,7 @@ export function snapshotUI(els) {
     evChargeEfficiency_percent: num(els.evChargeEfficiency?.value),
     evDepartureTime: els.evDepartureTime?.value ?? '',
     evTargetSoc_percent: num(els.evTargetSoc?.value),
+    evSocValue_cents_per_kWh: num(els.evSocValuation?.value),
     evSocSensor: els.evSocSensor?.value ?? '',
     evPlugSensor: els.evPlugSensor?.value ?? '',
 
@@ -116,6 +117,7 @@ export function hydrateUI(els, obj = {}) {
   setIfDef(els.evChargeEfficiency, obj.evChargeEfficiency_percent);
   setIfDef(els.evDepartureTime, obj.evDepartureTime);
   setIfDef(els.evTargetSoc, obj.evTargetSoc_percent);
+  setIfDef(els.evSocValuation, obj.evSocValue_cents_per_kWh);
   setIfDef(els.evSocSensor, obj.evSocSensor);
   setIfDef(els.evPlugSensor, obj.evPlugSensor);
 

--- a/app/src/ui-binding.js
+++ b/app/src/ui-binding.js
@@ -89,6 +89,7 @@ export function getElements() {
     evDepartureQuickSet: $("#ev-departure-quick-set"),
     evTargetSoc: $("#ev-target-soc"),
     evTargetSocQuickSet: $("#ev-target-soc-quick-set"),
+    evSocValuation: $("#ev-soc-valuation"),
     evSocSensor: $("#ev-soc-sensor"),
     evPlugSensor: $("#ev-plug-sensor"),
     evSocValue: $("#ev-soc-value"),

--- a/lib/build-lp.ts
+++ b/lib/build-lp.ts
@@ -28,6 +28,9 @@ export function buildLP({
   terminalSocValuation = "zero",
   terminalSocCustomPrice_cents_per_kWh = 0,
 
+  // EV SoC valuation: value of energy left in the EV battery in c€/kWh (0 = disabled)
+  evSocValue_cents_per_kWh = 0,
+
   // variable parameters
   initialSoc_percent = 20,
 
@@ -65,6 +68,8 @@ export function buildLP({
   const idleDrain_Wh = idleDrain_W * stepHours; // Wh lost from battery per slot due to inverter idle consumption
 
   const terminalPrice_cents_per_Wh = selectTerminalPriceCentsPerKWh(terminalSocValuation, importPrice, terminalSocCustomPrice_cents_per_kWh) / 1000 * (dischargeEfficiency_percent / 100); // c€/Wh
+  // EV energy is consumed as driving fuel (never discharged back to the house), so no discharge-efficiency factor.
+  const evTerminalPrice_cents_per_Wh = evSocValue_cents_per_kWh / 1000; // c€/Wh
 
   // Convert soc percentages to Wh
   const minSoc_Wh = (minSoc_percent / 100) * batteryCapacity_Wh;
@@ -150,6 +155,10 @@ export function buildLP({
   // Terminal SOC valuation
   if (terminalPrice_cents_per_Wh > 0) {
     objTerms.push(` - ${toNum(terminalPrice_cents_per_Wh)} ${soc(T - 1)}`);
+  }
+  // EV SoC valuation: value energy left in the EV battery at the end of the horizon
+  if (evActive && evTerminalPrice_cents_per_Wh > 0) {
+    objTerms.push(` - ${toNum(evTerminalPrice_cents_per_Wh)} ${evSocVar(T - 1)}`);
   }
   // Rebalancing symmetry-breaking: escalating penalty prefers earlier windows when cost-equivalent.
   if (D > 0) {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -55,6 +55,9 @@ export interface SolverConfig {
   terminalSocValuation: TerminalSocValuation;
   terminalSocCustomPrice_cents_per_kWh: number;
 
+  // EV SoC valuation (value of energy left in the EV battery, c€/kWh; 0 = disabled)
+  evSocValue_cents_per_kWh: number;
+
   // Initial state
   initialSoc_percent: number;
 

--- a/tests/api/services/config-builder.test.js
+++ b/tests/api/services/config-builder.test.js
@@ -165,19 +165,35 @@ describe('buildSolverConfigFromSettings — EV config', () => {
     expect(cfg.ev.evChargeEfficiency_percent).toBe(85);
   });
 
-  it('does not add ev when departure is in the past (D=0)', () => {
+  // When there is no usable departure (past or unparseable), the EV is still modeled so an
+  // EV SoC valuation can drive charging, but with no enforced target: evDepartureSlot is set
+  // beyond the horizon (T+1 = 97) so c_ev_target is skipped, and the target is 0.
+  it('models ev without a target when departure is in the past (D=0)', () => {
     const pastDeparture = { ...evSettings, evDepartureTime: '2024-01-01T11:00:00Z' };
     const cfg = buildSolverConfigFromSettings(
       pastDeparture, makeData(), NOW_MS, { pluggedIn: true, soc_percent: 50 },
     );
-    expect(cfg.ev).toBeUndefined();
+    expect(cfg.ev).toBeDefined();
+    expect(cfg.ev.evDepartureSlot).toBe(97); // T + 1, beyond the 96-slot horizon
+    expect(cfg.ev.evTargetSoc_percent).toBe(0);
+    expect(cfg.ev.evInitialSoc_percent).toBe(50);
   });
 
-  it('does not add ev when departure string is not a valid date', () => {
+  it('models ev without a target when departure string is not a valid date', () => {
     const badDeparture = { ...evSettings, evDepartureTime: '07:30' };
     const cfg = buildSolverConfigFromSettings(
       badDeparture, makeData(), NOW_MS, { pluggedIn: true, soc_percent: 50 },
     );
-    expect(cfg.ev).toBeUndefined();
+    expect(cfg.ev).toBeDefined();
+    expect(cfg.ev.evDepartureSlot).toBe(97);
+    expect(cfg.ev.evTargetSoc_percent).toBe(0);
+  });
+
+  it('passes evSocValue_cents_per_kWh through to the solver config', () => {
+    const cfg = buildSolverConfigFromSettings(
+      { ...evSettings, evSocValue_cents_per_kWh: 15 },
+      makeData(), NOW_MS, { pluggedIn: true, soc_percent: 50 },
+    );
+    expect(cfg.evSocValue_cents_per_kWh).toBe(15);
   });
 });

--- a/tests/lib/build-lp.test.js
+++ b/tests/lib/build-lp.test.js
@@ -253,4 +253,23 @@ describe('buildLP — EV charging (MILP)', () => {
     const lp = buildLP({ ...base, ev: { ...evCfg, evChargeEfficiency_percent: 100 } });
     expect(lp).toMatch(/c_ev_soc_0:.*0\.25 grid_to_ev_0/);
   });
+
+  it('values terminal EV SoC in the objective when evSocValue_cents_per_kWh > 0', () => {
+    // 20 c€/kWh → 0.02 c€/Wh, no discharge-efficiency factor; valued at the last slot (T-1=4)
+    const lp = buildLP({ ...base, ev: evCfg, evSocValue_cents_per_kWh: 20 });
+    const objLine = lp.split('\n').find((l) => l.trim().startsWith('obj:'));
+    expect(objLine).toMatch(/- 0\.02 ev_soc_4\b/);
+  });
+
+  it('does not value EV SoC when evSocValue_cents_per_kWh is 0', () => {
+    const lp = buildLP({ ...base, ev: evCfg, evSocValue_cents_per_kWh: 0 });
+    // ev_soc_t still appears in constraints; assert only the objective has no valuation term.
+    const objLine = lp.split('\n').find((l) => l.trim().startsWith('obj:'));
+    expect(objLine).not.toContain('ev_soc_');
+  });
+
+  it('does not value EV SoC when ev is not configured', () => {
+    const lp = buildLP({ ...base, evSocValue_cents_per_kWh: 20 });
+    expect(lp).not.toContain('ev_soc_');
+  });
 });


### PR DESCRIPTION
This pull request adds a configurable valuation for energy stored in the EV battery, so the optimizer charges the EV when electricity is cheap rather than only to meet a departure target or when prices go negative.

A single numeric setting `evSocValue_cents_per_kWh` (0 = disabled) is added to the EV tab. In the LP objective it values `ev_soc(T-1)` (end of horizon), mirroring the home battery's terminal SoC term but **without** a discharge-efficiency factor, since EV energy is consumed as driving fuel rather than discharged back to the house.

To make this work without a deadline, the EV is now modeled whenever it is plugged in (previously only when a future departure existed). With no/past departure it is built with no enforced target (`evDepartureSlot = T+1`, `evTargetSoc_percent = 0`), so charging is driven purely by the valuation.

**Manual testing instructions**
- In the EV tab, set "SoC value" to a number above expected market prices with the EV plugged in and no departure set, run a plan → EV charges in the cheapest slots (it stayed off before).
- Set "SoC value" back to 0 → EV charging stops when there is no target/departure.

<details>
<summary>Solver verification (HiGHS, synthetic 8-slot case)</summary>

Prices cheap (5) in slots 0-2, expensive (30) in slots 3-7; valuation 20 c€/kWh; no departure target.

- `evSocValue = 0` → EV charge total = 0 W (energy worthless, nothing forced).
- `evSocValue = 20` → charges from grid at max in the price-5 slots (value 20 > 5), and not via grid in the price-30 slots (value 20 < 30).
</details>

**Checklist**
- Tests: added build-lp objective assertions (term present/absent, no efficiency factor) and config-builder tests for the no/past-departure path and valuation pass-through. All 372 tests pass; typecheck and lint clean.
- Docs: n/a
- Announcement: 🚀 You can now assign a value to energy in your EV battery so it charges automatically when electricity is cheap
- AI: Claude Code implemented the full feature, human reviewed
