### PR TITLE
Count EV grid flows in DESS tipping-point logic

### DIFF
--- a/lib/dess-mapper.ts
+++ b/lib/dess-mapper.ts
@@ -66,6 +66,7 @@ export function mapRowsToDess(rows: PlanRow[], cfg: SolverConfig, options: DessM
     const pv2g = row.pv2g;
     const b2l = row.b2l;
     const b2g = row.b2g;
+    const g2ev = row.g2ev ?? 0;
 
     // Flow booleans
     const hasG2L = g2l > FLOW_EPSILON_W;
@@ -103,7 +104,7 @@ export function mapRowsToDess(rows: PlanRow[], cfg: SolverConfig, options: DessM
       // This means we'll want to use the grid as much as possible and store PV in the battery.
       // So we set pro-battery (and a target SoC that's higher than current SoC)
       strategy = Strategy.proBattery;
-      if (g2l + g2b >= cfg.maxGridImport_W - FLOW_EPSILON_W) {
+      if (g2l + g2b + g2ev >= cfg.maxGridImport_W - FLOW_EPSILON_W) {
         // Grid import is at (or very close to) max capacity.
         // We want to make sure to charge at max speed, even if the load would be lower than expected.
         // So we artificially increase the target SoC.
@@ -219,11 +220,20 @@ function aggregateSegmentPrice(
 
 /**
  * We want to find the tipping point price where battery usage is favored over grid usage.
- * Within the given segment, we look for grid→load flows and keep track of the highest price observed during these flows.
+ * Within the given segment, we look for grid flows that serve demand the battery could have
+ * served instead — grid→load or grid→EV — and keep the highest price observed while the
+ * battery still had discharge headroom. (Grid charging the EV at a high price while the
+ * battery could have supplied it is the same revealed-marginal-value signal as grid→load.)
  */
 function findHighestGridUsageCost(rows: PlanRow[], segment: Segment | null, cfg: SolverConfig): number {
   const maxDischarge = cfg.maxDischargePower_W - FLOW_EPSILON_W;
-  return aggregateSegmentPrice(rows, segment, r => r.g2l > FLOW_EPSILON_W && r.b2l + (r.b2ev ?? 0) < maxDischarge, r => r.ic, 'max');
+  return aggregateSegmentPrice(
+    rows,
+    segment,
+    r => (r.g2l > FLOW_EPSILON_W || (r.g2ev ?? 0) > FLOW_EPSILON_W) && r.b2l + (r.b2ev ?? 0) < maxDischarge,
+    r => r.ic,
+    'max',
+  );
 }
 
 /**

--- a/tests/lib/dess-mapper.test.js
+++ b/tests/lib/dess-mapper.test.js
@@ -368,6 +368,30 @@ describe('Tipping Point Calculations', () => {
     expect(result.diagnostics.gridBatteryTippingPoint_cents_per_kWh).toBe(40);
   });
 
+  it('should include grid->EV usage in the Grid Battery Tipping Point', () => {
+    const rows = [
+      createRow({ soc_percent: 50, g2ev: 100, ic: 45 }), // Grid charges EV at 45c, battery idle (headroom)
+      createRow({ soc_percent: 50, g2l: 100, ic: 30 }),  // Grid->load at 30c
+    ];
+
+    const result = mapRowsToDess(rows, mockCfg);
+    // Charging the EV from grid at 45c while the battery could have supplied it is the same
+    // signal as grid->load, so it sets the tipping point.
+    expect(result.diagnostics.gridBatteryTippingPoint_cents_per_kWh).toBe(45);
+  });
+
+  it('should ignore grid->EV when battery discharge is power-maxed', () => {
+    const rows = [
+      // EV pulls from grid at 99c, but the battery is already discharging at max (1000W),
+      // so it could not have supplied the EV — this slot must not count.
+      createRow({ soc_percent: 50, g2ev: 100, ic: 99, b2ev: 1000 }),
+      createRow({ soc_percent: 50, g2l: 100, ic: 30 }), // grid->load at 30c, battery has headroom
+    ];
+
+    const result = mapRowsToDess(rows, mockCfg);
+    expect(result.diagnostics.gridBatteryTippingPoint_cents_per_kWh).toBe(30);
+  });
+
   it('should return -Infinity for Grid Battery Tipping Point if no grid usage occurs', () => {
     const rows = [
       createRow({ soc_percent: 50, g2l: 0, ic: 40 }),
@@ -424,6 +448,16 @@ describe('mapRowsToDessV2', () => {
     const rows = [
       makeRow({ g2b: 100, ic: 15, soc_percent: 50 }),
       makeRow({ ic: 10, ec: 5, soc_percent: 50, g2l: 1000, g2b: 4000 }), // g2l+g2b = 5000 = maxGridImport
+    ];
+    const { perSlot } = mapRowsToDessV2(rows, cfg);
+    expect(perSlot[1].socTarget_percent).toBe(55); // 50 + 5
+  });
+
+  it('counts grid->EV toward grid-import saturation for the +5% SoC boost', () => {
+    const rows = [
+      makeRow({ g2b: 100, ic: 15, soc_percent: 50 }),
+      // g2l+g2b alone = 2000 (< 5000), but adding g2ev=3000 reaches the 5000 import cap.
+      makeRow({ ic: 10, ec: 5, soc_percent: 50, g2b: 2000, g2ev: 3000 }),
     ];
     const { perSlot } = mapRowsToDessV2(rows, cfg);
     expect(perSlot[1].socTarget_percent).toBe(55); // 50 + 5


### PR DESCRIPTION
The DESS mapper derives "tipping point" prices from the solved plan's per-slot flows. `findHighestGridUsageCost` finds the highest grid price at which we served demand from the grid while the battery still had discharge headroom, revealing the battery's marginal value. It already counted `b2ev` in the headroom check, but its trigger was `g2l` only: a slot where the grid charges the EV (`g2ev`) at a high price while the battery could have supplied it instead is the same signal, yet it was ignored. This helper is not display-only, it drives the proBattery/selfConsumption strategy choice, so under-counting biased real DESS decisions when the EV charged from the grid. Separately, the "is grid import saturated?" check omitted `g2ev`, so EV grid-charging that consumes import capacity could slip past the +5% target-SoC boost.

This PR:
- Triggers `findHighestGridUsageCost` on grid->load **or** grid->EV, keeping the existing battery power-headroom guard unchanged.
- Includes `g2ev` in the grid-import-saturation check (`g2l + g2b + g2ev >= maxGridImport_W`).

No min-SoC guard is added for forced/empty-battery EV charging: `buildSegments` already re-brackets the analysis at every min/max SoC crossing, and the existing `g2l` path relies on that rather than an explicit guard. Out of scope: the `imp` row field and the other three (display-only) tipping points.

Based on `feature/ev-availability-split`; retarget to `main` once that merges.

**Manual testing instructions**
- With an EV that charges from the grid at a high price while the battery has discharge headroom, confirm the grid/battery tipping point reflects that price (and thus the strategy for unexpected loads).
- With the EV pulling grid power such that `g2l + g2b + g2ev` reaches the import cap, confirm the target SoC gets the +5% boost.

**Checklist**
- Tests: added 3 dess-mapper cases (grid->EV raises the tipping point; ignored when battery discharge is power-maxed; counts toward import-saturation boost). Full suite 422/422, typecheck clean.
- Docs: n/a
- Announcement: 🐛 EV charging from the grid is now factored into the price thresholds that steer battery-vs-grid decisions
- AI: Claude Code investigated, implemented, and tested the fix; human reviewed.