### PR TITLE
Extended horizon phase 1: multi-day data plumbing

### DIFF
--- a/api/defaults/default-settings.json
+++ b/api/defaults/default-settings.json
@@ -33,5 +33,7 @@
   "evPlugSensor": "",
   "evChargeEfficiency_percent": 90,
   "evSocValue_cents_per_kWh": 0,
-  "evTripSocBuffer_percent": 20
+  "evTripSocBuffer_percent": 20,
+  "extendedHorizonDays": 0,
+  "priceForecastUrl": ""
 }

--- a/api/services/config-builder.ts
+++ b/api/services/config-builder.ts
@@ -3,7 +3,7 @@ import { loadSettings } from './settings-store.ts';
 import { loadData, saveData } from './data-store.ts';
 import { applyPredictionAdjustmentsToData, pruneExpiredPredictionAdjustments } from './prediction-adjustments.ts';
 import { recordFullSocObservation } from './rebalance-nudge.ts';
-import { extractWindow, getQuarterStart } from '../../lib/time-series-utils.ts';
+import { extractWindow, extendSeriesWithForecast, getQuarterStart } from '../../lib/time-series-utils.ts';
 import { fetchHaEntityState } from './ha-client.ts';
 import { buildEvConfig } from './ev-config-builder.ts';
 import { normalizeEvScheduleEntries, recordEvLastState } from './ev-schedule-entries.ts';
@@ -31,10 +31,24 @@ export function buildSolverConfigFromSettings(
   nowMs = getQuarterStart(new Date(), settings.stepSize_m),
   evState?: { pluggedIn: boolean; soc_percent: number },
 ): SolverConfig {
+  // Extended horizon: append forecast prices past the end of the actual price
+  // series. Actual values always win — the forecast never overrides them, and
+  // pricesKnownUntilMs marks where actuals end so the UI can flag the rest.
+  let importPrice = data.importPrice;
+  let exportPrice = data.exportPrice;
+  let pricesKnownUntilMs: number | undefined;
+  if (settings.extendedHorizonDays > 0) {
+    importPrice = extendSeriesWithForecast(data.importPrice, data.importPriceForecast);
+    exportPrice = extendSeriesWithForecast(data.exportPrice, data.exportPriceForecast);
+    if (importPrice !== data.importPrice || exportPrice !== data.exportPrice) {
+      pricesKnownUntilMs = Math.min(getSeriesEndMs(data.importPrice), getSeriesEndMs(data.exportPrice));
+    }
+  }
+
   const loadEndMs   = getSeriesEndMs(data.load);
   const pvEndMs     = getSeriesEndMs(data.pv);
-  const importEndMs = getSeriesEndMs(data.importPrice);
-  const exportEndMs = getSeriesEndMs(data.exportPrice);
+  const importEndMs = getSeriesEndMs(importPrice);
+  const exportEndMs = getSeriesEndMs(exportPrice);
   const endMs = Math.min(loadEndMs, pvEndMs, importEndMs, exportEndMs);
 
   // A series that starts after the plan window begins would be silently
@@ -44,8 +58,8 @@ export function buildSolverConfigFromSettings(
   // energy, so reject those outright.
   const mustCoverStart: Array<[string, TimeSeries]> = [
     ['load',        data.load],
-    ['importPrice', data.importPrice],
-    ['exportPrice', data.exportPrice],
+    ['importPrice', importPrice],
+    ['exportPrice', exportPrice],
   ];
   for (const [name, series] of mustCoverStart) {
     const seriesStartMs = new Date(series.start).getTime();
@@ -79,10 +93,10 @@ export function buildSolverConfigFromSettings(
   const alignedEndMs = nowMs + slotCount * stepMs;
 
   const base: SolverConfig = {
-    load_W:      extractWindow(data.load,        nowMs, alignedEndMs, settings.stepSize_m),
-    pv_W:        extractWindow(data.pv,          nowMs, alignedEndMs, settings.stepSize_m),
-    importPrice: extractWindow(data.importPrice, nowMs, alignedEndMs, settings.stepSize_m),
-    exportPrice: extractWindow(data.exportPrice, nowMs, alignedEndMs, settings.stepSize_m),
+    load_W:      extractWindow(data.load,   nowMs, alignedEndMs, settings.stepSize_m),
+    pv_W:        extractWindow(data.pv,     nowMs, alignedEndMs, settings.stepSize_m),
+    importPrice: extractWindow(importPrice, nowMs, alignedEndMs, settings.stepSize_m),
+    exportPrice: extractWindow(exportPrice, nowMs, alignedEndMs, settings.stepSize_m),
 
     stepSize_m:                           settings.stepSize_m,
     batteryCapacity_Wh:                   settings.batteryCapacity_Wh,
@@ -103,6 +117,11 @@ export function buildSolverConfigFromSettings(
     // maxSoc) would otherwise force an infeasible one-slot discharge in the LP.
     initialSoc_percent:                   Math.min(data.soc.value, settings.maxSoc_percent),
   };
+
+  // Only meaningful when forecast slots actually made it into the window.
+  if (pricesKnownUntilMs != null && pricesKnownUntilMs < alignedEndMs) {
+    base.pricesKnownUntilMs = pricesKnownUntilMs;
+  }
 
   if (settings.rebalanceEnabled) {
     // Math.ceil ensures the hold is never shorter than requested; Math.max(1, …) prevents 0-slot holds

--- a/api/services/data-store.ts
+++ b/api/services/data-store.ts
@@ -29,6 +29,8 @@ export function validateData(d: Data): Data {
   validateTimeSeries(d.pv, 'pv');
   validateTimeSeries(d.importPrice, 'importPrice');
   validateTimeSeries(d.exportPrice, 'exportPrice');
+  if (d.importPriceForecast !== undefined) validateTimeSeries(d.importPriceForecast, 'importPriceForecast');
+  if (d.exportPriceForecast !== undefined) validateTimeSeries(d.exportPriceForecast, 'exportPriceForecast');
   if (!Number.isFinite(d.soc.value)) {
     throw new Error('Invalid soc: value must be a finite number; refresh VRM data first');
   }

--- a/api/services/load-prediction-service.ts
+++ b/api/services/load-prediction-service.ts
@@ -104,7 +104,7 @@ export async function runForecast(config: PredictionRunConfig): Promise<Forecast
   if (activeType === 'fixed') {
     const load_W = fixedPredictor!.load_W;
     const nowMs = Date.now();
-    const { startIso, endIso } = getForecastTimeRange(nowMs);
+    const { startIso, endIso } = getForecastTimeRange(nowMs, config.extendedHorizonDays ?? 0);
     const startMs = new Date(startIso).getTime();
     const endMs = new Date(endIso).getTime();
     const nSlots = Math.round((endMs - startMs) / (15 * 60 * 1000));
@@ -156,7 +156,7 @@ export async function runForecast(config: PredictionRunConfig): Promise<Forecast
   const data = postprocess(rawData, sensors, derived);
 
   const now = new Date();
-  const { startIso, endIso } = getForecastTimeRange(now.getTime());
+  const { startIso, endIso } = getForecastTimeRange(now.getTime(), config.extendedHorizonDays ?? 0);
   const end = new Date(endIso);
 
   const recentStart = now.getTime() - 7 * 24 * 60 * 60 * 1000;

--- a/api/services/open-meteo-client.ts
+++ b/api/services/open-meteo-client.ts
@@ -38,15 +38,21 @@ export async function fetchArchiveIrradiance(
 
 /**
  * Fetch forecast irradiance data from the Open-Meteo Forecast API.
+ *
+ * The default ICON D2 model only covers ~2 days; for longer windows we fall
+ * back to ICON seamless (D2 → EU → global blend) unless a model is given, so
+ * far-out slots get real irradiance instead of nulls (which parse to 0 W).
  */
 export async function fetchForecastIrradiance(
   lat: number,
   lon: number,
   model?: string,
   resolution: 15 | 60 = 60,
+  forecastDays = 2,
   timeoutMs = OPEN_METEO_TIMEOUT_MS,
 ): Promise<IrradianceRecord[]> {
-  const url = buildForecastUrl({ latitude: lat, longitude: lon, model, pastDays: 1, forecastDays: 2, resolution });
+  const effectiveModel = model ?? (forecastDays > 2 ? 'icon_seamless' : undefined);
+  const url = buildForecastUrl({ latitude: lat, longitude: lon, model: effectiveModel, pastDays: 1, forecastDays, resolution });
   const response = await fetchWithTimeout(
     url,
     {},

--- a/api/services/planner-service.ts
+++ b/api/services/planner-service.ts
@@ -10,6 +10,7 @@ import { saveSettings } from './settings-store.ts';
 import { saveData } from './data-store.ts';
 import { applyPredictionAdjustmentsToData } from './prediction-adjustments.ts';
 import { refreshSeriesFromVrmAndPersist } from './vrm-refresh.ts';
+import { refreshPriceForecastAndPersist } from './price-forecast-service.ts';
 import { setDynamicEssSchedule } from './mqtt-service.ts';
 import { getRebalanceNudge, type RebalanceNudge } from './rebalance-nudge.ts';
 import type { PlanRowWithDess, Data } from '../types.ts';
@@ -118,6 +119,16 @@ export async function computePlan({ updateData = false } = {}): Promise<ComputeP
       console.error(
         'Failed to refresh VRM data before calculation:',
         vrmError instanceof Error ? vrmError.message : String(vrmError),
+      );
+    }
+    try {
+      // No-op unless extendedHorizonDays > 0 and a priceForecastUrl is set.
+      // On failure the previously stored forecast is kept and simply ages out.
+      await refreshPriceForecastAndPersist();
+    } catch (forecastError) {
+      console.error(
+        'Failed to refresh price forecast before calculation:',
+        forecastError instanceof Error ? forecastError.message : String(forecastError),
       );
     }
   }

--- a/api/services/prediction-forecast-runner.ts
+++ b/api/services/prediction-forecast-runner.ts
@@ -12,7 +12,7 @@ import { loadActiveAdjustmentsAndPrune } from './prediction-adjustment-store.ts'
 
 export async function buildPredictionRunConfig(): Promise<PredictionRunConfig> {
   const [config, settings] = await Promise.all([loadPredictionConfig(), loadSettings()]);
-  return { ...config, haUrl: settings.haUrl, haToken: settings.haToken };
+  return { ...config, haUrl: settings.haUrl, haToken: settings.haToken, extendedHorizonDays: settings.extendedHorizonDays };
 }
 
 export async function executePredictionValidation(config: PredictionRunConfig) {

--- a/api/services/price-forecast-service.ts
+++ b/api/services/price-forecast-service.ts
@@ -1,0 +1,152 @@
+/**
+ * price-forecast-service.ts
+ *
+ * Pulls forecast prices from a configured URL (the energieprijs forecast.json
+ * format: EpexPredictor predictions with supplier formulas applied) and
+ * persists them as data.importPriceForecast / data.exportPriceForecast.
+ *
+ * These series never replace actual prices — config-builder only uses them to
+ * extend the tail of the actual price series when the extended horizon is on.
+ */
+
+import { fetchWithTimeout } from '../../lib/fetch-utils.ts';
+import { loadSettings } from './settings-store.ts';
+import { loadData, saveData } from './data-store.ts';
+import type { TimeSeries } from '../types.ts';
+
+const PRICE_FORECAST_TIMEOUT_MS = 15000;
+const FEED_TZ = 'Europe/Brussels';
+const STEP_MINUTES = 15;
+
+interface ForecastFeedPoint {
+  time: string;
+  price: number;
+}
+
+interface ForecastFeed {
+  consumption_data?: ForecastFeedPoint[];
+  injection_data?: ForecastFeedPoint[];
+  known_until?: string;
+}
+
+const tzFormatter = new Intl.DateTimeFormat('en-US', {
+  timeZone: FEED_TZ,
+  year: 'numeric', month: '2-digit', day: '2-digit',
+  hour: '2-digit', minute: '2-digit', second: '2-digit',
+  hour12: false,
+});
+
+/** UTC offset of FEED_TZ at the given instant, in ms. */
+function tzOffsetMs(utcMs: number): number {
+  const parts = tzFormatter.formatToParts(utcMs);
+  const get = (type: string) => Number(parts.find(p => p.type === type)?.value ?? NaN);
+  const wallAsUtc = Date.UTC(
+    get('year'), get('month') - 1, get('day'),
+    get('hour') % 24, get('minute'), get('second'),
+  );
+  return wallAsUtc - utcMs;
+}
+
+/**
+ * Parse a feed timestamp to epoch ms. Timestamps with an explicit offset (or
+ * Z) are parsed directly; bare "YYYY-MM-DD HH:MM:SS" strings are interpreted
+ * as Europe/Brussels wall-clock time.
+ */
+export function parseFeedTimestamp(value: string): number {
+  if (typeof value !== 'string') return NaN;
+  if (/(?:Z|[+-]\d{2}:?\d{2})$/.test(value)) {
+    return new Date(value).getTime();
+  }
+  const m = /^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2}))?$/.exec(value.trim());
+  if (!m) return NaN;
+  const [y, mo, d, h, mi, s] = [Number(m[1]), Number(m[2]), Number(m[3]), Number(m[4]), Number(m[5]), Number(m[6] ?? 0)];
+  // Wall-clock → UTC: guess the offset at the wall time read as UTC, then
+  // re-evaluate once at the corrected instant. This converges except inside a
+  // DST transition, where either candidate is at most an hour off.
+  const wallAsUtc = Date.UTC(y, mo - 1, d, h, mi, s);
+  let ts = wallAsUtc - tzOffsetMs(wallAsUtc);
+  ts = wallAsUtc - tzOffsetMs(ts);
+  return ts;
+}
+
+/**
+ * Convert a list of feed points into a contiguous 15-min TimeSeries.
+ * Points are sorted by time; the series is truncated at the first gap or
+ * non-finite value so a malformed feed can never fabricate prices.
+ */
+export function pointsToSeries(points: ForecastFeedPoint[]): TimeSeries | null {
+  const stepMs = STEP_MINUTES * 60_000;
+  const parsed = points
+    .map(p => ({ timeMs: parseFeedTimestamp(p.time), price: Number(p.price) }))
+    .filter(p => Number.isFinite(p.timeMs))
+    .sort((a, b) => a.timeMs - b.timeMs);
+  if (parsed.length === 0) return null;
+
+  const values: number[] = [];
+  let expectedMs = parsed[0].timeMs;
+  for (const p of parsed) {
+    if (p.timeMs !== expectedMs || !Number.isFinite(p.price)) break;
+    values.push(p.price);
+    expectedMs += stepMs;
+  }
+  if (values.length === 0) return null;
+
+  return {
+    start: new Date(parsed[0].timeMs).toISOString(),
+    step: STEP_MINUTES,
+    values,
+  };
+}
+
+export interface ParsedPriceForecast {
+  importPriceForecast: TimeSeries;
+  exportPriceForecast: TimeSeries;
+  knownUntilMs: number | null;
+}
+
+/** Parse the forecast.json payload; throws when it contains no usable series. */
+export function parsePriceForecastFeed(feed: ForecastFeed): ParsedPriceForecast {
+  const importPriceForecast = pointsToSeries(feed.consumption_data ?? []);
+  const exportPriceForecast = pointsToSeries(feed.injection_data ?? []);
+  if (!importPriceForecast || !exportPriceForecast) {
+    throw new Error('Price forecast feed contains no usable consumption/injection series');
+  }
+  const knownUntilMs = feed.known_until != null ? parseFeedTimestamp(feed.known_until) : NaN;
+  return {
+    importPriceForecast,
+    exportPriceForecast,
+    knownUntilMs: Number.isFinite(knownUntilMs) ? knownUntilMs : null,
+  };
+}
+
+/**
+ * Fetch the configured price-forecast feed and persist the parsed series.
+ * No-op unless the extended horizon is enabled and a URL is configured.
+ * On failure the previously stored forecast is kept (and simply ages out).
+ */
+export async function refreshPriceForecastAndPersist(): Promise<void> {
+  const settings = await loadSettings();
+  if (settings.extendedHorizonDays <= 0 || !settings.priceForecastUrl) return;
+
+  const response = await fetchWithTimeout(
+    settings.priceForecastUrl,
+    {},
+    { timeoutMs: PRICE_FORECAST_TIMEOUT_MS, label: 'Price forecast request' },
+  );
+  if (!response.ok) {
+    throw new Error(`Price forecast feed returned status ${response.status}`);
+  }
+
+  const parsed = parsePriceForecastFeed(await response.json() as ForecastFeed);
+
+  const data = await loadData();
+  data.importPriceForecast = parsed.importPriceForecast;
+  data.exportPriceForecast = parsed.exportPriceForecast;
+  await saveData(data);
+
+  console.log('[price-forecast] refreshed', {
+    start: parsed.importPriceForecast.start,
+    slots: parsed.importPriceForecast.values.length,
+    knownUntil: parsed.knownUntilMs != null ? new Date(parsed.knownUntilMs).toISOString() : null,
+  });
+}

--- a/api/services/price-forecast-service.ts
+++ b/api/services/price-forecast-service.ts
@@ -48,51 +48,88 @@ function tzOffsetMs(utcMs: number): number {
 }
 
 /**
- * Parse a feed timestamp to epoch ms. Timestamps with an explicit offset (or
- * Z) are parsed directly; bare "YYYY-MM-DD HH:MM:SS" strings are interpreted
- * as Europe/Brussels wall-clock time.
+ * All UTC instants whose FEED_TZ wall-clock rendering matches the given wall
+ * time (passed as its components read as UTC). Ascending; 0, 1, or 2 results:
+ * a normal time yields one, the repeated hour at the autumn DST transition
+ * yields two, and a nonexistent spring-forward time yields none.
  */
-export function parseFeedTimestamp(value: string): number {
-  if (typeof value !== 'string') return NaN;
+function wallTimeToUtcCandidates(wallAsUtc: number): number[] {
+  // The zone's offsets on either side of a possible transition near this time.
+  const probeOffsets = new Set([
+    tzOffsetMs(wallAsUtc - 12 * 3_600_000),
+    tzOffsetMs(wallAsUtc + 12 * 3_600_000),
+  ]);
+  const candidates = new Set<number>();
+  for (const offset of probeOffsets) {
+    const ts = wallAsUtc - offset;
+    if (tzOffsetMs(ts) === offset) candidates.add(ts); // round-trips → real occurrence
+  }
+  return [...candidates].sort((a, b) => a - b);
+}
+
+/**
+ * Parse a feed timestamp to every epoch-ms instant it can denote. Timestamps
+ * with an explicit offset (or Z) are unambiguous; bare "YYYY-MM-DD HH:MM:SS"
+ * strings are interpreted as Europe/Brussels wall-clock time, which is
+ * ambiguous during the repeated hour at the autumn DST transition (both
+ * occurrences are returned, ascending). Empty when unparseable.
+ */
+export function feedTimestampCandidates(value: string): number[] {
+  if (typeof value !== 'string') return [];
   if (/(?:Z|[+-]\d{2}:?\d{2})$/.test(value)) {
-    return new Date(value).getTime();
+    const ts = new Date(value).getTime();
+    return Number.isFinite(ts) ? [ts] : [];
   }
   const m = /^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2}))?$/.exec(value.trim());
-  if (!m) return NaN;
+  if (!m) return [];
   const [y, mo, d, h, mi, s] = [Number(m[1]), Number(m[2]), Number(m[3]), Number(m[4]), Number(m[5]), Number(m[6] ?? 0)];
-  // Wall-clock → UTC: guess the offset at the wall time read as UTC, then
-  // re-evaluate once at the corrected instant. This converges except inside a
-  // DST transition, where either candidate is at most an hour off.
   const wallAsUtc = Date.UTC(y, mo - 1, d, h, mi, s);
-  let ts = wallAsUtc - tzOffsetMs(wallAsUtc);
-  ts = wallAsUtc - tzOffsetMs(ts);
-  return ts;
+  const candidates = wallTimeToUtcCandidates(wallAsUtc);
+  if (candidates.length > 0) return candidates;
+  // Nonexistent local time (spring-forward gap): best-effort single instant.
+  return [wallAsUtc - tzOffsetMs(wallAsUtc)];
+}
+
+/** Parse a feed timestamp to epoch ms, taking the earlier occurrence when ambiguous. NaN when unparseable. */
+export function parseFeedTimestamp(value: string): number {
+  return feedTimestampCandidates(value)[0] ?? NaN;
 }
 
 /**
  * Convert a list of feed points into a contiguous 15-min TimeSeries.
- * Points are sorted by time; the series is truncated at the first gap or
- * non-finite value so a malformed feed can never fabricate prices.
+ * Points are consumed in feed order; the series is truncated at the first
+ * gap, out-of-order timestamp, or invalid price, so a malformed feed can
+ * never fabricate prices. DST-ambiguous wall times resolve to whichever
+ * occurrence continues the sequence, keeping the autumn repeated hour
+ * contiguous.
  */
 export function pointsToSeries(points: ForecastFeedPoint[]): TimeSeries | null {
   const stepMs = STEP_MINUTES * 60_000;
-  const parsed = points
-    .map(p => ({ timeMs: parseFeedTimestamp(p.time), price: Number(p.price) }))
-    .filter(p => Number.isFinite(p.timeMs))
-    .sort((a, b) => a.timeMs - b.timeMs);
-  if (parsed.length === 0) return null;
-
   const values: number[] = [];
-  let expectedMs = parsed[0].timeMs;
-  for (const p of parsed) {
-    if (p.timeMs !== expectedMs || !Number.isFinite(p.price)) break;
+  let startMs: number | null = null;
+  let expectedMs: number = NaN;
+
+  for (const p of points) {
+    // Strict price check: JSON null / '' / booleans coerce to 0 via Number(),
+    // which would read as free electricity — only accept real finite numbers.
+    if (typeof p?.price !== 'number' || !Number.isFinite(p.price)) break;
+    const candidates = feedTimestampCandidates(p?.time as string);
+    if (candidates.length === 0) break;
+    const timeMs: number = startMs == null
+      ? candidates[0]
+      : (candidates.includes(expectedMs) ? expectedMs : candidates[0]);
+    if (startMs == null) {
+      startMs = timeMs;
+    } else if (timeMs !== expectedMs) {
+      break;
+    }
     values.push(p.price);
-    expectedMs += stepMs;
+    expectedMs = timeMs + stepMs;
   }
-  if (values.length === 0) return null;
+  if (startMs == null || values.length === 0) return null;
 
   return {
-    start: new Date(parsed[0].timeMs).toISOString(),
+    start: new Date(startMs).toISOString(),
     step: STEP_MINUTES,
     values,
   };

--- a/api/services/pv-prediction-service.ts
+++ b/api/services/pv-prediction-service.ts
@@ -79,7 +79,11 @@ export async function runPvForecast(config: PredictionRunConfig): Promise<PvFore
       period: is15MinMode ? '5minute' : 'hour',
     }),
     fetchArchiveIrradiance(latitude, longitude, startDate, endDate),
-    fetchForecastIrradiance(latitude, longitude, undefined, forecastResolution),
+    fetchForecastIrradiance(
+      latitude, longitude, undefined, forecastResolution,
+      // Standard window needs 2 days; Open-Meteo serves at most 16.
+      Math.min(16, 2 + (config.extendedHorizonDays ?? 0)),
+    ),
   ]);
 
   let data = postprocess(rawData, sensors, derived);
@@ -154,7 +158,7 @@ export async function runPvForecast(config: PredictionRunConfig): Promise<PvFore
 
   // 6. Build 15-min series for the solver (from future points only)
   const now = new Date();
-  const { startIso, endIso } = getForecastTimeRange(now.getTime());
+  const { startIso, endIso } = getForecastTimeRange(now.getTime(), config.extendedHorizonDays ?? 0);
 
   const mappedFuturePoints = futurePoints.map(p => ({
     time: p.time,

--- a/api/services/settings-store.ts
+++ b/api/services/settings-store.ts
@@ -15,6 +15,7 @@ const NUMERIC_FIELDS: (keyof Settings)[] = [
   'terminalSocCustomPrice_cents_per_kWh', 'rebalanceHoldHours',
   'evMinChargeCurrent_A', 'evMaxChargeCurrent_A', 'evBatteryCapacity_kWh',
   'evChargeEfficiency_percent', 'evSocValue_cents_per_kWh', 'evTripSocBuffer_percent',
+  'extendedHorizonDays',
 ];
 
 function validateSettings(s: Settings): Settings {
@@ -36,6 +37,13 @@ function validateSettings(s: Settings): Settings {
 
   // Trip buffer is a SoC share on top of the trip usage; clamp to a sane [0, 100].
   s.evTripSocBuffer_percent = Math.max(0, Math.min(100, s.evTripSocBuffer_percent));
+
+  // Whole days only; 6 extra days is the practical limit of the price forecast feed.
+  s.extendedHorizonDays = Math.max(0, Math.min(6, Math.round(s.extendedHorizonDays)));
+
+  if (typeof s.priceForecastUrl !== 'string') {
+    s.priceForecastUrl = '';
+  }
 
   if (!Array.isArray(s.optimizerQuickSettings)) {
     s.optimizerQuickSettings = [];

--- a/api/services/vrm-refresh.ts
+++ b/api/services/vrm-refresh.ts
@@ -70,9 +70,15 @@ export async function refreshSeriesFromVrmAndPersist(): Promise<void> {
   const shouldFetchPrices = sources.prices === 'vrm';
   const shouldFetchSoc = sources.soc === 'mqtt';
 
+  // Extended horizon: ask VRM for extra forecast days and clamp to whatever it
+  // actually returns. The prices window stays standard — VRM prices are
+  // day-ahead actuals; further days come from the price forecast feed.
+  const extraDays = settings.extendedHorizonDays > 0 ? settings.extendedHorizonDays : 0;
+  const forecastWindow = extraDays > 0 ? VRMClient.windowOptimizationHorizon(extraDays) : {};
+
   // Concurrent IO
   const [forecastsResult, pricesResult, socResult] = await Promise.allSettled([
-    shouldFetchForecasts ? client.fetchForecasts() : Promise.resolve(null),
+    shouldFetchForecasts ? client.fetchForecasts(forecastWindow, { clampEndToData: extraDays > 0 }) : Promise.resolve(null),
     shouldFetchPrices ? client.fetchPrices() : Promise.resolve(null),
     shouldFetchSoc ? readVictronSocPercent({ timeoutMs: 5000 }) : Promise.resolve(null),
   ]);
@@ -142,6 +148,8 @@ export async function refreshSeriesFromVrmAndPersist(): Promise<void> {
     pv,
     importPrice,
     exportPrice,
+    importPriceForecast: baseData.importPriceForecast,
+    exportPriceForecast: baseData.exportPriceForecast,
     soc,
     lastFullSocAt: baseData.lastFullSocAt,
     rebalanceState: baseData.rebalanceState,

--- a/api/types.ts
+++ b/api/types.ts
@@ -52,6 +52,10 @@ export interface Settings {
   evChargeEfficiency_percent: number;
   evSocValue_cents_per_kWh: number;
   evTripSocBuffer_percent: number;
+  /** Extra planning days beyond the standard day-ahead window. 0 = off (default behaviour). */
+  extendedHorizonDays: number;
+  /** URL of a price-forecast JSON feed (energieprijs forecast.json format). Empty = disabled. */
+  priceForecastUrl: string;
 }
 
 // ----------------------------- Persisted data ---------------------------
@@ -113,6 +117,9 @@ export interface Data {
   pv: TimeSeries;
   importPrice: TimeSeries;
   exportPrice: TimeSeries;
+  /** Forecast prices pulled from priceForecastUrl; only extend the actual series, never override it. */
+  importPriceForecast?: TimeSeries;
+  exportPriceForecast?: TimeSeries;
   soc: SocData;
   lastFullSocAt?: string | null;
   rebalanceState?: RebalanceState;
@@ -164,4 +171,6 @@ export interface PredictionConfig {
 export interface PredictionRunConfig extends PredictionConfig {
   haUrl: string;
   haToken: string;
+  /** Extra forecast days beyond the standard window (from Settings.extendedHorizonDays). */
+  extendedHorizonDays?: number;
 }

--- a/app/index.html
+++ b/app/index.html
@@ -1415,6 +1415,12 @@
                 <option value="api">API</option>
               </select>
             </label>
+            <label class="text-sm">Extra horizon (days)
+              <input id="extended-horizon-days" type="number" min="0" max="6" step="1" class="form-input" data-settings-input />
+            </label>
+            <label class="text-sm col-span-2">Price forecast URL
+              <input id="price-forecast-url" type="url" placeholder="https://…/forecast.json" class="form-input" data-settings-input />
+            </label>
           </div>
         </section>
 

--- a/app/src/state.js
+++ b/app/src/state.js
@@ -32,6 +32,9 @@ export function snapshotUI(els) {
       soc: els.sourceSoc?.value || "mqtt",
     },
 
+    extendedHorizonDays: num(els.extendedHorizonDays?.value),
+    priceForecastUrl: els.priceForecastUrl?.value ?? '',
+
     // ALGORITHM
     rebalanceEnabled: !!els.rebalanceEnabled?.checked,
     rebalanceHoldHours: num(els.rebalanceHoldHours?.value),
@@ -98,6 +101,10 @@ export function hydrateUI(els, obj = {}) {
     els.rebalanceEnabled.checked = !!obj.rebalanceEnabled;
   }
   setIfDef(els.rebalanceHoldHours, obj.rebalanceHoldHours);
+
+  // Data / extended horizon
+  setIfDef(els.extendedHorizonDays, obj.extendedHorizonDays);
+  setIfDef(els.priceForecastUrl, obj.priceForecastUrl);
 
   // HOME ASSISTANT
   setIfDef(els.haUrl, obj.haUrl);

--- a/app/src/ui-binding.js
+++ b/app/src/ui-binding.js
@@ -13,6 +13,8 @@ export function getElements() {
     sourceLoad: $("#source-load"),
     sourcePv: $("#source-pv"),
     sourceSoc: $("#source-soc"),
+    extendedHorizonDays: $("#extended-horizon-days"),
+    priceForecastUrl: $("#price-forecast-url"),
     rebalanceToggleLabel: $("#rebalance-toggle-label"),
     rebalanceEnabled: $("#rebalance-enabled"),
     rebalanceNudge: $("#rebalance-nudge"),

--- a/lib/time-series-utils.ts
+++ b/lib/time-series-utils.ts
@@ -87,19 +87,20 @@ export function extractWindow(
  * >= 13:00 -> until midnight tomorrow
  *
  * @param nowMs The current time in milliseconds (defaults to Date.now())
+ * @param extraDays Additional whole days beyond the standard window (extended horizon)
  * @returns An object containing the startIso (aligned to 15m) and endIso (midnight)
  */
-export function getForecastTimeRange(nowMs = Date.now()): { startIso: string; endIso: string } {
+export function getForecastTimeRange(nowMs = Date.now(), extraDays = 0): { startIso: string; endIso: string } {
   const now = new Date(nowMs);
   const currentHour = now.getHours();
 
   const end = new Date(now);
   end.setMinutes(0, 0, 0);
   if (currentHour < 13) {
-    end.setDate(end.getDate() + 1);
+    end.setDate(end.getDate() + 1 + extraDays);
     end.setHours(0, 0, 0, 0);
   } else {
-    end.setDate(end.getDate() + 2);
+    end.setDate(end.getDate() + 2 + extraDays);
     end.setHours(0, 0, 0, 0);
   }
 
@@ -162,6 +163,38 @@ export function buildForecastSeries(
   }
 
   return { start: startIso, step: 15, values };
+}
+
+/**
+ * Extend an actual time series with the tail of a forecast series.
+ *
+ * Actual values always win: the forecast contributes only slots strictly after
+ * the end of the actual series. Returns the actual series unchanged when the
+ * forecast is missing, does not reach past the actual data, or starts after
+ * the actual series ends (a gap would otherwise be zero-filled).
+ */
+export function extendSeriesWithForecast(actual: TimeSeries, forecast?: TimeSeries): TimeSeries {
+  if (!forecast || !Array.isArray(forecast.values) || forecast.values.length === 0) return actual;
+
+  const step = actual.step ?? 15;
+  const stepMs = step * 60_000;
+  const actualEndMs = new Date(actual.start).getTime() + actual.values.length * stepMs;
+  const forecastStartMs = new Date(forecast.start).getTime();
+  const forecastEndMs = forecastStartMs + forecast.values.length * (forecast.step ?? 15) * 60_000;
+
+  if (!Number.isFinite(actualEndMs) || !Number.isFinite(forecastStartMs) || !Number.isFinite(forecastEndMs)) return actual;
+  if (forecastEndMs <= actualEndMs) return actual;
+  if (forecastStartMs > actualEndMs) return actual; // gap between actual and forecast
+
+  const tailSlots = Math.floor((forecastEndMs - actualEndMs) / stepMs);
+  if (tailSlots <= 0) return actual;
+
+  const tail = extractWindow(forecast, actualEndMs, actualEndMs + tailSlots * stepMs, step);
+  return {
+    start: actual.start,
+    step,
+    values: [...actual.values, ...tail],
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -95,6 +95,10 @@ export interface SolverConfig {
   // Initial state
   initialSoc_percent: number;
 
+  // Extended horizon: instant after which price slots come from a forecast
+  // feed instead of published actuals (absent when all prices are actual).
+  pricesKnownUntilMs?: number;
+
   // Rebalancing (optional — only present when rebalanceEnabled is true)
   rebalanceHoldSlots?: number;
   rebalanceRemainingSlots?: number;

--- a/lib/vrm-api.ts
+++ b/lib/vrm-api.ts
@@ -178,7 +178,7 @@ export class VRMClient {
  * We do the time arithmetic in local time first — because "midnight" in your
  * billing world is local midnight — then call .getTime() to convert to UTC ms.
  */
-  static windowOptimizationHorizon(): VRMWindow {
+  static windowOptimizationHorizon(extraDays = 0): VRMWindow {
     const nowLocal = new Date(); // browser local time
     const y = nowLocal.getFullYear();
     const m = nowLocal.getMonth();
@@ -192,7 +192,8 @@ export class VRMClient {
     // --- End = local midnight depending on cutoff ---
     // Before 13:00 → up to midnight tonight (= start of tomorrow)
     // After / at 13:00 → up to midnight tomorrow (= start of day after tomorrow)
-    const dayOffset = (hr < 13) ? 1 : 2;
+    // extraDays pushes the end further out for the extended horizon.
+    const dayOffset = ((hr < 13) ? 1 : 2) + extraDays;
     const endLocal = new Date(y, m, d + dayOffset, 0, 0, 0, 0);
 
     // Convert both local times to absolute UTC timestamps
@@ -279,7 +280,7 @@ export class VRMClient {
    * This converts each hourly kWh spike into a constant average power over that hour in W,
    * and fills all 4×15-min slots of the hour with that W.
    */
-  async fetchForecasts(opts: Partial<VRMWindow> = {}): Promise<VRMForecasts> {
+  async fetchForecasts(opts: Partial<VRMWindow> = {}, { clampEndToData = false } = {}): Promise<VRMForecasts> {
     if (!this.installationId) throw new Error('Missing installationId');
 
     const win = ensureWindow(opts);
@@ -299,7 +300,21 @@ export class VRMClient {
     const loadWSeries = toSeries(rec['vrm_consumption_fc']);   // ms -> W
     const pvWSeries = toSeries(rec['solar_yield_forecast']); // ms -> W
 
-    const timeline = VRMClient.buildTimeline15Min(win.startMs, win.endMs);
+    // When a window beyond VRM's own horizon is requested, truncate at the
+    // last returned data point (+1h, values are hourly): slots past that would
+    // be zero-filled, and zero load reads as "free energy" to the solver.
+    let endMs = win.endMs;
+    if (clampEndToData) {
+      const lastDataMs = Math.max(
+        loadWSeries.size > 0 ? Math.max(...loadWSeries.keys()) : -Infinity,
+        pvWSeries.size > 0 ? Math.max(...pvWSeries.keys()) : -Infinity,
+      );
+      if (Number.isFinite(lastDataMs)) {
+        endMs = Math.min(endMs, lastDataMs + 3_600_000);
+      }
+    }
+
+    const timeline = VRMClient.buildTimeline15Min(win.startMs, endMs);
 
     const load_W = fillHourlyWAcrossQuarterHours(loadWSeries, timeline);
     const pv_W = fillHourlyWAcrossQuarterHours(pvWSeries, timeline);

--- a/lib/vrm-api.ts
+++ b/lib/vrm-api.ts
@@ -301,17 +301,18 @@ export class VRMClient {
     const pvWSeries = toSeries(rec['solar_yield_forecast']); // ms -> W
 
     // When a window beyond VRM's own horizon is requested, truncate at the
-    // last returned data point (+1h, values are hourly): slots past that would
-    // be zero-filled, and zero load reads as "free energy" to the solver.
+    // last returned LOAD data point (+1h, values are hourly): slots past that
+    // would be zero-filled, and zero load reads as "free energy" to the
+    // solver. PV coverage deliberately doesn't count — missing PV is safely
+    // zero (no sun), but a PV series outlasting load must not stretch the
+    // timeline over fabricated zero-load hours. No load data at all yields an
+    // empty timeline, which callers treat as a failed fetch (previous data is
+    // kept) rather than an all-zero forecast.
     let endMs = win.endMs;
     if (clampEndToData) {
-      const lastDataMs = Math.max(
-        loadWSeries.size > 0 ? Math.max(...loadWSeries.keys()) : -Infinity,
-        pvWSeries.size > 0 ? Math.max(...pvWSeries.keys()) : -Infinity,
-      );
-      if (Number.isFinite(lastDataMs)) {
-        endMs = Math.min(endMs, lastDataMs + 3_600_000);
-      }
+      endMs = loadWSeries.size > 0
+        ? Math.min(endMs, Math.max(...loadWSeries.keys()) + 3_600_000)
+        : win.startMs;
     }
 
     const timeline = VRMClient.buildTimeline15Min(win.startMs, endMs);

--- a/plans/extended-horizon-plan.md
+++ b/plans/extended-horizon-plan.md
@@ -38,7 +38,7 @@ timestamp separating published day-ahead prices from model predictions.
   non-Optimal status and is already refused for hardware writes.
 - `status` added to the `[calculate] solve` log line.
 
-## Phase 1 — Server data plumbing
+## Phase 1 — Server data plumbing (this branch)
 
 - Settings: `extendedHorizonDays` (0 = off), `priceForecastUrl`.
 - New `price-forecast-service.ts`: fetch and parse `forecast.json`
@@ -54,8 +54,9 @@ timestamp separating published day-ahead prices from model predictions.
   `extendedHorizonDays + 2` (Open-Meteo serves up to 16). For `pv: 'vrm'`,
   extend `windowOptimizationHorizon` (`lib/vrm-api.ts`) the same way and clamp
   to what VRM returns.
-- Timestamps in `forecast.json` are Brussels wall-clock; either parse with an
-  explicit timezone or add UTC timestamps to the feed first (preferred).
+- Timestamps in `forecast.json` are Brussels wall-clock; parsed with an
+  explicit `Europe/Brussels` timezone conversion (Intl-based, DST-safe), with
+  ISO-with-offset timestamps also accepted should the feed ever add them.
 - The `min()` horizon rule in `config-builder.ts` stays: with all four series
   extended it yields the requested horizon and remains the safety net when a
   source falls short.

--- a/tests/api/services/open-meteo-client.test.js
+++ b/tests/api/services/open-meteo-client.test.js
@@ -33,7 +33,7 @@ describe('Open-Meteo HTTP client', () => {
     }));
 
     await expect(
-      fetchForecastIrradiance(51, 4, undefined, 60, 5),
+      fetchForecastIrradiance(51, 4, undefined, 60, 2, 5),
     ).rejects.toThrow('Open-Meteo Forecast API request timed out after 5ms');
   });
 });

--- a/tests/api/services/price-forecast-service.test.js
+++ b/tests/api/services/price-forecast-service.test.js
@@ -40,6 +40,11 @@ describe('parseFeedTimestamp', () => {
     expect(ts).toBeLessThanOrEqual(upper);
   });
 
+  it('returns the earlier occurrence for an ambiguous fall-back wall time', () => {
+    // 02:30 on 2026-10-25 exists as 00:30Z (CEST) and 01:30Z (CET).
+    expect(parseFeedTimestamp('2026-10-25 02:30:00')).toBe(new Date('2026-10-25T00:30:00Z').getTime());
+  });
+
   it('returns NaN for unparseable input', () => {
     expect(parseFeedTimestamp('not a date')).toBeNaN();
     expect(parseFeedTimestamp(undefined)).toBeNaN();
@@ -49,15 +54,52 @@ describe('parseFeedTimestamp', () => {
 describe('pointsToSeries', () => {
   const point = (iso, price) => ({ time: iso, price });
 
-  it('builds a contiguous 15-min series sorted by time', () => {
+  it('builds a contiguous 15-min series from feed-ordered points', () => {
     const series = pointsToSeries([
-      point('2026-01-15T10:15:00Z', 2),
       point('2026-01-15T10:00:00Z', 1),
+      point('2026-01-15T10:15:00Z', 2),
       point('2026-01-15T10:30:00Z', 3),
     ]);
     expect(series.start).toBe('2026-01-15T10:00:00.000Z');
     expect(series.step).toBe(15);
     expect(series.values).toEqual([1, 2, 3]);
+  });
+
+  it('truncates at an out-of-order timestamp instead of reordering the feed', () => {
+    const series = pointsToSeries([
+      point('2026-01-15T10:15:00Z', 2),
+      point('2026-01-15T10:00:00Z', 1),
+      point('2026-01-15T10:30:00Z', 3),
+    ]);
+    expect(series.start).toBe('2026-01-15T10:15:00.000Z');
+    expect(series.values).toEqual([2]);
+  });
+
+  it('truncates at null, empty-string, and boolean prices (Number() would coerce them to 0)', () => {
+    for (const bad of [null, '', true, '5']) {
+      const series = pointsToSeries([
+        point('2026-01-15T10:00:00Z', 1),
+        point('2026-01-15T10:15:00Z', bad),
+        point('2026-01-15T10:30:00Z', 3),
+      ]);
+      expect(series.values).toEqual([1]);
+    }
+    // A feed starting with a null price yields no series at all, not a zero price.
+    expect(pointsToSeries([point('2026-01-15T10:00:00Z', null)])).toBeNull();
+  });
+
+  it('keeps the repeated hour contiguous across the autumn DST transition', () => {
+    // Brussels falls back 03:00 CEST → 02:00 CET on 2026-10-25 (01:00 UTC):
+    // wall times 02:00–02:45 occur twice; the sequence disambiguates them.
+    const walls = [
+      '2026-10-25 01:45:00',
+      '2026-10-25 02:00:00', '2026-10-25 02:15:00', '2026-10-25 02:30:00', '2026-10-25 02:45:00',
+      '2026-10-25 02:00:00', '2026-10-25 02:15:00', '2026-10-25 02:30:00', '2026-10-25 02:45:00',
+      '2026-10-25 03:00:00',
+    ];
+    const series = pointsToSeries(walls.map((w, i) => point(w, i + 1)));
+    expect(series.start).toBe('2026-10-24T23:45:00.000Z'); // 01:45 CEST
+    expect(series.values).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
   });
 
   it('truncates at the first gap so missing slots never become fabricated prices', () => {

--- a/tests/api/services/price-forecast-service.test.js
+++ b/tests/api/services/price-forecast-service.test.js
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../../../api/services/settings-store.ts', () => ({
+  loadSettings: vi.fn(),
+}));
+vi.mock('../../../api/services/data-store.ts', () => ({
+  loadData: vi.fn(),
+  saveData: vi.fn(),
+}));
+
+import {
+  parseFeedTimestamp,
+  pointsToSeries,
+  parsePriceForecastFeed,
+  refreshPriceForecastAndPersist,
+} from '../../../api/services/price-forecast-service.ts';
+import { loadSettings } from '../../../api/services/settings-store.ts';
+import { loadData, saveData } from '../../../api/services/data-store.ts';
+
+describe('parseFeedTimestamp', () => {
+  it('parses bare timestamps as Europe/Brussels wall-clock (winter, UTC+1)', () => {
+    expect(parseFeedTimestamp('2026-01-15 12:00:00')).toBe(new Date('2026-01-15T11:00:00Z').getTime());
+  });
+
+  it('parses bare timestamps as Europe/Brussels wall-clock (summer, UTC+2)', () => {
+    expect(parseFeedTimestamp('2026-08-14 12:00:00')).toBe(new Date('2026-08-14T10:00:00Z').getTime());
+  });
+
+  it('parses timestamps with an explicit offset or Z directly', () => {
+    expect(parseFeedTimestamp('2026-08-14T12:00:00Z')).toBe(new Date('2026-08-14T12:00:00Z').getTime());
+    expect(parseFeedTimestamp('2026-08-14T12:00:00+02:00')).toBe(new Date('2026-08-14T10:00:00Z').getTime());
+  });
+
+  it('handles the spring-forward DST transition without drifting more than an hour', () => {
+    // 2026-03-29 02:30 does not exist in Brussels (clocks jump 02:00 → 03:00).
+    const ts = parseFeedTimestamp('2026-03-29 02:30:00');
+    const lower = new Date('2026-03-29T00:30:00Z').getTime(); // 02:30 CEST
+    const upper = new Date('2026-03-29T01:30:00Z').getTime(); // 02:30 CET
+    expect(ts).toBeGreaterThanOrEqual(lower);
+    expect(ts).toBeLessThanOrEqual(upper);
+  });
+
+  it('returns NaN for unparseable input', () => {
+    expect(parseFeedTimestamp('not a date')).toBeNaN();
+    expect(parseFeedTimestamp(undefined)).toBeNaN();
+  });
+});
+
+describe('pointsToSeries', () => {
+  const point = (iso, price) => ({ time: iso, price });
+
+  it('builds a contiguous 15-min series sorted by time', () => {
+    const series = pointsToSeries([
+      point('2026-01-15T10:15:00Z', 2),
+      point('2026-01-15T10:00:00Z', 1),
+      point('2026-01-15T10:30:00Z', 3),
+    ]);
+    expect(series.start).toBe('2026-01-15T10:00:00.000Z');
+    expect(series.step).toBe(15);
+    expect(series.values).toEqual([1, 2, 3]);
+  });
+
+  it('truncates at the first gap so missing slots never become fabricated prices', () => {
+    const series = pointsToSeries([
+      point('2026-01-15T10:00:00Z', 1),
+      point('2026-01-15T10:15:00Z', 2),
+      point('2026-01-15T11:00:00Z', 9), // gap: 10:30 and 10:45 missing
+    ]);
+    expect(series.values).toEqual([1, 2]);
+  });
+
+  it('truncates at the first non-finite price', () => {
+    const series = pointsToSeries([
+      point('2026-01-15T10:00:00Z', 1),
+      point('2026-01-15T10:15:00Z', 'oops'),
+      point('2026-01-15T10:30:00Z', 3),
+    ]);
+    expect(series.values).toEqual([1]);
+  });
+
+  it('returns null when no points parse', () => {
+    expect(pointsToSeries([])).toBeNull();
+    expect(pointsToSeries([point('garbage', 1)])).toBeNull();
+  });
+});
+
+describe('parsePriceForecastFeed', () => {
+  it('parses consumption and injection series plus known_until', () => {
+    const feed = {
+      consumption_data: [{ time: '2026-01-15T10:00:00Z', price: 25 }],
+      injection_data: [{ time: '2026-01-15T10:00:00Z', price: 8 }],
+      known_until: '2026-01-15T23:45:00Z',
+    };
+    const parsed = parsePriceForecastFeed(feed);
+    expect(parsed.importPriceForecast.values).toEqual([25]);
+    expect(parsed.exportPriceForecast.values).toEqual([8]);
+    expect(parsed.knownUntilMs).toBe(new Date('2026-01-15T23:45:00Z').getTime());
+  });
+
+  it('throws when either series is unusable', () => {
+    expect(() => parsePriceForecastFeed({ consumption_data: [], injection_data: [] }))
+      .toThrowError(/no usable/);
+  });
+});
+
+describe('refreshPriceForecastAndPersist', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('does nothing when the extended horizon is off or no URL is configured', async () => {
+    loadSettings.mockResolvedValue({ extendedHorizonDays: 0, priceForecastUrl: 'https://example.com/f.json' });
+    await refreshPriceForecastAndPersist();
+
+    loadSettings.mockResolvedValue({ extendedHorizonDays: 3, priceForecastUrl: '' });
+    await refreshPriceForecastAndPersist();
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(saveData).not.toHaveBeenCalled();
+  });
+
+  it('fetches, parses, and persists the forecast series', async () => {
+    loadSettings.mockResolvedValue({ extendedHorizonDays: 3, priceForecastUrl: 'https://example.com/forecast.json' });
+    loadData.mockResolvedValue({ existing: true });
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        consumption_data: [
+          { time: '2026-01-15 11:00:00', price: 25 },
+          { time: '2026-01-15 11:15:00', price: 26 },
+        ],
+        injection_data: [
+          { time: '2026-01-15 11:00:00', price: 8 },
+          { time: '2026-01-15 11:15:00', price: 9 },
+        ],
+        known_until: '2026-01-15 23:45:00',
+      }),
+    });
+
+    await refreshPriceForecastAndPersist();
+
+    expect(global.fetch).toHaveBeenCalledWith('https://example.com/forecast.json', expect.anything());
+    expect(saveData).toHaveBeenCalledTimes(1);
+    const persisted = saveData.mock.calls[0][0];
+    // 11:00 Brussels winter time = 10:00Z
+    expect(persisted.importPriceForecast.start).toBe('2026-01-15T10:00:00.000Z');
+    expect(persisted.importPriceForecast.values).toEqual([25, 26]);
+    expect(persisted.exportPriceForecast.values).toEqual([8, 9]);
+    expect(persisted.existing).toBe(true);
+  });
+
+  it('throws (and does not persist) when the feed responds with an error status', async () => {
+    loadSettings.mockResolvedValue({ extendedHorizonDays: 3, priceForecastUrl: 'https://example.com/forecast.json' });
+    global.fetch.mockResolvedValue({ ok: false, status: 503 });
+
+    await expect(refreshPriceForecastAndPersist()).rejects.toThrowError(/503/);
+    expect(saveData).not.toHaveBeenCalled();
+  });
+});

--- a/tests/api/services/solver-timeline.test.js
+++ b/tests/api/services/solver-timeline.test.js
@@ -103,6 +103,50 @@ describe('Solver Timeline Logic (Refactored)', () => {
     expect(() => buildSolverConfigFromSettings(mockSettings, exactStart)).not.toThrow();
   });
 
+  it('extends prices with the forecast tail when the extended horizon is enabled', () => {
+    // Actual prices end at 14:00; load/pv run much longer.
+    const data = {
+      load: { start: '2024-01-01T10:00:00Z', step: 15, values: Array(100).fill(100) },
+      pv: { start: '2024-01-01T10:00:00Z', step: 15, values: Array(100).fill(0) },
+      importPrice: { start: '2024-01-01T10:00:00Z', step: 15, values: Array(16).fill(10) },
+      exportPrice: { start: '2024-01-01T10:00:00Z', step: 15, values: Array(16).fill(5) },
+      importPriceForecast: { start: '2024-01-01T13:00:00Z', step: 15, values: Array(40).fill(20) },
+      exportPriceForecast: { start: '2024-01-01T13:00:00Z', step: 15, values: Array(40).fill(15) },
+      soc: { timestamp: '2024-01-01T12:00:00Z', value: 50 }
+    };
+
+    // Without the setting: forecast ignored, horizon ends at 14:00 (8 slots from 12:00).
+    const base = buildSolverConfigFromSettings(mockSettings, data);
+    expect(base.importPrice.length).toBe(8);
+    expect(base.pricesKnownUntilMs).toBeUndefined();
+
+    // With the setting: horizon runs to the forecast end (13:00 + 40×15min = 23:00 → 44 slots from 12:00),
+    // actual values win up to 14:00, forecast values fill the tail.
+    const extended = buildSolverConfigFromSettings({ ...mockSettings, extendedHorizonDays: 2 }, data);
+    expect(extended.importPrice.length).toBe(44);
+    expect(extended.importPrice.slice(0, 8).every(v => v === 10)).toBe(true);
+    expect(extended.importPrice.slice(8).every(v => v === 20)).toBe(true);
+    expect(extended.exportPrice.slice(8).every(v => v === 15)).toBe(true);
+    expect(extended.pricesKnownUntilMs).toBe(new Date('2024-01-01T14:00:00Z').getTime());
+  });
+
+  it('ignores a forecast that leaves a gap after the actual prices', () => {
+    const data = {
+      load: { start: '2024-01-01T10:00:00Z', step: 15, values: Array(100).fill(100) },
+      pv: { start: '2024-01-01T10:00:00Z', step: 15, values: Array(100).fill(0) },
+      importPrice: { start: '2024-01-01T10:00:00Z', step: 15, values: Array(16).fill(10) },
+      exportPrice: { start: '2024-01-01T10:00:00Z', step: 15, values: Array(16).fill(5) },
+      // Starts 15:00, actual ends 14:00 → gap → must be ignored, not zero-filled.
+      importPriceForecast: { start: '2024-01-01T15:00:00Z', step: 15, values: Array(40).fill(20) },
+      exportPriceForecast: { start: '2024-01-01T15:00:00Z', step: 15, values: Array(40).fill(15) },
+      soc: { timestamp: '2024-01-01T12:00:00Z', value: 50 }
+    };
+
+    const config = buildSolverConfigFromSettings({ ...mockSettings, extendedHorizonDays: 2 }, data);
+    expect(config.importPrice.length).toBe(8);
+    expect(config.pricesKnownUntilMs).toBeUndefined();
+  });
+
   it('allows a PV series that starts after the plan window begins (leading zeros = no sun)', () => {
     const data = {
       load: { start: '2024-01-01T10:00:00Z', step: 15, values: Array(100).fill(100) },

--- a/tests/lib/time-series-utils.test.js
+++ b/tests/lib/time-series-utils.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { extractWindow, getQuarterStart, buildForecastSeries } from '../../lib/time-series-utils.ts';
+import { extractWindow, getQuarterStart, buildForecastSeries, getForecastTimeRange, extendSeriesWithForecast } from '../../lib/time-series-utils.ts';
 
 describe('Time Series Utils', () => {
   describe('getQuarterStart', () => {
@@ -141,5 +141,83 @@ describe('buildForecastSeries', () => {
     const series = buildForecastSeries([], start, end, 15);
     expect(series.values).toHaveLength(4);
     expect(series.values.every(v => v === 0)).toBe(true);
+  });
+});
+
+describe('getForecastTimeRange', () => {
+  // Times are interpreted in local time; use explicit local Date values.
+  it('extends the end by extraDays', () => {
+    const now = new Date(2024, 0, 1, 10, 0, 0); // 10:00 local, before 13:00
+    const base = getForecastTimeRange(now.getTime());
+    const extended = getForecastTimeRange(now.getTime(), 3);
+    const dayMs = 24 * 60 * 60 * 1000;
+    expect(new Date(extended.endIso).getTime() - new Date(base.endIso).getTime()).toBe(3 * dayMs);
+    expect(extended.startIso).toBe(base.startIso);
+  });
+
+  it('defaults to the standard window when extraDays is omitted', () => {
+    const now = new Date(2024, 0, 1, 14, 0, 0); // after 13:00 → midnight tomorrow
+    const { endIso } = getForecastTimeRange(now.getTime());
+    expect(new Date(endIso).getTime()).toBe(new Date(2024, 0, 3, 0, 0, 0).getTime());
+  });
+});
+
+describe('extendSeriesWithForecast', () => {
+  const startMs = new Date('2024-01-01T10:00:00Z').getTime();
+  const stepMs = 15 * 60 * 1000;
+  const actual = {
+    start: new Date(startMs).toISOString(),
+    step: 15,
+    values: [10, 11, 12, 13], // ends 11:00
+  };
+
+  it('appends only the forecast tail past the end of the actual series', () => {
+    const forecast = {
+      start: new Date(startMs + 2 * stepMs).toISOString(), // 10:30, overlaps actual
+      step: 15,
+      values: [99, 99, 20, 21, 22], // 10:30..11:45; tail past 11:00 = [20, 21, 22]
+    };
+    const merged = extendSeriesWithForecast(actual, forecast);
+    expect(merged.start).toBe(actual.start);
+    expect(merged.values).toEqual([10, 11, 12, 13, 20, 21, 22]);
+  });
+
+  it('returns the actual series unchanged when there is no forecast', () => {
+    expect(extendSeriesWithForecast(actual, undefined)).toBe(actual);
+    expect(extendSeriesWithForecast(actual, { start: actual.start, step: 15, values: [] })).toBe(actual);
+  });
+
+  it('returns the actual series unchanged when the forecast ends before the actual data', () => {
+    const forecast = { start: actual.start, step: 15, values: [1, 2] };
+    expect(extendSeriesWithForecast(actual, forecast)).toBe(actual);
+  });
+
+  it('returns the actual series unchanged when the forecast starts after the actual data ends (gap)', () => {
+    const forecast = {
+      start: new Date(startMs + 5 * stepMs).toISOString(), // 11:15, actual ends 11:00
+      step: 15,
+      values: [20, 21],
+    };
+    expect(extendSeriesWithForecast(actual, forecast)).toBe(actual);
+  });
+
+  it('accepts a forecast starting exactly where the actual series ends', () => {
+    const forecast = {
+      start: new Date(startMs + 4 * stepMs).toISOString(), // 11:00
+      step: 15,
+      values: [20, 21],
+    };
+    const merged = extendSeriesWithForecast(actual, forecast);
+    expect(merged.values).toEqual([10, 11, 12, 13, 20, 21]);
+  });
+
+  it('resamples a coarser forecast to the actual step', () => {
+    const forecast = {
+      start: new Date(startMs + 4 * stepMs).toISOString(), // 11:00
+      step: 60,
+      values: [40], // one hour → four 15-min slots
+    };
+    const merged = extendSeriesWithForecast(actual, forecast);
+    expect(merged.values).toEqual([10, 11, 12, 13, 40, 40, 40, 40]);
   });
 });

--- a/tests/lib/vrm-api.test.js
+++ b/tests/lib/vrm-api.test.js
@@ -31,3 +31,56 @@ describe('VRMClient HTTP requests', () => {
     await expect(client._fetch('/test')).rejects.toThrow('VRM API request timed out after 5ms');
   });
 });
+
+describe('VRMClient.fetchForecasts — clampEndToData', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const H = 3_600_000;
+  const startMs = Date.UTC(2026, 0, 15, 0, 0, 0);
+  const win = { startMs, endMs: startMs + 6 * H };
+
+  const mockResponse = (records) => {
+    global.fetch.mockResolvedValue({ ok: true, json: async () => ({ success: true, records }) });
+  };
+
+  const client = () => new VRMClient({ installationId: '1', token: 't' });
+
+  it('clamps the timeline to load coverage, not a longer PV series', async () => {
+    mockResponse({
+      // Load through 01:00 (covers 00:00–02:00); PV through 03:00.
+      vrm_consumption_fc: [[startMs, 400], [startMs + H, 500]],
+      solar_yield_forecast: [[startMs, 100], [startMs + H, 200], [startMs + 2 * H, 300], [startMs + 3 * H, 250]],
+    });
+
+    const forecasts = await client().fetchForecasts(win, { clampEndToData: true });
+
+    // 2 h of 15-min slots — the PV tail must not stretch the timeline over zero-load hours.
+    expect(forecasts.timestamps).toHaveLength(8);
+    expect(forecasts.load_W.every(v => v > 0)).toBe(true);
+  });
+
+  it('returns an empty timeline when VRM returns no load data at all', async () => {
+    mockResponse({
+      solar_yield_forecast: [[startMs, 100], [startMs + H, 200]],
+    });
+
+    const forecasts = await client().fetchForecasts(win, { clampEndToData: true });
+    expect(forecasts.timestamps).toHaveLength(0);
+  });
+
+  it('keeps the full requested window when clamping is off (default)', async () => {
+    mockResponse({
+      vrm_consumption_fc: [[startMs, 400]],
+      solar_yield_forecast: [[startMs, 100]],
+    });
+
+    const forecasts = await client().fetchForecasts(win);
+    expect(forecasts.timestamps).toHaveLength(24); // 6 h × 4, zero-filled past the data as before
+  });
+});


### PR DESCRIPTION
Second stacked PR for the extended planning horizon (plan: `plans/extended-horizon-plan.md`). Stacked on #142 (phase 0); only the last commit is new here.

## What this adds

**Settings (both opt-in, defaults unchanged):**
- `extendedHorizonDays` (0–6, default 0 = today's behaviour exactly)
- `priceForecastUrl` (default empty), e.g. `https://energie.bartm.be/forecast.json`
- Two matching fields in the Data Sources card of the settings UI.

**Price forecasts (pulled by optivolt, never pushed via HA):**
- New `price-forecast-service.ts` fetches the energieprijs `forecast.json` feed during the `/calculate` update step and persists `data.importPriceForecast` / `data.exportPriceForecast` as separate series, next to the actuals.
- Brussels wall-clock timestamps are converted DST-safely (Intl-based); ISO-with-offset timestamps are also accepted. The series is truncated at the first gap or non-finite value so a malformed feed can never fabricate prices.
- On fetch failure the previous forecast is kept and simply ages out (the horizon shrinks gracefully).

**Merge at solve time — actual prices always win:**
- `extendSeriesWithForecast()` appends only the forecast tail strictly past the end of the actual price series; a forecast that leaves a gap is ignored entirely (never zero-filled).
- `SolverConfig.pricesKnownUntilMs` marks where actuals end, for the dashed-line UI in phase 3.
- The whole merge is gated on `extendedHorizonDays > 0`; VRM refresh now carries the forecast series through so they survive data refreshes.

**Load & PV forecast windows:**
- `getForecastTimeRange()` gains an `extraDays` parameter, threaded from settings through `PredictionRunConfig` into the load and PV forecast services.
- Open-Meteo requests `2 + extendedHorizonDays` forecast days (max 16) and switches from ICON D2 (~2-day coverage) to `icon_seamless` beyond 2 days, so far-out slots get real irradiance instead of nulls-parsed-as-0.
- VRM forecast fetches use an extended window when the setting is on, clamped to the data VRM actually returns — zero-filled fabricated load would read as free energy to the solver. The VRM *prices* window stays standard: those are day-ahead actuals; further days come from the forecast feed.

The `min()` horizon rule from phase 0 stays the safety net: the plan only extends as far as every series actually reaches.

## Tests
24 new tests: wall-clock/DST parsing, feed truncation, persistence gating, `extendSeriesWithForecast` merge/gap/resample cases, `getForecastTimeRange` extraDays, and config-builder merge + `pricesKnownUntilMs` behaviour. 514 total pass; typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)