### PR TITLE
Harden plan safety and timeline inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ The **API** exposes:
     }
   }
   ```
-- `POST /calculate` — Builds and solves the LP with **HiGHS** from persisted settings/data. Optional body flags: `updateData` refreshes VRM series before solving, and `writeToVictron` attempts an MQTT DESS schedule write.
+- `POST /calculate` — Builds and solves the LP with **HiGHS** from persisted settings/data. Optional boolean body flags: `updateData` refreshes VRM series before solving, and `writeToVictron` attempts an MQTT DESS schedule write. All input series are resampled onto the configured solver step before solving.
 - `POST /vrm/refresh-settings` — Fetches latest Dynamic ESS limits/settings from VRM and persists.
 - `GET /predictions/config` — Reads prediction configuration plus `isAddon`.
 - `POST /predictions/config` — Saves prediction configuration. Home Assistant URL/token are intentionally stored in `/settings`, not this file.
@@ -200,6 +200,6 @@ The **API** exposes:
 - `POST /predictions/pv/forecast` — Runs the PV forecast when PV configuration is complete.
 - `POST /predictions/forecast` — Runs load and PV forecasts together, persists raw forecasts according to data-source settings, and returns adjusted forecasts.
 - `GET /predictions/forecast/now` — Same combined forecast path with recent comparison disabled.
-- `GET /ev/current` — Current time slot's EV charging decision (`ev_charge_mode`, `ev_charge_A`, source flows, EV SoC).
+- `GET /ev/current` — Current time slot's EV charging decision (`ev_charge_mode`, `ev_charge_A`, source flows, EV SoC). Outside the current plan horizon it returns a fail-safe `off` decision with `plan_valid: false`.
 - `GET /ev/schedule` — Full per-slot EV charging schedule from the last computed plan.
 - `GET /ha/entity/:entityId` — Fetch live entity state from Home Assistant (used to validate EV sensor configuration).

--- a/api/routes/calculate.ts
+++ b/api/routes/calculate.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 import type { Request, Response, NextFunction } from 'express';
-import { toHttpError } from '../http-errors.ts';
+import { assertCondition, toHttpError } from '../http-errors.ts';
 import { planAndMaybeWrite } from '../services/planner-service.ts';
 
 const router = express.Router();
@@ -8,8 +8,16 @@ const router = express.Router();
 router.post('/', async (req: Request, res: Response, next: NextFunction) => {
   try {
     const body = req.body ?? {};
-    const shouldUpdateData = !!body.updateData;
-    const shouldWriteToVictron = !!body.writeToVictron;
+    assertCondition(
+      body && typeof body === 'object' && !Array.isArray(body),
+      400,
+      'calculate payload must be an object',
+    );
+    assertOptionalBoolean(body.updateData, 'updateData');
+    assertOptionalBoolean(body.writeToVictron, 'writeToVictron');
+
+    const shouldUpdateData = body.updateData ?? false;
+    const shouldWriteToVictron = body.writeToVictron ?? false;
 
     logCalculateCall(body, {
       updateData: shouldUpdateData,
@@ -37,6 +45,10 @@ router.post('/', async (req: Request, res: Response, next: NextFunction) => {
     next(toHttpError(error, 500, 'Failed to calculate plan'));
   }
 });
+
+function assertOptionalBoolean(value: unknown, field: string): asserts value is boolean | undefined {
+  assertCondition(value === undefined || typeof value === 'boolean', 400, `${field} must be a boolean`);
+}
 
 function logCalculateCall(rawBody: unknown, parsed: { updateData: boolean; writeToVictron: boolean }): void {
   console.log('[calculate] request', {

--- a/api/routes/ev.ts
+++ b/api/routes/ev.ts
@@ -56,6 +56,30 @@ router.get('/current', (req: Request, res: Response, next: NextFunction) => {
 
     const nowMs = Date.now();
     const rows = plan.rows;
+    if (rows.length === 0) {
+      throw new HttpError(404, 'Computed plan has no slots');
+    }
+
+    const firstSlotMs = rows[0].timestampMs;
+    const planEndMs = rows[rows.length - 1].timestampMs + plan.timing.stepMin * 60_000;
+    if (nowMs < firstSlotMs || nowMs >= planEndMs) {
+      const reason = nowMs < firstSlotMs ? 'before_plan' : 'expired_plan';
+      res.json({
+        timestampMs: null,
+        ev_charge_W: 0,
+        ev_charge_A: 0,
+        ev_charge_mode: 'off',
+        g2ev_W: 0,
+        pv2ev_W: 0,
+        b2ev_W: 0,
+        ev_soc_percent: null,
+        is_charging: false,
+        plan_valid: false,
+        reason,
+      });
+      return;
+    }
+
     let row = rows[0];
     for (let i = rows.length - 1; i >= 0; i--) {
       if (rows[i].timestampMs <= nowMs) {
@@ -74,6 +98,7 @@ router.get('/current', (req: Request, res: Response, next: NextFunction) => {
       b2ev_W: row.b2ev,
       ev_soc_percent: row.ev_soc_percent,
       is_charging: row.ev_charge > 0,
+      plan_valid: true,
     });
   } catch (err) {
     next(err);

--- a/api/services/config-builder.ts
+++ b/api/services/config-builder.ts
@@ -36,8 +36,13 @@ export function buildSolverConfigFromSettings(
   const importEndMs = getSeriesEndMs(data.importPrice);
   const exportEndMs = getSeriesEndMs(data.exportPrice);
   const endMs = Math.min(loadEndMs, pvEndMs, importEndMs, exportEndMs);
+  const stepMs = settings.stepSize_m * 60_000;
+  if (!Number.isFinite(stepMs) || stepMs <= 0) {
+    throw new HttpError(422, 'Invalid solver step size');
+  }
+  const slotCount = Math.floor((endMs - nowMs) / stepMs);
 
-  if (endMs <= nowMs) {
+  if (slotCount <= 0) {
     throw new HttpError(422, 'Insufficient future data', {
       details: {
         now:       new Date(nowMs).toISOString(),
@@ -49,11 +54,13 @@ export function buildSolverConfigFromSettings(
     });
   }
 
+  const alignedEndMs = nowMs + slotCount * stepMs;
+
   const base: SolverConfig = {
-    load_W:      extractWindow(data.load,        nowMs, endMs),
-    pv_W:        extractWindow(data.pv,          nowMs, endMs),
-    importPrice: extractWindow(data.importPrice, nowMs, endMs),
-    exportPrice: extractWindow(data.exportPrice, nowMs, endMs),
+    load_W:      extractWindow(data.load,        nowMs, alignedEndMs, settings.stepSize_m),
+    pv_W:        extractWindow(data.pv,          nowMs, alignedEndMs, settings.stepSize_m),
+    importPrice: extractWindow(data.importPrice, nowMs, alignedEndMs, settings.stepSize_m),
+    exportPrice: extractWindow(data.exportPrice, nowMs, alignedEndMs, settings.stepSize_m),
 
     stepSize_m:                           settings.stepSize_m,
     batteryCapacity_Wh:                   settings.batteryCapacity_Wh,

--- a/lib/time-series-utils.ts
+++ b/lib/time-series-utils.ts
@@ -30,39 +30,51 @@ export interface PredictionResult {
  */
 export function getQuarterStart(date: Date | number | string = new Date(), stepMinutes = 15): number {
   const d = new Date(date);
-  const q = Math.floor(d.getMinutes() / stepMinutes) * stepMinutes;
-  d.setMinutes(q, 0, 0);
-  return d.getTime();
+  const stepMs = stepMinutes * 60 * 1000;
+  if (!Number.isFinite(stepMs) || stepMs <= 0) return NaN;
+  return Math.floor(d.getTime() / stepMs) * stepMs;
 }
 
 /**
- * Extracts a window of data from a source time series to match a target start time.
- * Missing slots are padded with 0.
+ * Resamples a source time series into a target window using overlap-weighted averages.
+ * Missing portions of target slots are padded with 0.
  */
-export function extractWindow(source: TimeSeries, targetStartMs: number, targetEndMs: number): number[] {
+export function extractWindow(
+  source: TimeSeries,
+  targetStartMs: number,
+  targetEndMs: number,
+  targetStepMinutes = source.step || 15,
+): number[] {
   const sourceStartMs = new Date(source.start).getTime();
-  const stepMs = (source.step || 15) * 60 * 1000;
-
-  // Calculate offset in slots
-  // If source starts BEFORE target, offset is positive (we skip some source data)
-  // If source starts AFTER target, offset is negative (we need padding)
-  const offsetMs = targetStartMs - sourceStartMs;
-  const offsetSlots = Math.floor(offsetMs / stepMs);
-
-  const targetDurationMs = targetEndMs - targetStartMs;
-  const targetSlots = Math.floor(targetDurationMs / stepMs);
+  const sourceStepMs = (source.step || 15) * 60 * 1000;
+  const targetStepMs = targetStepMinutes * 60 * 1000;
+  const targetSlots = Math.floor((targetEndMs - targetStartMs) / targetStepMs);
 
   const result: number[] = [];
 
   for (let i = 0; i < targetSlots; i++) {
-    const sourceIndex = offsetSlots + i;
+    const slotStartMs = targetStartMs + i * targetStepMs;
+    const slotEndMs = slotStartMs + targetStepMs;
+    let sourceIndex = Math.max(0, Math.floor((slotStartMs - sourceStartMs) / sourceStepMs));
+    let weightedValue = 0;
 
-    if (sourceIndex >= 0 && sourceIndex < source.values.length) {
-      result.push(source.values[sourceIndex]);
-    } else {
-      // Pad with 0 for missing data
-      result.push(0);
+    while (sourceIndex < source.values.length) {
+      const sourceSlotStartMs = sourceStartMs + sourceIndex * sourceStepMs;
+      const sourceSlotEndMs = sourceSlotStartMs + sourceStepMs;
+      if (sourceSlotStartMs >= slotEndMs) break;
+
+      const overlapMs = Math.max(
+        0,
+        Math.min(slotEndMs, sourceSlotEndMs) - Math.max(slotStartMs, sourceSlotStartMs),
+      );
+      if (overlapMs > 0) {
+        weightedValue += source.values[sourceIndex] * (overlapMs / targetStepMs);
+      }
+      sourceIndex += 1;
     }
+
+    // Uncovered parts of a target slot retain the historical zero-padding behavior.
+    result.push(weightedValue);
   }
 
   return result;

--- a/tests/api/api.test.js
+++ b/tests/api/api.test.js
@@ -34,22 +34,22 @@ const mockData = {
   // 5 hours of data
   load: {
     start: "2024-01-01T00:00:00.000Z",
-    step: 15,
+    step: 60,
     values: [500, 500, 500, 500, 500]
   },
   pv: {
     start: "2024-01-01T00:00:00.000Z",
-    step: 15,
+    step: 60,
     values: [0, 0, 0, 0, 0]
   },
   importPrice: {
     start: "2024-01-01T00:00:00.000Z",
-    step: 15,
+    step: 60,
     values: [10, 10, 10, 10, 10]
   },
   exportPrice: {
     start: "2024-01-01T00:00:00.000Z",
-    step: 15,
+    step: 60,
     values: [5, 5, 5, 5, 5]
   },
   soc: {
@@ -124,5 +124,17 @@ describe('Integration: API', () => {
 
     expect(res.status).toBe(200);
     expect(setDynamicEssSchedule).toHaveBeenCalled();
+  });
+
+  it.each(['updateData', 'writeToVictron'])('rejects non-boolean %s values', async (field) => {
+    vi.useRealTimers();
+    const res = await request(app)
+      .post('/calculate')
+      .send({ [field]: 'false' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe(`${field} must be a boolean`);
+    expect(refreshSeriesFromVrmAndPersist).not.toHaveBeenCalled();
+    expect(setDynamicEssSchedule).not.toHaveBeenCalled();
   });
 });

--- a/tests/api/ev.test.js
+++ b/tests/api/ev.test.js
@@ -92,6 +92,7 @@ describe('GET /ev/current', () => {
     expect(res.body.timestampMs).toBe(START_MS);
     expect(res.body.ev_charge_W).toBe(1380);
     expect(res.body.is_charging).toBe(true);
+    expect(res.body.plan_valid).toBe(true);
   });
 
   it('selects the most recent past slot', async () => {
@@ -104,13 +105,37 @@ describe('GET /ev/current', () => {
     expect(res.body.is_charging).toBe(false);
   });
 
-  it('falls back to rows[0] when all timestamps are in the future', async () => {
+  it('returns a safe off command before the plan starts', async () => {
     getLastPlan.mockReturnValue(mockPlan);
     vi.setSystemTime(START_MS - 10_000); // before all slots
 
     const res = await request(app).get('/ev/current');
 
-    expect(res.body.timestampMs).toBe(START_MS);
+    expect(res.body).toMatchObject({
+      timestampMs: null,
+      ev_charge_W: 0,
+      ev_charge_A: 0,
+      ev_charge_mode: 'off',
+      is_charging: false,
+      plan_valid: false,
+      reason: 'before_plan',
+    });
+  });
+
+  it('returns a safe off command after the plan expires', async () => {
+    getLastPlan.mockReturnValue(mockPlan);
+    vi.setSystemTime(START_MS + 2_700_000);
+
+    const res = await request(app).get('/ev/current');
+
+    expect(res.body).toMatchObject({
+      timestampMs: null,
+      ev_charge_W: 0,
+      ev_charge_mode: 'off',
+      is_charging: false,
+      plan_valid: false,
+      reason: 'expired_plan',
+    });
   });
 });
 

--- a/tests/api/services/config-builder.test.js
+++ b/tests/api/services/config-builder.test.js
@@ -94,6 +94,32 @@ describe('buildSolverConfigFromSettings — rebalancing', () => {
   });
 });
 
+describe('buildSolverConfigFromSettings — timeline normalization', () => {
+  it('resamples mixed source resolutions onto the configured solver step', () => {
+    const data = makeData();
+    data.load = { start: NOW_STRING, step: 60, values: Array(24).fill(400) };
+
+    const cfg = buildSolverConfigFromSettings(mockSettings, data, NOW_MS);
+
+    expect(cfg.load_W).toHaveLength(96);
+    expect(cfg.pv_W).toHaveLength(96);
+    expect(cfg.importPrice).toHaveLength(96);
+    expect(cfg.exportPrice).toHaveLength(96);
+    expect(cfg.load_W.slice(0, 4)).toEqual([400, 400, 400, 400]);
+  });
+
+  it('averages finer source slots when the solver step is coarser', () => {
+    const data = makeData();
+    data.load.values = [100, 200, 300, 400, ...Array(92).fill(0)];
+
+    const cfg = buildSolverConfigFromSettings({ ...mockSettings, stepSize_m: 60 }, data, NOW_MS);
+
+    expect(cfg.load_W[0]).toBe(250);
+    expect(cfg.load_W).toHaveLength(24);
+    expect(cfg.pv_W).toHaveLength(24);
+  });
+});
+
 // EV config (static fields only); schedule comes from data.evScheduleEntries.
 // Detailed EvConfig coverage lives in ev-config-builder.test.js; these are wiring checks.
 const evSettings = {

--- a/tests/lib/time-series-utils.test.js
+++ b/tests/lib/time-series-utils.test.js
@@ -66,6 +66,24 @@ describe('Time Series Utils', () => {
       const result = extractWindow(source, start, end);
       expect(result).toEqual([50, 0, 0]);
     });
+
+    it('repeats coarser source values when resampling to a finer target step', () => {
+      const hourly = {
+        start: new Date(baseTime).toISOString(),
+        step: 60,
+        values: [100, 200],
+      };
+
+      const result = extractWindow(hourly, baseTime, baseTime + 2 * 60 * 60 * 1000, 15);
+
+      expect(result).toEqual([100, 100, 100, 100, 200, 200, 200, 200]);
+    });
+
+    it('averages finer source values when resampling to a coarser target step', () => {
+      const result = extractWindow(source, baseTime, baseTime + 60 * 60 * 1000, 60);
+
+      expect(result).toEqual([25]);
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

Implements findings 1, 2, and 5 from the codebase review:

- return an explicit fail-safe EV `off` decision before or after the cached plan horizon
- reject non-boolean `updateData` and `writeToVictron` values instead of coercing truthy strings
- resample load, PV, and price series onto `settings.stepSize_m` using overlap-weighted averages before building the LP

## Why

The previous EV fallback could expose a charging row outside its valid time window, the calculate route treated the string `"false"` as permission to write to Victron, and mixed source resolutions could either fail with unequal LP arrays or use the wrong energy duration.

## Impact

Valid API callers remain compatible. `GET /ev/current` now includes `plan_valid`; outside the horizon it returns zero power, mode `off`, and a reason. Invalid calculate flag types return HTTP 400. Solver inputs now share one canonical timeline.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run test:run` — 40 files, 433 tests passed
