### PR TITLE
Bound external HTTP requests

### DIFF
--- a/api/services/ha-client.ts
+++ b/api/services/ha-client.ts
@@ -7,6 +7,9 @@
  */
 
 import type { HaReading } from '../../lib/ha-postprocess.ts';
+import { fetchWithTimeout } from '../../lib/fetch-utils.ts';
+
+const HA_ENTITY_TIMEOUT_MS = 5000;
 
 // ----------------------------- REST: entity state -----------------------------
 
@@ -22,6 +25,7 @@ interface FetchHaEntityStateOptions {
   haUrl: string;
   haToken: string;
   entityId: string;
+  timeoutMs?: number;
 }
 
 /**
@@ -44,15 +48,18 @@ export async function fetchHaEntityState({
   haUrl,
   haToken,
   entityId,
+  timeoutMs = HA_ENTITY_TIMEOUT_MS,
 }: FetchHaEntityStateOptions): Promise<HaEntityState> {
   const isAddon = !!process.env.SUPERVISOR_TOKEN;
   const baseUrl = isAddon ? 'http://supervisor/core' : wsUrlToHttp(haUrl);
   const token: string = isAddon ? process.env.SUPERVISOR_TOKEN! : haToken;
 
   const url = `${baseUrl}/api/states/${encodeURIComponent(entityId)}`;
-  const res = await fetch(url, {
-    headers: { Authorization: `Bearer ${token}` },
-  });
+  const res = await fetchWithTimeout(
+    url,
+    { headers: { Authorization: `Bearer ${token}` } },
+    { timeoutMs, label: 'Home Assistant entity request' },
+  );
 
   if (!res.ok) {
     throw new Error(`HA returned ${res.status} for entity "${entityId}"`);

--- a/api/services/open-meteo-client.ts
+++ b/api/services/open-meteo-client.ts
@@ -7,6 +7,9 @@
 
 import { buildArchiveUrl, buildForecastUrl, parseIrradianceResponse, parseForecastResponse } from '../../lib/open-meteo.ts';
 import type { IrradianceRecord } from '../../lib/predict-pv.ts';
+import { fetchWithTimeout } from '../../lib/fetch-utils.ts';
+
+const OPEN_METEO_TIMEOUT_MS = 15000;
 
 /**
  * Fetch historical irradiance data from the Open-Meteo Archive API.
@@ -16,9 +19,14 @@ export async function fetchArchiveIrradiance(
   lon: number,
   startDate: string,
   endDate: string,
+  timeoutMs = OPEN_METEO_TIMEOUT_MS,
 ): Promise<IrradianceRecord[]> {
   const url = buildArchiveUrl({ latitude: lat, longitude: lon, startDate, endDate });
-  const response = await fetch(url);
+  const response = await fetchWithTimeout(
+    url,
+    {},
+    { timeoutMs, label: 'Open-Meteo Archive API request' },
+  );
 
   if (!response.ok) {
     throw new Error(`Open-Meteo Archive API returned status ${response.status}`);
@@ -36,9 +44,14 @@ export async function fetchForecastIrradiance(
   lon: number,
   model?: string,
   resolution: 15 | 60 = 60,
+  timeoutMs = OPEN_METEO_TIMEOUT_MS,
 ): Promise<IrradianceRecord[]> {
   const url = buildForecastUrl({ latitude: lat, longitude: lon, model, pastDays: 1, forecastDays: 2, resolution });
-  const response = await fetch(url);
+  const response = await fetchWithTimeout(
+    url,
+    {},
+    { timeoutMs, label: 'Open-Meteo Forecast API request' },
+  );
 
   if (!response.ok) {
     throw new Error(`Open-Meteo Forecast API returned status ${response.status}`);

--- a/lib/fetch-utils.ts
+++ b/lib/fetch-utils.ts
@@ -27,7 +27,7 @@ export async function fetchWithTimeout(
   try {
     return await fetch(input, { ...init, signal });
   } catch (error) {
-    if (isAbortError(error)) {
+    if (timeoutSignal.aborted && isAbortError(error)) {
       throw new Error(`${label} timed out after ${timeoutMs}ms`, { cause: error });
     }
     throw error;

--- a/lib/fetch-utils.ts
+++ b/lib/fetch-utils.ts
@@ -1,0 +1,35 @@
+export interface FetchTimeoutOptions {
+  timeoutMs: number;
+  label: string;
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && (error.name === 'AbortError' || error.name === 'TimeoutError');
+}
+
+/**
+ * Run a fetch request with a hard deadline and a stable, operation-specific timeout error.
+ */
+export async function fetchWithTimeout(
+  input: Parameters<typeof fetch>[0],
+  init: RequestInit = {},
+  { timeoutMs, label }: FetchTimeoutOptions,
+): Promise<Response> {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    throw new RangeError('timeoutMs must be a positive finite number');
+  }
+
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  const signal = init.signal
+    ? AbortSignal.any([init.signal, timeoutSignal])
+    : timeoutSignal;
+
+  try {
+    return await fetch(input, { ...init, signal });
+  } catch (error) {
+    if (isAbortError(error)) {
+      throw new Error(`${label} timed out after ${timeoutMs}ms`, { cause: error });
+    }
+    throw error;
+  }
+}

--- a/lib/vrm-api.ts
+++ b/lib/vrm-api.ts
@@ -25,10 +25,13 @@ const win = VRMClient.windowLastHourToNextMidnightUTC();
 const forecasts2 = await vrm.fetchForecasts(win);
 ----------------------------------------------------------------------------- */
 
+import { fetchWithTimeout } from './fetch-utils.ts';
+
 interface VRMClientConfig {
   baseURL?: string;
   installationId?: string;
   token?: string;
+  timeoutMs?: number;
 }
 
 interface VRMWindow {
@@ -107,12 +110,14 @@ export class VRMClient {
   installationId: string;
   token: string;
   defaultIntervalMins: number;
+  timeoutMs: number;
 
-  constructor({ baseURL, installationId, token }: VRMClientConfig = {}) {
+  constructor({ baseURL, installationId, token, timeoutMs = 15000 }: VRMClientConfig = {}) {
     this.baseURL = (baseURL || 'https://vrmapi.victronenergy.com').replace(/\/+$/, '') + "/v2";
     this.installationId = installationId || '';
     this.token = token || '';
     this.defaultIntervalMins = 15;
+    this.timeoutMs = timeoutMs;
   }
 
   setAuth({ installationId, token }: { installationId?: string | null; token?: string | null } = {}): void {
@@ -141,7 +146,11 @@ export class VRMClient {
       init.body = JSON.stringify(body);
     }
 
-    const res = await fetch(url.toString(), init);
+    const res = await fetchWithTimeout(
+      url.toString(),
+      init,
+      { timeoutMs: this.timeoutMs, label: 'VRM API request' },
+    );
     if (!res.ok) {
       let txt = '';
       try { txt = await res.text(); } catch { /* ignore */ }

--- a/tests/api/services/ha-client.test.js
+++ b/tests/api/services/ha-client.test.js
@@ -55,7 +55,10 @@ describe('fetchHaEntityState', () => {
     expect(result).toEqual(mockState);
     expect(global.fetch).toHaveBeenCalledWith(
       'http://homeassistant.local:8123/api/states/sensor.ev_battery_level',
-      { headers: { Authorization: 'Bearer test-token' } },
+      {
+        headers: { Authorization: 'Bearer test-token' },
+        signal: expect.any(AbortSignal),
+      },
     );
   });
 
@@ -85,7 +88,23 @@ describe('fetchHaEntityState', () => {
 
     expect(global.fetch).toHaveBeenCalledWith(
       'http://supervisor/core/api/states/sensor.foo',
-      { headers: { Authorization: 'Bearer supervisor-secret' } },
+      {
+        headers: { Authorization: 'Bearer supervisor-secret' },
+        signal: expect.any(AbortSignal),
+      },
     );
+  });
+
+  it('reports a clear timeout error', async () => {
+    global.fetch.mockRejectedValue(new DOMException('timed out', 'TimeoutError'));
+
+    await expect(
+      fetchHaEntityState({
+        haUrl: 'ws://homeassistant.local:8123/api/websocket',
+        haToken: 'test-token',
+        entityId: 'sensor.slow',
+        timeoutMs: 25,
+      }),
+    ).rejects.toThrow('Home Assistant entity request timed out after 25ms');
   });
 });

--- a/tests/api/services/ha-client.test.js
+++ b/tests/api/services/ha-client.test.js
@@ -96,15 +96,17 @@ describe('fetchHaEntityState', () => {
   });
 
   it('reports a clear timeout error', async () => {
-    global.fetch.mockRejectedValue(new DOMException('timed out', 'TimeoutError'));
+    global.fetch.mockImplementation((_input, { signal }) => new Promise((_resolve, reject) => {
+      signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+    }));
 
     await expect(
       fetchHaEntityState({
         haUrl: 'ws://homeassistant.local:8123/api/websocket',
         haToken: 'test-token',
         entityId: 'sensor.slow',
-        timeoutMs: 25,
+        timeoutMs: 5,
       }),
-    ).rejects.toThrow('Home Assistant entity request timed out after 25ms');
+    ).rejects.toThrow('Home Assistant entity request timed out after 5ms');
   });
 });

--- a/tests/api/services/open-meteo-client.test.js
+++ b/tests/api/services/open-meteo-client.test.js
@@ -1,0 +1,37 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  fetchArchiveIrradiance,
+  fetchForecastIrradiance,
+} from '../../../api/services/open-meteo-client.ts';
+
+describe('Open-Meteo HTTP client', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('applies a deadline to archive requests', async () => {
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ hourly: { time: [], shortwave_radiation: [] } }),
+    });
+
+    await fetchArchiveIrradiance(51, 4, '2026-01-01', '2026-01-02', 1234);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('archive-api.open-meteo.com'),
+      { signal: expect.any(AbortSignal) },
+    );
+  });
+
+  it('reports forecast timeouts with operation context', async () => {
+    global.fetch.mockRejectedValue(new DOMException('timed out', 'TimeoutError'));
+
+    await expect(
+      fetchForecastIrradiance(51, 4, undefined, 60, 50),
+    ).rejects.toThrow('Open-Meteo Forecast API request timed out after 50ms');
+  });
+});

--- a/tests/api/services/open-meteo-client.test.js
+++ b/tests/api/services/open-meteo-client.test.js
@@ -28,10 +28,12 @@ describe('Open-Meteo HTTP client', () => {
   });
 
   it('reports forecast timeouts with operation context', async () => {
-    global.fetch.mockRejectedValue(new DOMException('timed out', 'TimeoutError'));
+    global.fetch.mockImplementation((_input, { signal }) => new Promise((_resolve, reject) => {
+      signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+    }));
 
     await expect(
-      fetchForecastIrradiance(51, 4, undefined, 60, 50),
-    ).rejects.toThrow('Open-Meteo Forecast API request timed out after 50ms');
+      fetchForecastIrradiance(51, 4, undefined, 60, 5),
+    ).rejects.toThrow('Open-Meteo Forecast API request timed out after 5ms');
   });
 });

--- a/tests/lib/fetch-utils.test.js
+++ b/tests/lib/fetch-utils.test.js
@@ -26,12 +26,33 @@ describe('fetchWithTimeout', () => {
   });
 
   it('maps aborts to a stable timeout error', async () => {
-    global.fetch.mockRejectedValue(new DOMException('timed out', 'TimeoutError'));
+    global.fetch.mockImplementation((_input, { signal }) => new Promise((_resolve, reject) => {
+      signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+    }));
 
     await expect(fetchWithTimeout('https://example.com', {}, {
-      timeoutMs: 20,
+      timeoutMs: 5,
       label: 'Example request',
-    })).rejects.toThrow('Example request timed out after 20ms');
+    })).rejects.toThrow('Example request timed out after 5ms');
+  });
+
+  it('preserves caller-initiated aborts', async () => {
+    const controller = new AbortController();
+    global.fetch.mockImplementation((_input, { signal }) => new Promise((_resolve, reject) => {
+      signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+    }));
+
+    const request = fetchWithTimeout(
+      'https://example.com',
+      { signal: controller.signal },
+      { timeoutMs: 1000, label: 'Example request' },
+    );
+    controller.abort(new DOMException('Caller cancelled', 'AbortError'));
+
+    await expect(request).rejects.toMatchObject({
+      name: 'AbortError',
+      message: 'Caller cancelled',
+    });
   });
 
   it('preserves non-timeout failures', async () => {

--- a/tests/lib/fetch-utils.test.js
+++ b/tests/lib/fetch-utils.test.js
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchWithTimeout } from '../../lib/fetch-utils.ts';
+
+describe('fetchWithTimeout', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('passes a timeout signal to fetch', async () => {
+    const response = { ok: true };
+    global.fetch.mockResolvedValue(response);
+
+    await expect(fetchWithTimeout('https://example.com', {}, {
+      timeoutMs: 1000,
+      label: 'Example request',
+    })).resolves.toBe(response);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://example.com',
+      { signal: expect.any(AbortSignal) },
+    );
+  });
+
+  it('maps aborts to a stable timeout error', async () => {
+    global.fetch.mockRejectedValue(new DOMException('timed out', 'TimeoutError'));
+
+    await expect(fetchWithTimeout('https://example.com', {}, {
+      timeoutMs: 20,
+      label: 'Example request',
+    })).rejects.toThrow('Example request timed out after 20ms');
+  });
+
+  it('preserves non-timeout failures', async () => {
+    global.fetch.mockRejectedValue(new Error('DNS failed'));
+
+    await expect(fetchWithTimeout('https://example.com', {}, {
+      timeoutMs: 20,
+      label: 'Example request',
+    })).rejects.toThrow('DNS failed');
+  });
+});

--- a/tests/lib/vrm-api.test.js
+++ b/tests/lib/vrm-api.test.js
@@ -1,0 +1,31 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { VRMClient } from '../../lib/vrm-api.ts';
+
+describe('VRMClient HTTP requests', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('applies the configured request deadline', async () => {
+    global.fetch.mockResolvedValue({ ok: true, json: async () => ({ success: true }) });
+    const client = new VRMClient({ installationId: '123', token: 'secret', timeoutMs: 2500 });
+
+    await client._fetch('/test');
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://vrmapi.victronenergy.com/v2/test',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it('reports a clear timeout error', async () => {
+    global.fetch.mockRejectedValue(new DOMException('timed out', 'TimeoutError'));
+    const client = new VRMClient({ installationId: '123', token: 'secret', timeoutMs: 75 });
+
+    await expect(client._fetch('/test')).rejects.toThrow('VRM API request timed out after 75ms');
+  });
+});

--- a/tests/lib/vrm-api.test.js
+++ b/tests/lib/vrm-api.test.js
@@ -23,9 +23,11 @@ describe('VRMClient HTTP requests', () => {
   });
 
   it('reports a clear timeout error', async () => {
-    global.fetch.mockRejectedValue(new DOMException('timed out', 'TimeoutError'));
-    const client = new VRMClient({ installationId: '123', token: 'secret', timeoutMs: 75 });
+    global.fetch.mockImplementation((_input, { signal }) => new Promise((_resolve, reject) => {
+      signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+    }));
+    const client = new VRMClient({ installationId: '123', token: 'secret', timeoutMs: 5 });
 
-    await expect(client._fetch('/test')).rejects.toThrow('VRM API request timed out after 75ms');
+    await expect(client._fetch('/test')).rejects.toThrow('VRM API request timed out after 5ms');
   });
 });


### PR DESCRIPTION
## Summary

Implements finding 10 from the codebase review by adding hard deadlines to every previously unbounded external HTTP request:

- Home Assistant entity REST requests: 5 seconds
- VRM API requests: 15 seconds
- Open-Meteo archive and forecast requests: 15 seconds

A shared `fetchWithTimeout` helper combines an existing abort signal with the deadline, preserves ordinary network failures, and emits operation-specific timeout errors.

## Why

Node's `fetch` has no application-level deadline by default. A stalled VRM, Open-Meteo, or Home Assistant connection could therefore leave API operations pending indefinitely.

## Impact

Successful requests and existing response handling are unchanged. Stalled requests now abort predictably and surface errors such as `VRM API request timed out after 15000ms`. Optional timeout arguments allow deterministic tests and targeted callers without changing existing call sites.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run test:run` — 43 files, 434 tests passed
