### PR TITLE
Value EV SoC at every departure window, not just the last

### DIFF
--- a/lib/build-lp.ts
+++ b/lib/build-lp.ts
@@ -175,8 +175,10 @@ export function buildLP({
   }
   // EV SoC valuation: the car drives away with whatever energy it holds at each departure, so
   // value the SoC at the last slot of EVERY window (its endSlot - 1), not just the final one.
-  // The SoC chain re-anchors at each window start (resetAt), so these are independent energies —
-  // valuing only the last window would leave earlier windows' pre-departure charging unrewarded.
+  // Valuing only the last window would leave earlier windows' pre-departure charging unrewarded.
+  // This assumes every window carries resetSoc_Wh (ev-config-builder always sets it), making the
+  // windows' energies independent. A reset-less window would continue the previous chain, and
+  // valuing both window ends would then double-count the energy charged before the gap.
   if (evActive && evTerminalPrice_cents_per_Wh > 0) {
     for (const w of evWindows) {
       objTerms.push(` - ${toNum(evTerminalPrice_cents_per_Wh)} ${evSocVar(w.endSlot - 1)}`);

--- a/lib/build-lp.ts
+++ b/lib/build-lp.ts
@@ -116,7 +116,6 @@ export function buildLP({
   for (const w of evWindows) for (let t = w.startSlot; t < w.endSlot; t++) evAvailable[t] = true;
   const evResetAt = new Map<number, number>();
   for (const w of evWindows) if (w.resetSoc_Wh != null) evResetAt.set(w.startSlot, w.resetSoc_Wh);
-  const evLastAvailableSlot = evAvailable.lastIndexOf(true);
   // SoC deadlines, clamped to in-horizon slots and to battery capacity.
   const evTargets = (ev?.targets ?? [])
     .filter((tg) => tg.slot >= 0 && tg.slot < T)
@@ -174,11 +173,14 @@ export function buildLP({
   if (terminalPrice_cents_per_Wh > 0) {
     objTerms.push(` - ${toNum(terminalPrice_cents_per_Wh)} ${soc(T - 1)}`);
   }
-  // EV SoC valuation: value energy left in the EV battery at the last slot it is available.
-  // (SoC is held flat after the last window, so this equals the horizon-end SoC today, but
-  // valuing the last available slot is correct once multiple windows exist.)
-  if (evActive && evTerminalPrice_cents_per_Wh > 0 && evLastAvailableSlot >= 0) {
-    objTerms.push(` - ${toNum(evTerminalPrice_cents_per_Wh)} ${evSocVar(evLastAvailableSlot)}`);
+  // EV SoC valuation: the car drives away with whatever energy it holds at each departure, so
+  // value the SoC at the last slot of EVERY window (its endSlot - 1), not just the final one.
+  // The SoC chain re-anchors at each window start (resetAt), so these are independent energies —
+  // valuing only the last window would leave earlier windows' pre-departure charging unrewarded.
+  if (evActive && evTerminalPrice_cents_per_Wh > 0) {
+    for (const w of evWindows) {
+      objTerms.push(` - ${toNum(evTerminalPrice_cents_per_Wh)} ${evSocVar(w.endSlot - 1)}`);
+    }
   }
   // Rebalancing symmetry-breaking: escalating penalty prefers earlier windows when cost-equivalent.
   if (D > 0) {

--- a/tests/lib/build-lp.test.js
+++ b/tests/lib/build-lp.test.js
@@ -275,6 +275,26 @@ describe('buildLP — EV charging (MILP)', () => {
     expect(objLine).not.toMatch(/ev_soc_4\b/);
   });
 
+  it('values the last slot of every window when multiple windows exist', () => {
+    // Windows [0,2) and [3,5): the car drives away at slot 2 and again (or stays) at the end,
+    // so both ev_soc_1 and ev_soc_4 must be valued — not only the final window's slot.
+    const lp = buildLP({
+      ...base,
+      ev: {
+        ...evCfg,
+        availabilityWindows: [
+          { startSlot: 0, endSlot: 2, resetSoc_Wh: 30000 },
+          { startSlot: 3, endSlot: 5, resetSoc_Wh: 30000 },
+        ],
+        targets: [],
+      },
+      evSocValue_cents_per_kWh: 20,
+    });
+    const objLine = lp.split('\n').find((l) => l.trim().startsWith('obj:'));
+    expect(objLine).toMatch(/- 0\.02 ev_soc_1\b/);
+    expect(objLine).toMatch(/- 0\.02 ev_soc_4\b/);
+  });
+
   it('omits the EV SoC valuation term when no slot is available', () => {
     const lp = buildLP({
       ...base,

--- a/tests/lib/ev-departure-integration.test.js
+++ b/tests/lib/ev-departure-integration.test.js
@@ -65,6 +65,37 @@ describe('EV charging stops at departure (end-to-end)', () => {
     expect(rows[T - 1].ev_soc_percent).toBeCloseTo(rows[2].ev_soc_percent, 6);
   });
 
+  it('values energy at every departure, charging in an earlier window even when a later one exists', () => {
+    // Plugged in now, leaves at slot 3, returns at slot 5 and stays to the horizon end.
+    // Each departure takes energy away, so the SoC valuation must reward charging in BOTH
+    // windows — not only the last one. Regression for: adding a later arrival made the
+    // first window's charging disappear (only ev_soc_lastAvailableSlot was valued).
+    const cfg = {
+      ...baseCfg,
+      ev: {
+        evMinChargePower_W: 1380,
+        evMaxChargePower_W: 3680,
+        evBatteryCapacity_Wh: 60000,
+        evInitialSoc_percent: 50,
+        evChargeEfficiency_percent: 100,
+        availabilityWindows: [
+          { startSlot: 0, endSlot: 3, resetSoc_Wh: 30000 }, // plugged in now, leaves at slot 3
+          { startSlot: 5, endSlot: T, resetSoc_Wh: 30000 }, // returns at slot 5, stays plugged in
+        ],
+        targets: [],
+      },
+    };
+    const result = highs.solve(buildLP(cfg), {});
+    const rows = parseSolution(result, cfg, { startMs: 0, stepMin: 15 });
+
+    // Charges in the first window (before the morning departure)...
+    expect(rows.slice(0, 3).some((r) => r.ev_charge > 0)).toBe(true);
+    // ...stays off while away...
+    for (let t = 3; t < 5; t++) expect(rows[t].ev_charge).toBe(0);
+    // ...and charges again in the second window.
+    expect(rows.slice(5, T).some((r) => r.ev_charge > 0)).toBe(true);
+  });
+
   it('keeps charging after an early target deadline when the car stays plugged in', () => {
     const cfg = {
       ...baseCfg,


### PR DESCRIPTION
## What

The EV SoC valuation term in the LP objective rewarded the energy left in the EV battery only at the **last slot the car is available**. With multiple availability windows the SoC chain re-anchors at each window start (`resetAt`), so each window's pre-departure energy is independent. Valuing only the final window left earlier windows' charging unrewarded — the optimizer would skip charging before an earlier departure whenever a later window existed.

This values the SoC at the last slot of **every** window (`endSlot - 1`) instead.

## Tests

- `build-lp.test.js` — asserts the objective contains valuation terms for both windows' last slots when multiple windows exist.
- `ev-departure-integration.test.js` — end-to-end solve proving the car charges in an early window, stays off while away, and charges again in the later window.

## Note

⚠️ **Stacked on `fix/ev-flows-in-tipping-points`** (#126) — this fix depends on the availability-windows structures introduced there, so it targets that branch as its base. Merge/rebase onto `main` after #126 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)