### PR TITLE
Extended horizon phase 2: day-1 rebalance restriction + solver verification

### DIFF
--- a/api/services/config-builder.ts
+++ b/api/services/config-builder.ts
@@ -137,6 +137,12 @@ export function buildSolverConfigFromSettings(
     base.rebalanceHoldSlots = holdSlots;
     base.rebalanceRemainingSlots = remainingSlots;
     base.rebalanceTargetSoc_percent = settings.maxSoc_percent;
+    // On an extended horizon, keep "hold once" a day-1 decision: the window
+    // must start within the first 24 h instead of drifting days out. This also
+    // caps the start_balance binary count at one day's worth of slots.
+    if (settings.extendedHorizonDays > 0) {
+      base.rebalanceMaxStartSlot = Math.max(0, Math.floor((24 * 60) / settings.stepSize_m) - 1);
+    }
   }
 
   const ev = buildEvConfig(settings, data.evScheduleEntries ?? [], evState, nowMs, base.load_W.length);

--- a/lib/build-lp.ts
+++ b/lib/build-lp.ts
@@ -37,6 +37,7 @@ export function buildLP({
   // rebalancing (MILP)
   rebalanceRemainingSlots,
   rebalanceTargetSoc_percent,
+  rebalanceMaxStartSlot,
   ev,
 }: SolverConfig): string {
   const T = load_W.length;
@@ -85,6 +86,13 @@ export function buildLP({
   const rebalanceTargetSoc_Wh = D > 0
     ? (safeTargetSoc_percent / 100) * batteryCapacity_Wh
     : 0;
+  // Latest allowed start position for the window. Defaults to T - D (any start
+  // that still fits); rebalanceMaxStartSlot caps it so a multi-day horizon
+  // cannot defer the hold days out. Clamped to >= 0 so at least k=0 exists.
+  const KMAX = Math.min(
+    T - D,
+    rebalanceMaxStartSlot != null ? Math.max(0, Math.trunc(rebalanceMaxStartSlot)) : Infinity,
+  );
   const startBalance = (k: number) => `start_balance_${k}`;
 
   // EV variable name helpers
@@ -199,7 +207,7 @@ export function buildLP({
   }
   // Rebalancing symmetry-breaking: escalating penalty prefers earlier windows when cost-equivalent.
   if (D > 0) {
-    for (let k = 0; k <= T - D; k++) {
+    for (let k = 0; k <= KMAX; k++) {
       objTerms.push(` + ${toNum(TIEBREAK.rebalanceStartPerSlot * (k + 1))} ${startBalance(k)}`);
     }
   }
@@ -251,7 +259,7 @@ export function buildLP({
   if (D > 0) {
     // Exactly-one-start constraint: exactly one window starting position is chosen
     const startVars: string[] = [];
-    for (let k = 0; k <= T - D; k++) {
+    for (let k = 0; k <= KMAX; k++) {
       startVars.push(startBalance(k));
     }
     lines.push(` c_balance_start: ${startVars.join(' + ')} = 1`);
@@ -259,7 +267,7 @@ export function buildLP({
     // Per-slot SoC forcing: soc_t >= rebalanceTargetSoc_Wh when slot t is in the chosen window
     for (let t = 0; t < T; t++) {
       const kLow = Math.max(0, t - D + 1);
-      const kHigh = Math.min(t, T - D);
+      const kHigh = Math.min(t, KMAX);
       if (kLow > kHigh) continue; // no valid start position covers this slot
       const terms: string[] = [];
       for (let k = kLow; k <= kHigh; k++) {
@@ -373,7 +381,7 @@ export function buildLP({
   if (D > 0 || evActive) {
     lines.push("Binaries");
     if (D > 0) {
-      for (let k = 0; k <= T - D; k++) {
+      for (let k = 0; k <= KMAX; k++) {
         lines.push(` start_balance_${k}`);
       }
     }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -103,6 +103,12 @@ export interface SolverConfig {
   rebalanceHoldSlots?: number;
   rebalanceRemainingSlots?: number;
   rebalanceTargetSoc_percent?: number;
+  /**
+   * Latest slot index (inclusive) at which the rebalance window may start.
+   * Set on extended horizons to keep "hold once" a day-1 decision instead of
+   * letting the solver defer it days out (also caps the binary count).
+   */
+  rebalanceMaxStartSlot?: number;
 
   // EV charging (optional — only present when evEnabled is true and EV is plugged in)
   ev?: EvConfig;

--- a/plans/extended-horizon-plan.md
+++ b/plans/extended-horizon-plan.md
@@ -61,14 +61,26 @@ timestamp separating published day-ahead prices from model predictions.
   extended it yields the requested horizon and remains the safety net when a
   source falls short.
 
-## Phase 2 — Solver & EV review
+## Phase 2 — Solver & EV review (this branch)
 
 - EV targets need no new code: entries beyond the old horizon stop being
-  filtered by `ev-config-builder.ts` once the horizon covers them.
-- Rebalancing: restrict `start_balance_k` to day-1 slots so "hold once" keeps
-  its current meaning over a multi-day horizon (and caps that binary count).
-- Verify the escalating symmetry-break penalties (`build-lp.ts`) stay
-  numerically sane at ~384 slots.
+  filtered by `ev-config-builder.ts` once the horizon covers them (covered by
+  a regression test).
+- Rebalancing: `rebalanceMaxStartSlot` restricts `start_balance_k` to day-1
+  slots on extended horizons, so "hold once" keeps its current meaning (and
+  the binary count is capped at one day's worth). Standard horizons are
+  untouched.
+- Symmetry-break penalties verified at 384 slots: the largest escalating
+  coefficient (1e-6 × 384 = 3.84e-4 c€) stays an order of magnitude below the
+  smallest real cost coefficient (~2.5e-3 c€ per W at 10 c€/kWh), and far
+  above solver tolerance.
+- Synthetic 4-day solve benchmark (M-series Mac, WASM HiGHS, gap 0.5%):
+  LP-only 0.13 s, EV binaries 0.55 s, rebalance capped 3.1 s,
+  EV + rebalance capped 18.5 s (uncapped 25.8 s; 7.5 s at gap 2%). All
+  Optimal within the 30 s limit — but EV × rebalance on a 4-day horizon is
+  the combination to watch on slower hardware; fallbacks if the phase-4
+  shadow period shows timeouts: loosen the MIP gap for large horizons, or
+  coarsen far-out slots.
 
 ## Phase 3 — Dashboard
 

--- a/tests/api/services/ev-config-builder.test.js
+++ b/tests/api/services/ev-config-builder.test.js
@@ -223,3 +223,18 @@ describe('buildEvConfig — overdue entries', () => {
     expect(ev.availabilityWindows).toEqual([{ startSlot: 1, endSlot: T, resetSoc_Wh: 24000 }]);
   });
 });
+
+describe('buildEvConfig — multi-day horizon', () => {
+  it('activates a target beyond the standard horizon once T covers it', () => {
+    // Target 3 days out (2024-01-04 12:00 = slot 288 from 2024-01-01 12:00).
+    const entries = [entry('target', '2024-01-04T12:00:00Z', 80)];
+
+    // Standard 24 h horizon: beyond T → ignored (but persisted upstream).
+    const standard = buildEvConfig(base, entries, pluggedIn, NOW_MS, 96);
+    expect(standard.targets).toEqual([]);
+
+    // 4-day horizon: the same entry becomes a real deadline, no re-staging needed.
+    const extended = buildEvConfig(base, entries, pluggedIn, NOW_MS, 384);
+    expect(extended.targets).toEqual([{ slot: 287, soc_Wh: 48000 }]);
+  });
+});

--- a/tests/api/services/solver-timeline.test.js
+++ b/tests/api/services/solver-timeline.test.js
@@ -130,6 +130,23 @@ describe('Solver Timeline Logic (Refactored)', () => {
     expect(extended.pricesKnownUntilMs).toBe(new Date('2024-01-01T14:00:00Z').getTime());
   });
 
+  it('caps rebalance window starts to day 1 only on the extended horizon', () => {
+    const data = {
+      load: { start: '2024-01-01T10:00:00Z', step: 15, values: Array(100).fill(100) },
+      pv: { start: '2024-01-01T10:00:00Z', step: 15, values: Array(100).fill(0) },
+      importPrice: { start: '2024-01-01T10:00:00Z', step: 15, values: Array(100).fill(10) },
+      exportPrice: { start: '2024-01-01T10:00:00Z', step: 15, values: Array(100).fill(5) },
+      soc: { timestamp: '2024-01-01T12:00:00Z', value: 50 }
+    };
+    const rebalanceSettings = { ...mockSettings, rebalanceEnabled: true, rebalanceHoldHours: 3 };
+
+    const standard = buildSolverConfigFromSettings(rebalanceSettings, data);
+    expect(standard.rebalanceMaxStartSlot).toBeUndefined();
+
+    const extended = buildSolverConfigFromSettings({ ...rebalanceSettings, extendedHorizonDays: 2 }, data);
+    expect(extended.rebalanceMaxStartSlot).toBe(95); // 24 h of 15-min slots, 0-indexed
+  });
+
   it('ignores a forecast that leaves a gap after the actual prices', () => {
     const data = {
       load: { start: '2024-01-01T10:00:00Z', step: 15, values: Array(100).fill(100) },

--- a/tests/lib/build-lp.test.js
+++ b/tests/lib/build-lp.test.js
@@ -132,6 +132,28 @@ describe('buildLP — MILP rebalancing', () => {
     expect(lp).toContain('c_balance_start: start_balance_0 = 1');
   });
 
+  it('caps window start positions at rebalanceMaxStartSlot', () => {
+    // T=8, D=3 → starts would be 0..5; cap at 2 → only 0..2
+    const lp = buildLP({ ...mockData, rebalanceRemainingSlots: D, rebalanceTargetSoc_percent: 100, rebalanceMaxStartSlot: 2 });
+    expect(lp).toContain('start_balance_2');
+    expect(lp).not.toContain('start_balance_3');
+    expect(lp).toContain('c_balance_start: start_balance_0 + start_balance_1 + start_balance_2 = 1');
+    // Slots past the last reachable window slot (cap + D - 1 = 4) get no forcing constraint
+    expect(lp).toContain('c_rebalance_4:');
+    expect(lp).not.toContain('c_rebalance_5:');
+  });
+
+  it('ignores a rebalanceMaxStartSlot beyond T - D', () => {
+    const lp = buildLP({ ...mockData, rebalanceRemainingSlots: D, rebalanceTargetSoc_percent: 100, rebalanceMaxStartSlot: 99 });
+    expect(lp).toContain(`start_balance_${T - D}`);
+    expect(lp).not.toContain(`start_balance_${T - D + 1}`);
+  });
+
+  it('clamps a negative rebalanceMaxStartSlot so k=0 always exists', () => {
+    const lp = buildLP({ ...mockData, rebalanceRemainingSlots: D, rebalanceTargetSoc_percent: 100, rebalanceMaxStartSlot: -5 });
+    expect(lp).toContain('c_balance_start: start_balance_0 = 1');
+  });
+
   it('truncates fractional rebalanceRemainingSlots to integer', () => {
     // 2.9 should be treated as 2, not 3
     const lp = buildLP({ ...mockData, rebalanceRemainingSlots: 2.9, rebalanceTargetSoc_percent: 100 });
@@ -512,5 +534,50 @@ describe('buildLP — EV trips (drop windows)', () => {
       ev: { ...evCfg, availabilityWindows: [{ startSlot: 0, endSlot: T, drop_Wh: 5000 }] },
     });
     expect(lp).toMatch(/c_ev_soc_0:.*= 30000\b/);
+  });
+});
+
+describe('buildLP — multi-day horizon (~384 slots)', () => {
+  // 4 days at 15-min slots. Exercises the extended-horizon shape: EV binaries
+  // for every slot plus rebalance binaries capped to day 1.
+  const T = 384;
+  const base = {
+    load_W: Array(T).fill(500),
+    pv_W: Array(T).fill(0),
+    importPrice: Array(T).fill(10),
+    exportPrice: Array(T).fill(5),
+    batteryCapacity_Wh: 10000,
+    maxSoc_percent: 100,
+  };
+  const ev = {
+    evMinChargePower_W: 1380,
+    evMaxChargePower_W: 3680,
+    evBatteryCapacity_Wh: 60000,
+    evInitialSoc_percent: 50,
+    evChargeEfficiency_percent: 90,
+    availabilityWindows: [{ startSlot: 0, endSlot: T }],
+    targets: [{ slot: 300, soc_Wh: 48000 }],
+  };
+
+  it('keeps the escalating symmetry-break penalties well below real cost coefficients', () => {
+    const lp = buildLP({ ...base, ev, rebalanceRemainingSlots: 12, rebalanceTargetSoc_percent: 100, rebalanceMaxStartSlot: 95 });
+
+    // Largest EV symmetry penalty: 1e-6 × 384 = 0.000384 c€ on the last slot.
+    expect(lp).toContain('0.000384 ev_on_383');
+    // Largest rebalance start penalty: capped at day 1 → 1e-6 × 96.
+    expect(lp).toContain('0.000096 start_balance_95');
+    expect(lp).not.toContain('start_balance_96');
+
+    // Real per-slot cost scale for comparison: 10 c€/kWh × 0.25 h / 1000 = 0.0025 c€ per W.
+    // The largest tiebreak (0.000384) stays an order of magnitude below it.
+    expect(lp).toContain('0.0025 grid_to_load_0');
+
+    // toNum must never emit scientific notation, which the LP parser rejects.
+    expect(lp).not.toMatch(/\d[eE][+-]\d/);
+  });
+
+  it('keeps a far-out EV target constraint in the LP', () => {
+    const lp = buildLP({ ...base, ev });
+    expect(lp).toContain('c_ev_target_300: ev_soc_300 >= 48000');
   });
 });


### PR DESCRIPTION
Third stacked PR for the extended planning horizon (plan: `plans/extended-horizon-plan.md`). Stacked on #144 (phase 1); only the last commit is new here.

## What this adds

**Rebalance stays a day-1 decision:**
- New `SolverConfig.rebalanceMaxStartSlot` caps the latest slot at which the rebalance hold window may start. `build-lp.ts` applies it to the `start_balance_k` binaries, the exactly-one-start constraint, and the per-slot SoC forcing.
- `config-builder.ts` sets it to the first 24 h of slots (slot 95 at 15-min steps) only when `extendedHorizonDays > 0` — on a multi-day horizon "hold once" can no longer drift days out, and the binary count is capped at one day's worth. Standard horizons are byte-identical to before.

**EV multi-day targets — verified, no new code:**
- `ev-config-builder.ts` filters entries purely on the horizon slot count, so a "80% in 3 days" target automatically becomes a real LP constraint once the horizon covers it. Added a regression test showing the same entry is ignored at T=96 and active at T=384.

**Numeric verification at ~384 slots:**
- The escalating symmetry-break penalties top out at 1e-6 × 384 = 3.84e-4 c€ — an order of magnitude below the smallest real cost coefficient (~2.5e-3 c€/W at 10 c€/kWh) and far above solver tolerance. A test pins these coefficients and asserts the LP never emits scientific notation.
- Synthetic 4-day solve benchmark (M-series Mac, WASM HiGHS, default 0.5% gap), all Optimal within the 30 s limit:

| configuration | solve time |
|---|---|
| LP only (no binaries) | 0.13 s |
| EV binaries (384) | 0.55 s |
| rebalance, capped to day 1 | 3.1 s |
| EV + rebalance, capped | 18.5 s |
| EV + rebalance, uncapped | 25.8 s |
| EV + rebalance, capped, 2% gap | 7.5 s |

The EV × rebalance combination on a 4-day horizon is the one to watch on slower hardware during the phase-4 shadow period; documented fallbacks are a looser MIP gap for large horizons or coarser far-out slots. Findings recorded in the plan doc.

## Tests
7 new tests (521 total pass): `rebalanceMaxStartSlot` cap/clamp/ignore cases in the LP builder, config-builder wiring (set only on extended horizons), the multi-day EV target regression, and the 384-slot penalty-scale check. Typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)