### PR TITLE
Fixes from code review

### DIFF
--- a/api/services/config-builder.ts
+++ b/api/services/config-builder.ts
@@ -70,7 +70,9 @@ export function buildSolverConfigFromSettings(
     terminalSocValuation:                 settings.terminalSocValuation,
     terminalSocCustomPrice_cents_per_kWh: settings.terminalSocCustomPrice_cents_per_kWh,
     evSocValue_cents_per_kWh:             settings.evSocValue_cents_per_kWh,
-    initialSoc_percent:                   data.soc.value,
+    // Clamp to maxSoc: a battery fuller than the configured ceiling (e.g. after lowering
+    // maxSoc) would otherwise force an infeasible one-slot discharge in the LP.
+    initialSoc_percent:                   Math.min(data.soc.value, settings.maxSoc_percent),
   };
 
   if (settings.rebalanceEnabled) {

--- a/api/services/mqtt-service.ts
+++ b/api/services/mqtt-service.ts
@@ -56,21 +56,24 @@ export async function readVictronSocLimits({ timeoutMs }: { timeoutMs?: number }
  *
  * rows: optimizer rows with DESS slot data
  * slotCount: how many slots to push (starting from rows[0])
+ * stepSeconds: slot duration; falls back to the row spacing (needs >= 2 rows) when omitted.
  */
-export async function setDynamicEssSchedule(rows: PlanRowWithDess[], slotCount: number): Promise<{ serial: string; slotsWritten: number }> {
+export async function setDynamicEssSchedule(rows: PlanRowWithDess[], slotCount: number, stepSeconds?: number): Promise<{ serial: string; slotsWritten: number }> {
   const client = getVictronClient();
   const serial = await client.getSerial();
 
   const nSlots = Math.min(slotCount, rows.length);
   const tasks = [];
-  const stepSeconds = (rows[1].timestampMs - rows[0].timestampMs) / 1000;
+  // Prefer the explicit slot duration; only fall back to the row delta when there are
+  // >= 2 rows, so a single-slot plan (end of the data horizon) doesn't crash on rows[1].
+  const slotSeconds = stepSeconds ?? (rows.length >= 2 ? (rows[1].timestampMs - rows[0].timestampMs) / 1000 : 900);
 
   for (let i = 0; i < nSlots; i += 1) {
     const row = rows[i];
 
     const slot = {
       startEpoch: Math.round(row.timestampMs / 1000),
-      durationSeconds: stepSeconds,
+      durationSeconds: slotSeconds,
       strategy: row.dess.strategy,
       flags: row.dess.flags,
       socTarget: Math.round(row.dess.socTarget_percent),

--- a/api/services/planner-service.ts
+++ b/api/services/planner-service.ts
@@ -191,17 +191,22 @@ export async function computePlan({ updateData = false } = {}): Promise<ComputeP
   return lastPlan;
 }
 
-export async function writePlanToVictron(rows: PlanRowWithDess[]): Promise<void> {
-  await setDynamicEssSchedule(rows, Math.min(DESS_SLOTS, rows.length));
+export async function writePlanToVictron(rows: PlanRowWithDess[], stepMin: number): Promise<void> {
+  await setDynamicEssSchedule(rows, Math.min(DESS_SLOTS, rows.length), stepMin * 60);
 }
 
 export async function planAndMaybeWrite({
   updateData = false,
   writeToVictron = false,
 } = {}): Promise<ComputePlanResult> {
-  const result = await computePlan({ updateData });
+  const plan = await computePlan({ updateData });
   if (writeToVictron) {
-    await writePlanToVictron(result.rows);
+    // Never push a non-optimal solve to the hardware: infeasible/unbounded solves yield
+    // all-zero (garbage) rows that would otherwise be written as a real schedule.
+    if (plan.result.Status !== 'Optimal') {
+      throw new Error(`Refusing to write schedule to Victron: solver status is "${plan.result.Status ?? 'unknown'}" (expected "Optimal")`);
+    }
+    await writePlanToVictron(plan.rows, plan.timing.stepMin);
   }
-  return result;
+  return plan;
 }

--- a/lib/parse-solution.ts
+++ b/lib/parse-solution.ts
@@ -54,7 +54,7 @@ export function parseSolution(result: HighsSolution, cfg: SolverConfig, opts: Pa
     else if (name.startsWith("pv_to_grid_")) pv2g[t] = v;
     else if (name.startsWith("battery_to_load_")) b2l[t] = v;
     else if (name.startsWith("battery_to_grid_")) b2g[t] = v;
-    else if (name.startsWith("soc_")) soc[t] = v;
+    else if (/^soc_\d+$/.test(name)) soc[t] = v; // exact: must not match soc_shortfall_*
     else if (name.startsWith("grid_to_ev_"))    g2ev[t]  = v;
     else if (name.startsWith("pv_to_ev_"))       pv2ev[t] = v;
     else if (name.startsWith("battery_to_ev_"))  b2ev[t]  = v;

--- a/lib/victron-mqtt.ts
+++ b/lib/victron-mqtt.ts
@@ -67,16 +67,28 @@ export class VictronMqttClient {
 
     const url = `${this.protocol}://${this.host}:${this.port}`;
 
-    this._clientPromise = mqtt.connectAsync(url, {
+    const clientPromise = mqtt.connectAsync(url, {
       username: this.username,
       password: this.password,
       reconnectPeriod: this.reconnectPeriod,
     });
+    this._clientPromise = clientPromise;
 
-    const client = await this._clientPromise;
+    let client: MqttClient;
+    try {
+      client = await clientPromise;
+    } catch (err) {
+      if (this._clientPromise === clientPromise) this._clientPromise = null;
+      throw err;
+    }
 
     client.on('error', (err) => {
       console.error('[victron-mqtt] client error:', err.message);
+    });
+    // With reconnectPeriod 0 the client never reconnects on its own; drop the cached
+    // instance when the connection closes so the next call establishes a fresh one.
+    client.on('close', () => {
+      if (this._clientPromise === clientPromise) this._clientPromise = null;
     });
 
     return client;
@@ -168,6 +180,9 @@ export class VictronMqttClient {
     const wait = this._waitForFirstMessage(
       client,
       (topic, payload) => {
+        // The message handler sees traffic from ALL subscriptions on the shared client,
+        // so only accept messages that actually match the serial wildcard.
+        if (!/^N\/[^/]+\/system\/0\/Serial$/.test(topic)) return undefined;
         // Payload is {"value":"xxxxxxxxx"}
         const obj = JSON.parse(payload.toString()) as { value?: string };
         return obj?.value;

--- a/tests/api/services/planner-service.test.js
+++ b/tests/api/services/planner-service.test.js
@@ -10,7 +10,7 @@ import { loadSettings, saveSettings } from '../../../api/services/settings-store
 import { loadData, saveData } from '../../../api/services/data-store.ts';
 import { refreshSeriesFromVrmAndPersist } from '../../../api/services/vrm-refresh.ts';
 import { setDynamicEssSchedule } from '../../../api/services/mqtt-service.ts';
-import { computePlan } from '../../../api/services/planner-service.ts';
+import { computePlan, planAndMaybeWrite } from '../../../api/services/planner-service.ts';
 import { FeedIn } from '../../../lib/dess-mapper.ts';
 
 const NOW_STRING = '2024-01-01T00:00:00Z';
@@ -131,6 +131,19 @@ describe('computePlan — rebalance bookkeeping', () => {
     const result = await computePlan();
 
     expect(result.rows[0].dess.feedin).toBe(FeedIn.allowed);
+  });
+
+  it('refuses to write to Victron when the solve is not optimal', async () => {
+    loadSettings.mockResolvedValue(baseSettings);
+    // Load far exceeds max grid import + max discharge + PV every slot → infeasible.
+    loadData.mockResolvedValue({
+      ...baseData,
+      load: { start: NOW_STRING, step: 60, values: [50000, 50000, 50000, 50000, 50000] },
+      pv: { start: NOW_STRING, step: 60, values: [0, 0, 0, 0, 0] },
+    });
+
+    await expect(planAndMaybeWrite({ writeToVictron: true })).rejects.toThrow(/solver status/i);
+    expect(setDynamicEssSchedule).not.toHaveBeenCalled();
   });
 
   it('includes original prediction values on rows when manual adjustments changed them', async () => {

--- a/tests/lib/parse-solution.test.js
+++ b/tests/lib/parse-solution.test.js
@@ -38,6 +38,23 @@ describe('parseSolution', () => {
     expect(rows[1].timestampMs).toBe(1700000000000 + 3600000);
   });
 
+  it('does not let soc_shortfall_* columns corrupt soc (regardless of key order)', () => {
+    const result = {
+      Columns: {
+        'soc_0': { Primal: 200 },
+        'soc_1': { Primal: 150 },
+        // Emitted after soc_* here: the old startsWith("soc_") match would clobber soc.
+        'soc_shortfall_0': { Primal: 999 },
+        'soc_shortfall_1': { Primal: 999 },
+      },
+    };
+
+    const rows = parseSolution(result, cfg, opts);
+
+    expect(rows[0].soc).toBe(200);
+    expect(rows[1].soc).toBe(150);
+  });
+
   it('computes per-slot import and export costs', () => {
     const result = {
       Columns: {


### PR DESCRIPTION
This pull request applies fixes from a code review of the solver pipeline and MQTT layer:

- **Clamp initial SoC to maxSoc when building the solver config.** A battery sitting above a freshly lowered `maxSoc` setting would force the LP to discharge the excess within a single slot, making the whole problem infeasible. Clamped at the config boundary so the LP itself is untouched.
- **Fix MQTT serial detection cross-talk.** Serial detection accepted the first message on any topic of the shared client, so a concurrent read (e.g. battery SoC) could permanently cache its value as the portal id, sending all schedule writes to a bogus topic. Now only messages matching `N/<id>/system/0/Serial` are accepted.
- **Recover from dropped MQTT connections.** The cached client promise was never cleared on connect failure or connection close; with `reconnectPeriod 0` every later call then timed out until a process restart. The cached promise is now dropped in both cases so the next call reconnects.
- **Match `soc` columns exactly when parsing the solution.** `startsWith("soc_")` also matched `soc_shortfall_*`, so shortfall values overwrote the real SoC whenever HiGHS emitted them after the `soc_t` columns; it only worked by accident of column ordering. Now matches `/^soc_\d+$/` exactly.
- **Guard Victron writes on solver status and single-slot plans.** Refuse to write a schedule to the hardware unless the solver status is `Optimal` (an infeasible/unbounded solve produces all-zero rows that would otherwise be written as a real schedule). Also pass the slot duration through from the plan timing instead of deriving it from `rows[1]`, which crashed on a single-slot plan at the end of the data horizon.

**Manual testing instructions**
- `npm run test:run`, `npm run typecheck`, `npm run lint` all pass (425 tests)
- With the server running, restart the MQTT broker (or briefly drop the network to the GX device) and trigger a calculate with write: schedule writes should succeed again without restarting the server

🤖 Generated with [Claude Code](https://claude.com/claude-code)