### PR TITLE
Make EV ready-by, target SoC, and SoC value fields pinnable

### DIFF
--- a/app/src/optimizer-quick-settings.js
+++ b/app/src/optimizer-quick-settings.js
@@ -22,6 +22,11 @@ export const QUICK_SETTING_DEFS = [
   { id: "evMaxChargeCurrent_A", selector: "#ev-max-charge-current", label: "EV max current (A)", kind: "number" },
   { id: "evBatteryCapacity_kWh", selector: "#ev-battery-capacity", label: "EV capacity (kWh)", kind: "number" },
   { id: "evChargeEfficiency_percent", selector: "#ev-charge-efficiency", label: "EV efficiency (%)", kind: "number" },
+  // These EV inputs sit in a button/unit group on the EV tab; mirrorClass drops the
+  // adjacency classes (rounded-r-none, border-r-0, pr-16) so the standalone clone renders cleanly.
+  { id: "evDepartureTime", selector: "#ev-departure-time", label: "EV ready by", kind: "datetime", mirrorClass: "form-input" },
+  { id: "evTargetSoc_percent", selector: "#ev-target-soc", label: "EV target SoC (%)", kind: "number", mirrorClass: "form-input" },
+  { id: "evSocValue_cents_per_kWh", selector: "#ev-soc-valuation", label: "EV SoC value (c€/kWh)", kind: "number", mirrorClass: "form-input" },
 ];
 
 const FIELD_LABEL_CLASS = "block text-xs font-medium text-slate-400 dark:text-slate-500 mb-1 tracking-wide";
@@ -180,6 +185,7 @@ function createMirrorField(state, def, source) {
   mirror.id = `optimizer-quick-${def.id}`;
   mirror.removeAttribute("name");
   mirror.dataset.optimizerQuickMirror = def.id;
+  if (def.mirrorClass) mirror.className = def.mirrorClass;
   syncControl(source, mirror);
 
   mirror.addEventListener(inputEventName(mirror), () => {

--- a/tests/app/optimizer-quick-settings.test.js
+++ b/tests/app/optimizer-quick-settings.test.js
@@ -9,6 +9,7 @@ const definitions = [
   { id: 'minSoc_percent', selector: '#minsoc', label: 'Min SoC (%)', kind: 'number' },
   { id: 'mode', selector: '#mode', label: 'Mode', kind: 'select' },
   { id: 'blockFeedInOnNegativePrices', selector: '#block-feedin-negative-prices', label: 'Block feed-in', kind: 'checkbox' },
+  { id: 'evTargetSoc_percent', selector: '#ev-target-soc', label: 'EV target SoC (%)', kind: 'number', mirrorClass: 'form-input' },
 ];
 
 function setupDom(selection = '[]') {
@@ -30,6 +31,13 @@ function setupDom(selection = '[]') {
       <input id="block-feedin-negative-prices" type="checkbox" />
       <span class="toggle-knob"></span>
       <span>Block feed-in</span>
+    </label>
+    <label class="block text-sm">
+      <span>EV target SoC (%)</span>
+      <div class="flex mt-1">
+        <input id="ev-target-soc" type="number" class="form-input flex-1 min-w-0 !mt-0 !rounded-r-none !border-r-0" value="80" />
+        <button id="ev-target-soc-quick-set" type="button"></button>
+      </div>
     </label>
   `;
 
@@ -147,6 +155,21 @@ describe('optimizer quick settings', () => {
     expect(controller.getSelectedIds()).toEqual(['minSoc_percent']);
     expect(JSON.parse(els.selectionInput.value)).toEqual(['minSoc_percent']);
     expect(els.body.querySelector('#optimizer-quick-missing')).toBeNull();
+  });
+
+  it('applies mirrorClass to the cloned mirror, dropping source adjacency classes', () => {
+    const els = setupDom('["evTargetSoc_percent"]');
+    initOptimizerQuickSettings({ ...els, definitions });
+
+    const mirror = document.querySelector('#optimizer-quick-evTargetSoc_percent');
+    expect(mirror.className).toBe('form-input');
+    expect(mirror.classList.contains('!rounded-r-none')).toBe(false);
+
+    // Pin button still lives on the source label, and two-way sync still works.
+    expect(document.querySelector('[data-quick-setting-pin="evTargetSoc_percent"]')).toBeTruthy();
+    mirror.value = '90';
+    mirror.dispatchEvent(new Event('input', { bubbles: true }));
+    expect(document.querySelector('#ev-target-soc').value).toBe('90');
   });
 
   it('parses JSON and comma-separated selection values', () => {


### PR DESCRIPTION
## Summary
Adds the three EV-tab fields — **Ready by**, **Target SoC**, and **SoC value** — to the optimizer quick-settings, so they can be pinned to the optimizer page exactly like the existing settings-page fields.

The quick-settings mechanism is fully DOM-driven: each `QUICK_SETTING_DEFS` entry maps a settings key to a source selector, installs a pin toggle on that control's label, and clones the input as a live two-way mirror on the optimizer page. This change just adds three defs.

## Changes
- `app/src/optimizer-quick-settings.js`
  - Add 3 EV defs (`evDepartureTime`, `evTargetSoc_percent`, `evSocValue_cents_per_kWh`) using their existing settings keys as ids.
  - Add an optional `mirrorClass` field. The EV inputs carry adjacency classes (`!rounded-r-none`, `!border-r-0`, `pr-16`) meant for their on-page quick-set buttons / unit suffix; without this, the standalone clone renders with a broken right edge. `mirrorClass: "form-input"` resets the clone to a clean control.
- `tests/app/optimizer-quick-settings.test.js`
  - Add a test verifying `mirrorClass` is applied (dropping adjacency classes) while the pin button and two-way sync still work.

Pinned fields persist via the existing `optimizerQuickSettings` selection (saved/restored in `state.js`), so no settings plumbing changes were needed.

## Verification
- `npm run lint` — clean
- `npm run typecheck` — clean
- `npm run test:run` — 373/373 pass

## Notes
Based on `feature/ev-soc-valuation` (not yet merged to `main`), since it builds on that branch's EV SoC valuation field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)