### PR TITLE
Extended horizon phase 0: input guards and solver time limit

### DIFF
--- a/api/services/config-builder.ts
+++ b/api/services/config-builder.ts
@@ -36,6 +36,28 @@ export function buildSolverConfigFromSettings(
   const importEndMs = getSeriesEndMs(data.importPrice);
   const exportEndMs = getSeriesEndMs(data.exportPrice);
   const endMs = Math.min(loadEndMs, pvEndMs, importEndMs, exportEndMs);
+
+  // A series that starts after the plan window begins would be silently
+  // zero-padded by extractWindow for the leading slots. Zero PV just means
+  // "no sun yet" and is legitimate (e.g. a forecast that starts at sunrise),
+  // but zero load or zero prices would make the solver plan against free
+  // energy, so reject those outright.
+  const mustCoverStart: Array<[string, TimeSeries]> = [
+    ['load',        data.load],
+    ['importPrice', data.importPrice],
+    ['exportPrice', data.exportPrice],
+  ];
+  for (const [name, series] of mustCoverStart) {
+    const seriesStartMs = new Date(series.start).getTime();
+    if (seriesStartMs > nowMs) {
+      throw new HttpError(422, `Series '${name}' starts after the plan window begins`, {
+        details: {
+          now:         new Date(nowMs).toISOString(),
+          seriesStart: new Date(seriesStartMs).toISOString(),
+        },
+      });
+    }
+  }
   const stepMs = settings.stepSize_m * 60_000;
   if (!Number.isFinite(stepMs) || stepMs <= 0) {
     throw new HttpError(422, 'Invalid solver step size');

--- a/api/services/planner-service.ts
+++ b/api/services/planner-service.ts
@@ -16,6 +16,10 @@ import type { PlanRowWithDess, Data } from '../types.ts';
 
 // How many slots we push into Dynamic ESS
 const DESS_SLOTS = 4;
+// Upper bound on a single HiGHS solve, in seconds. Current ~100-slot MILPs
+// solve well under a second; this only kicks in when something degenerates
+// (or once longer horizons multiply the binary count).
+const SOLVE_TIME_LIMIT_S = 30;
 
 // Lazy, shared HiGHS instance
 type HighsInstance = Awaited<ReturnType<typeof highsFactory>>;
@@ -132,7 +136,12 @@ export async function computePlan({ updateData = false } = {}): Promise<ComputeP
   const lpText = buildLP(cfg);
   const highs = await getHighsInstance();
   const hasBinaries = cfg.ev != null || (cfg.rebalanceRemainingSlots ?? 0) > 0;
-  const solveOptions = hasBinaries ? { mip_rel_gap: 0.005, mip_abs_gap: 0.01 } : {};
+  // The solve runs synchronously on the event loop, so a runaway MIP would
+  // block every HTTP request; the time limit bounds that. A limited solve
+  // comes back with a non-Optimal status and is refused for hardware writes.
+  const solveOptions = hasBinaries
+    ? { mip_rel_gap: 0.005, mip_abs_gap: 0.01, time_limit: SOLVE_TIME_LIMIT_S }
+    : { time_limit: SOLVE_TIME_LIMIT_S };
   let result: ReturnType<typeof highs.solve>;
   const t0 = performance.now();
   try {
@@ -154,6 +163,7 @@ export async function computePlan({ updateData = false } = {}): Promise<ComputeP
     ev: evInfo,
     rebalance: (cfg.rebalanceRemainingSlots ?? 0) > 0,
     solveMs: Math.round(solveMs),
+    status: result.Status,
   });
 
   const rows = attachOriginalPredictionValues(parseSolution(result, cfg, timing), data);

--- a/plans/extended-horizon-plan.md
+++ b/plans/extended-horizon-plan.md
@@ -1,0 +1,89 @@
+# Extended planning horizon
+
+Extend the plan window from the current ~12–36 h (bounded by the VRM day-ahead
+window) to a configurable multi-day horizon, so long-range EV targets ("80% in
+3 days") become real LP constraints instead of manually staged intermediate
+targets.
+
+## Decisions
+
+- **Opt-in setting** `extendedHorizonDays: 0–6`, default `0` = today's
+  behaviour exactly. Resource-constrained devices are unaffected unless they
+  opt in. A `priceForecastUrl` setting (default empty) enables the forecast
+  price source.
+- **15-minute slots for the whole horizon.** ~384 slots at 4 days. Coarser
+  far-out slots are a documented fallback if solve times become a problem, not
+  built now.
+- **Real prices always win.** Forecast values only fill slots beyond the end of
+  the actual price series.
+- **Forecast prices are stored as separate series** and merged at solve time —
+  actuals keep their existing owner and transport (HA push via `POST /data`, or
+  VRM pull), while optivolt itself pulls predictions from `priceForecastUrl`
+  during the `/calculate` update step. Pushing predictions through HA would hit
+  HA's ~16 KB attribute limit and adds automation plumbing for no benefit.
+
+The forecast source is <https://energie.bartm.be/forecast.json> (built in the
+`energieprijs` repo from the hosted EpexPredictor API): 15-minute Belgian spot
+prices ~7 days ahead with the Ecopower formulas applied, plus a `known_until`
+timestamp separating published day-ahead prices from model predictions.
+
+## Phase 0 — Safety groundwork (this branch)
+
+- **Leading-gap guard** in `config-builder.ts`: `extractWindow` zero-pads slots
+  a series doesn't cover. Zero PV is legitimate (no sun yet); zero load or
+  prices would let the solver plan against free energy. Load and price series
+  that start after the plan window now fail with a 422 instead.
+- **Solver time limit**: pass `time_limit` to HiGHS so a degenerate MILP can't
+  block the (synchronous) event loop indefinitely. A limited solve returns a
+  non-Optimal status and is already refused for hardware writes.
+- `status` added to the `[calculate] solve` log line.
+
+## Phase 1 — Server data plumbing
+
+- Settings: `extendedHorizonDays` (0 = off), `priceForecastUrl`.
+- New `price-forecast-service.ts`: fetch and parse `forecast.json`
+  (`consumption_data` → import, `injection_data` → export), persist as
+  `data.importPriceForecast` / `data.exportPriceForecast`. On fetch failure
+  keep the previous forecast; the horizon then shrinks gracefully as it ages.
+- `config-builder.ts`: merge actual + forecast per price series — actual values
+  win wherever both exist, forecast extends the tail. Expose the merge boundary
+  (`pricesKnownUntilMs`) for the UI and diagnostics.
+- Load: extend `getForecastTimeRange` (`lib/time-series-utils.ts`) by
+  `extendedHorizonDays`; the historical predictor itself is unbounded.
+- PV: replace the hardcoded `forecastDays: 2` in `open-meteo-client.ts` with
+  `extendedHorizonDays + 2` (Open-Meteo serves up to 16). For `pv: 'vrm'`,
+  extend `windowOptimizationHorizon` (`lib/vrm-api.ts`) the same way and clamp
+  to what VRM returns.
+- Timestamps in `forecast.json` are Brussels wall-clock; either parse with an
+  explicit timezone or add UTC timestamps to the feed first (preferred).
+- The `min()` horizon rule in `config-builder.ts` stays: with all four series
+  extended it yields the requested horizon and remains the safety net when a
+  source falls short.
+
+## Phase 2 — Solver & EV review
+
+- EV targets need no new code: entries beyond the old horizon stop being
+  filtered by `ev-config-builder.ts` once the horizon covers them.
+- Rebalancing: restrict `start_balance_k` to day-1 slots so "hold once" keeps
+  its current meaning over a multi-day horizon (and caps that binary count).
+- Verify the escalating symmetry-break penalties (`build-lp.ts`) stay
+  numerically sane at ~384 slots.
+
+## Phase 3 — Dashboard
+
+- Dashed price line beyond `pricesKnownUntilMs` (Chart.js `segment.borderDash`)
+  plus a shaded "forecast zone" background.
+- View-range toggle "Standard | Full horizon", defaulting to Standard so the
+  default UX is unchanged; persisted client-side.
+- Hourly aggregation for bar charts in the full-horizon view (sum energy,
+  average power), with a 15 min/1 h toggle; auto-select 1 h beyond ~48 h.
+- Verify multi-day EV annotations (previously skipped beyond the horizon) and
+  add day-collapsible sections to the table.
+
+## Phase 4 — Validation
+
+- Unit tests: merge priority, leading-gap guard, horizon setting variations,
+  multi-day EV targets/windows, day-1 rebalance restriction.
+- Synthetic 4-day solve benchmark before relying on the MILP at ~384 slots.
+- Shadow period: run `extendedHorizonDays: 3` with calculation only (no
+  hardware writes) comparing `solveMs` and plan quality.

--- a/tests/api/services/solver-timeline.test.js
+++ b/tests/api/services/solver-timeline.test.js
@@ -74,4 +74,47 @@ describe('Solver Timeline Logic (Refactored)', () => {
     const configFull = buildSolverConfigFromSettings(mockSettings, longData);
     expect(configFull.load_W.length).toBe(96); // 24h * 4
   });
+
+  it('rejects load and price series that start after the plan window begins', () => {
+    const baseData = {
+      load: { start: '2024-01-01T10:00:00Z', step: 15, values: Array(100).fill(100) },
+      pv: { start: '2024-01-01T10:00:00Z', step: 15, values: Array(100).fill(0) },
+      importPrice: { start: '2024-01-01T10:00:00Z', step: 15, values: Array(100).fill(10) },
+      exportPrice: { start: '2024-01-01T10:00:00Z', step: 15, values: Array(100).fill(5) },
+      soc: { timestamp: '2024-01-01T12:00:00Z', value: 50 }
+    };
+
+    // extractWindow would zero-pad the leading slots of these series, which
+    // for load/prices means planning against free energy.
+    for (const key of ['load', 'importPrice', 'exportPrice']) {
+      const data = {
+        ...baseData,
+        [key]: { ...baseData[key], start: '2024-01-01T12:30:00Z' }, // after now (12:00)
+      };
+      expect(() => buildSolverConfigFromSettings(mockSettings, data))
+        .toThrowError(new RegExp(`'${key}' starts after`));
+    }
+
+    // A series starting exactly at the window start is fine.
+    const exactStart = {
+      ...baseData,
+      importPrice: { ...baseData.importPrice, start: '2024-01-01T12:00:00Z' },
+    };
+    expect(() => buildSolverConfigFromSettings(mockSettings, exactStart)).not.toThrow();
+  });
+
+  it('allows a PV series that starts after the plan window begins (leading zeros = no sun)', () => {
+    const data = {
+      load: { start: '2024-01-01T10:00:00Z', step: 15, values: Array(100).fill(100) },
+      pv: { start: '2024-01-01T14:00:00Z', step: 15, values: Array(84).fill(500) },
+      importPrice: { start: '2024-01-01T10:00:00Z', step: 15, values: Array(100).fill(10) },
+      exportPrice: { start: '2024-01-01T10:00:00Z', step: 15, values: Array(100).fill(5) },
+      soc: { timestamp: '2024-01-01T12:00:00Z', value: 50 }
+    };
+
+    const config = buildSolverConfigFromSettings(mockSettings, data);
+    // Slots between 12:00 and 14:00 are zero-padded PV.
+    expect(config.pv_W.slice(0, 8).every(v => v === 0)).toBe(true);
+    expect(config.pv_W[8]).toBe(500);
+  });
 });


### PR DESCRIPTION
First slice of the extended-horizon work (stacked on `ev-trips`). Full design in `plans/extended-horizon-plan.md`; this PR is Phase 0, safe independently of the rest:

## Changes
- **Leading-gap guard**: `extractWindow` silently zero-pads slots a series doesn't cover. For load and prices that means planning against free electricity, so `config-builder` now rejects those series when they start after the plan window (422 with details). PV is exempt — leading zeros legitimately mean no sun yet.
- **Solver time limit**: `time_limit: 30` passed to HiGHS. The solve runs synchronously on the event loop, so a degenerate MILP (more likely once horizons multiply the binary count) could block every HTTP request indefinitely. Limited solves return non-Optimal and are already refused for hardware writes.
- `status` added to the `[calculate] solve` log line.
- `plans/extended-horizon-plan.md`: the full phased plan (opt-in `extendedHorizonDays` setting, separate forecast price series merged at solve time with real values winning, PV/load horizon extension, dashed forecast styling + hourly bars in the UI).

## Testing
- 490 tests pass, typecheck and lint clean
- New tests: 422 for late-starting load/import/export series, exact-start accepted, late-starting PV zero-padded as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)