### PR TITLE
Extended horizon phase 3: multi-day dashboard

### DIFF
--- a/api/routes/calculate.ts
+++ b/api/routes/calculate.ts
@@ -39,6 +39,8 @@ router.post('/', async (req: Request, res: Response, next: NextFunction) => {
       summary,
       rebalanceWindow,
       rebalanceNudge,
+      // Extended horizon: prices past this instant are forecast, not actuals.
+      pricesKnownUntilMs: cfg.pricesKnownUntilMs ?? null,
     });
   } catch (error) {
     logCalculateError(error);

--- a/api/routes/calculate.ts
+++ b/api/routes/calculate.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import type { Request, Response, NextFunction } from 'express';
 import { assertCondition, toHttpError } from '../http-errors.ts';
 import { planAndMaybeWrite } from '../services/planner-service.ts';
+import { getForecastTimeRange } from '../../lib/time-series-utils.ts';
 
 const router = express.Router();
 
@@ -41,6 +42,9 @@ router.post('/', async (req: Request, res: Response, next: NextFunction) => {
       rebalanceNudge,
       // Extended horizon: prices past this instant are forecast, not actuals.
       pricesKnownUntilMs: cfg.pricesKnownUntilMs ?? null,
+      // Canonical end of the classic day-ahead window, computed in the
+      // server's timezone so every client slices the "Standard" view alike.
+      standardWindowEndMs: new Date(getForecastTimeRange(timing.startMs).endIso).getTime(),
     });
   } catch (error) {
     logCalculateError(error);

--- a/app/index.html
+++ b/app/index.html
@@ -571,7 +571,21 @@
     <!-- Power flows — full width -->
     <section class="lg:col-span-3 min-w-0">
       <div class="card">
-        <h3 class="mb-3 sidebar-label">Power flows</h3>
+        <div class="mb-3 flex items-center justify-between gap-4">
+          <h3 class="sidebar-label">Power flows</h3>
+          <div class="flex items-center gap-2">
+            <div id="flows-res-toggle" hidden class="inline-flex rounded-full bg-slate-100 p-0.5 dark:bg-slate-800"
+              role="group" aria-label="Bar resolution">
+              <button id="flows-res-15" type="button">15 min</button>
+              <button id="flows-res-60" type="button">1 h</button>
+            </div>
+            <div id="view-range-toggle" hidden class="inline-flex rounded-full bg-slate-100 p-0.5 dark:bg-slate-800"
+              role="group" aria-label="View range">
+              <button id="view-range-standard" type="button">Standard</button>
+              <button id="view-range-full" type="button">Full horizon</button>
+            </div>
+          </div>
+        </div>
         <div class="h-80 w-full chart-wrap">
           <canvas id="flows" class="h-full w-full"></canvas>
           <div class="chart-empty">

--- a/app/main.js
+++ b/app/main.js
@@ -134,6 +134,8 @@ async function boot() {
     onSave: optimizer.queuePersistSnapshot,
     onRun: optimizer.onRun,
     onTableDisplayChange: optimizer.onTableDisplayChange,
+    onViewRangeChange: optimizer.onViewRangeChange,
+    onFlowsResolutionChange: optimizer.onFlowsResolutionChange,
     updateTerminalCustomUI: () => updateTerminalCustomUI(els),
   });
 

--- a/app/src/charts/solution-charts.js
+++ b/app/src/charts/solution-charts.js
@@ -357,13 +357,13 @@ export function aggregateLoadPvBuckets(rows, stepSize_m = 15) {
   const hourMap = new Map();
 
   for (const row of rows) {
-    const dt = new Date(row.timestampMs);
-    dt.setMinutes(0, 0, 0);
-    const hourMs = dt.getTime();
+    // Absolute-hour bucketing (epoch floor): local wall-clock would collapse
+    // the repeated hour at the autumn DST transition into one bucket.
+    const hourMs = Math.floor(row.timestampMs / 3_600_000) * 3_600_000;
 
     if (!hourMap.has(hourMs)) {
       hourMap.set(hourMs, {
-        dtHour: dt,
+        dtHour: new Date(hourMs),
         loadKWh: 0,
         pvKWh: 0,
         originalLoadKWh: 0,

--- a/app/src/charts/solution-charts.js
+++ b/app/src/charts/solution-charts.js
@@ -242,16 +242,62 @@ function makePriceZeroLinePlugin() {
   };
 }
 
-export function drawPricesStepLines(canvas, rows, _stepSize_m = 15) {
+/**
+ * Shade the part of the chart where prices are forecast (beyond the last
+ * published actual) and label it, so predicted prices are never mistaken for
+ * real ones.
+ */
+function makeForecastZonePlugin(boundaryIdx) {
+  return {
+    id: 'priceForecastZone',
+    beforeDatasetsDraw(chart) {
+      const { ctx, chartArea, scales } = chart;
+      if (!chartArea) return;
+      const xFrom = Math.max(chartArea.left, scales.x.getPixelForValue(boundaryIdx));
+      if (xFrom >= chartArea.right) return;
+
+      ctx.save();
+      ctx.fillStyle = 'rgba(148, 163, 184, 0.08)';
+      ctx.fillRect(xFrom, chartArea.top, chartArea.right - xFrom, chartArea.bottom - chartArea.top);
+      ctx.strokeStyle = 'rgba(148, 163, 184, 0.5)';
+      ctx.lineWidth = 1;
+      ctx.setLineDash([4, 4]);
+      ctx.beginPath();
+      ctx.moveTo(xFrom, chartArea.top);
+      ctx.lineTo(xFrom, chartArea.bottom);
+      ctx.stroke();
+      ctx.setLineDash([]);
+      ctx.fillStyle = getChartTheme().axisTickColor;
+      ctx.font = '600 10px system-ui, sans-serif';
+      ctx.textAlign = 'left';
+      ctx.textBaseline = 'top';
+      ctx.fillText('forecast', xFrom + 6, chartArea.top + 4);
+      ctx.restore();
+    }
+  };
+}
+
+export function drawPricesStepLines(canvas, rows, _stepSize_m = 15, pricesKnownUntilMs = null) {
   const timestampsMs = rows.map(r => r.timestampMs);
   const axis = buildTimeAxisFromTimestamps(timestampsMs);
   const strokeW = (axis.labels.length > 48) ? 1 : 2;
+
+  // First slot whose prices come from the forecast feed rather than
+  // published actuals (-1 when the whole window is actual).
+  const boundaryIdx = pricesKnownUntilMs != null
+    ? timestampsMs.findIndex(ms => ms >= pricesKnownUntilMs)
+    : -1;
 
   const commonLine = {
     stepped: true,
     borderWidth: strokeW,
     pointRadius: 0,
-    pointHitRadius: 8
+    pointHitRadius: 8,
+    ...(boundaryIdx >= 0 ? {
+      segment: {
+        borderDash: (ctx) => (ctx.p0DataIndex >= boundaryIdx ? [4, 3] : undefined),
+      },
+    } : {}),
   };
 
   renderChart(canvas, {
@@ -283,9 +329,10 @@ export function drawPricesStepLines(canvas, rows, _stepSize_m = 15) {
           intersect: false,
           enabled: false,
           external: createTooltipHandler({
-            renderContent: (_idx, tooltip) => {
+            renderContent: (idx, tooltip) => {
               const time = tooltip.title?.[0] ?? "";
-              let html = ttHeader(time);
+              const isForecast = boundaryIdx >= 0 && idx >= boundaryIdx;
+              let html = ttHeader(time, isForecast ? 'forecast' : '');
               for (const pt of (tooltip.dataPoints ?? [])) {
                 html += ttRow(pt.dataset.borderColor, pt.dataset.label, `${pt.raw.toFixed(1)} c€/kWh`);
               }
@@ -296,7 +343,10 @@ export function drawPricesStepLines(canvas, rows, _stepSize_m = 15) {
         },
       },
     }),
-    plugins: [makePriceZeroLinePlugin()]
+    plugins: [
+      makePriceZeroLinePlugin(),
+      ...(boundaryIdx >= 0 ? [makeForecastZonePlugin(boundaryIdx)] : []),
+    ]
   });
 }
 

--- a/app/src/optimizer-controller.js
+++ b/app/src/optimizer-controller.js
@@ -49,6 +49,7 @@ export function createOptimizerController({ els, services = {}, getEvEntries = (
   let lastTableRows = [];
   let lastTableRebalanceWindow = null;
   let lastPricesKnownUntilMs = null;
+  let lastStandardWindowEndMs = null;
 
   const debounceRun = deps.debounce(onRun, 250);
   const persistConfigDebounced = deps.debounce((cfg) => {
@@ -93,6 +94,7 @@ export function createOptimizerController({ els, services = {}, getEvEntries = (
       lastTableRows = rows;
       lastTableRebalanceWindow = result.rebalanceWindow ?? null;
       lastPricesKnownUntilMs = result.pricesKnownUntilMs ?? null;
+      lastStandardWindowEndMs = result.standardWindowEndMs ?? null;
 
       renderVisuals();
       deps.updateEvPanel(els, rows, result.summary, cfgForViz.stepSize_m, evSettings);
@@ -123,11 +125,14 @@ export function createOptimizerController({ els, services = {}, getEvEntries = (
   }
 
   // The rows currently shown: the full plan, or its standard-window prefix.
+  // The boundary comes from the server (plan timezone); browser-local fallback.
   function getVisibleRows() {
     if (!lastTableRows.length) return { rows: [], view: "standard", hasExtended: false };
-    const hasExtended = planExceedsStandardView(lastTableRows);
+    const hasExtended = planExceedsStandardView(lastTableRows, lastStandardWindowEndMs);
     const view = hasExtended ? getStoredViewRange() : "standard";
-    const rows = view === "full" ? lastTableRows : sliceRowsToStandardView(lastTableRows);
+    const rows = view === "full"
+      ? lastTableRows
+      : sliceRowsToStandardView(lastTableRows, lastStandardWindowEndMs);
     return { rows, view, hasExtended };
   }
 

--- a/app/src/optimizer-controller.js
+++ b/app/src/optimizer-controller.js
@@ -15,6 +15,18 @@ import {
   updateRebalanceNudgeUI,
   updateSummaryUI,
 } from "./state.js";
+import {
+  aggregateRowsHourly,
+  clampRebalanceWindow,
+  getStoredFlowsResolution,
+  getStoredViewRange,
+  mapRebalanceWindowToRows,
+  planExceedsStandardView,
+  rowsSpanHours,
+  sliceRowsToStandardView,
+  storeFlowsResolution,
+  storeViewRange,
+} from "./plan-view.js";
 
 export function createOptimizerController({ els, services = {}, getEvEntries = () => [], onPlanRows = () => {} }) {
   const deps = {
@@ -36,6 +48,7 @@ export function createOptimizerController({ els, services = {}, getEvEntries = (
 
   let lastTableRows = [];
   let lastTableRebalanceWindow = null;
+  let lastPricesKnownUntilMs = null;
 
   const debounceRun = deps.debounce(onRun, 250);
   const persistConfigDebounced = deps.debounce((cfg) => {
@@ -79,9 +92,9 @@ export function createOptimizerController({ els, services = {}, getEvEntries = (
 
       lastTableRows = rows;
       lastTableRebalanceWindow = result.rebalanceWindow ?? null;
-      renderScheduleTable();
+      lastPricesKnownUntilMs = result.pricesKnownUntilMs ?? null;
 
-      renderAllCharts(rows, cfgForViz, result.rebalanceWindow ?? null, evSettings);
+      renderVisuals();
       deps.updateEvPanel(els, rows, result.summary, cfgForViz.stepSize_m, evSettings);
       onPlanRows(rows);
     } catch (err) {
@@ -109,25 +122,89 @@ export function createOptimizerController({ els, services = {}, getEvEntries = (
     }
   }
 
+  // The rows currently shown: the full plan, or its standard-window prefix.
+  function getVisibleRows() {
+    if (!lastTableRows.length) return { rows: [], view: "standard", hasExtended: false };
+    const hasExtended = planExceedsStandardView(lastTableRows);
+    const view = hasExtended ? getStoredViewRange() : "standard";
+    const rows = view === "full" ? lastTableRows : sliceRowsToStandardView(lastTableRows);
+    return { rows, view, hasExtended };
+  }
+
   function renderScheduleTable() {
     if (!lastTableRows.length) return false;
+    const { rows } = getVisibleRows();
     deps.renderTable({
-      rows: lastTableRows,
+      rows,
       cfg: getVizConfig(),
       targets: { table: els.table, tableUnit: els.tableUnit },
       showKwh: !!els.tableKwh?.checked,
       showDess: !!els.tableDess?.checked,
-      rebalanceWindow: lastTableRebalanceWindow,
+      rebalanceWindow: clampRebalanceWindow(lastTableRebalanceWindow, rows.length),
       evSettings: getEvSettings(),
     });
     return true;
   }
 
-  function renderAllCharts(rows, cfg, rebalanceWindow = null, evSettings = null) {
-    deps.drawFlowsBarStackSigned(els.flows, rows, cfg.stepSize_m, rebalanceWindow, evSettings);
+  // Re-render charts + table from the cached plan (no solve).
+  function renderVisuals() {
+    if (!lastTableRows.length) return false;
+    const cfg = getVizConfig();
+    const evSettings = getEvSettings();
+    const { rows, view, hasExtended } = getVisibleRows();
+    const rebalanceWindow = clampRebalanceWindow(lastTableRebalanceWindow, rows.length);
+
+    // Hourly bars keep the multi-day view readable; the standard view always
+    // uses native slots. Default to hourly beyond 48 h unless the user chose.
+    const spanH = rowsSpanHours(rows);
+    const canAggregate = spanH > 48;
+    const resolution = canAggregate ? (getStoredFlowsResolution() ?? "60") : "15";
+
+    updateViewToggleUI(hasExtended, view, canAggregate, resolution);
+
+    if (resolution === "60") {
+      const hourlyRows = aggregateRowsHourly(rows, cfg.stepSize_m);
+      deps.drawFlowsBarStackSigned(
+        els.flows, hourlyRows, 60,
+        mapRebalanceWindowToRows(rebalanceWindow, rows, hourlyRows),
+        evSettings,
+      );
+    } else {
+      deps.drawFlowsBarStackSigned(els.flows, rows, cfg.stepSize_m, rebalanceWindow, evSettings);
+    }
     deps.drawSocChart(els.soc, rows, cfg.stepSize_m, evSettings);
-    deps.drawPricesStepLines(els.prices, rows, cfg.stepSize_m);
+    deps.drawPricesStepLines(els.prices, rows, cfg.stepSize_m, lastPricesKnownUntilMs);
     deps.drawLoadPvGrouped(els.loadpv, rows, cfg.stepSize_m);
+    renderScheduleTable();
+    return true;
+  }
+
+  const SEG_ACTIVE = "rounded-full px-2.5 py-1 text-xs font-medium bg-white text-ink shadow-sm dark:bg-slate-700 dark:text-slate-100 transition-all";
+  const SEG_INACTIVE = "rounded-full px-2.5 py-1 text-xs font-medium text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200 transition-all";
+
+  function setSegState(btn, active) {
+    if (!btn) return;
+    btn.className = active ? SEG_ACTIVE : SEG_INACTIVE;
+    btn.setAttribute("aria-pressed", String(active));
+  }
+
+  function updateViewToggleUI(hasExtended, view, canAggregate, resolution) {
+    if (els.viewRangeToggle) els.viewRangeToggle.hidden = !hasExtended;
+    setSegState(els.viewRangeStandard, view === "standard");
+    setSegState(els.viewRangeFull, view === "full");
+    if (els.flowsResToggle) els.flowsResToggle.hidden = !canAggregate;
+    setSegState(els.flowsRes15, resolution === "15");
+    setSegState(els.flowsRes60, resolution === "60");
+  }
+
+  function onViewRangeChange(range) {
+    storeViewRange(range);
+    renderVisuals();
+  }
+
+  function onFlowsResolutionChange(resolution) {
+    storeFlowsResolution(resolution);
+    renderVisuals();
   }
 
   async function persistConfig(cfg = deps.snapshotUI(els)) {
@@ -182,9 +259,12 @@ export function createOptimizerController({ els, services = {}, getEvEntries = (
     debounceRun,
     onRun,
     onTableDisplayChange,
+    onViewRangeChange,
+    onFlowsResolutionChange,
     persistConfig,
     persistConfigDebounced,
     queuePersistSnapshot,
     renderScheduleTable,
+    renderVisuals,
   };
 }

--- a/app/src/plan-view.js
+++ b/app/src/plan-view.js
@@ -1,0 +1,162 @@
+/**
+ * plan-view.js
+ *
+ * Pure helpers for the extended-horizon dashboard views: slicing plan rows to
+ * the standard (day-ahead) window, hourly aggregation for bar charts, and the
+ * client-side persistence of the view toggles.
+ */
+
+const VIEW_RANGE_KEY = "optivolt:viewRange";
+const FLOWS_RES_KEY = "optivolt:flowsResolution";
+
+/**
+ * End of the "standard" view for a plan starting at the given timestamp: the
+ * classic day-ahead window (local midnight tonight before 13:00, midnight
+ * tomorrow after), mirroring the server's forecast windows.
+ */
+export function standardViewEndMs(firstTimestampMs) {
+  const d = new Date(firstTimestampMs);
+  const dayOffset = d.getHours() < 13 ? 1 : 2;
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate() + dayOffset, 0, 0, 0, 0).getTime();
+}
+
+/** Rows within the standard window (a prefix of the plan, so slot indices are preserved). */
+export function sliceRowsToStandardView(rows) {
+  if (!Array.isArray(rows) || rows.length === 0) return rows ?? [];
+  const endMs = standardViewEndMs(rows[0].timestampMs);
+  const idx = rows.findIndex((r) => r.timestampMs >= endMs);
+  return idx < 0 ? rows : rows.slice(0, idx);
+}
+
+/** True when the plan extends beyond the standard window (i.e. a view toggle is useful). */
+export function planExceedsStandardView(rows) {
+  if (!Array.isArray(rows) || rows.length === 0) return false;
+  return rows[rows.length - 1].timestampMs >= standardViewEndMs(rows[0].timestampMs);
+}
+
+/** Span of the given rows in hours (0 for empty/single-row input). */
+export function rowsSpanHours(rows) {
+  if (!Array.isArray(rows) || rows.length < 2) return 0;
+  return (rows[rows.length - 1].timestampMs - rows[0].timestampMs) / 3_600_000;
+}
+
+/**
+ * Clamp a rebalance window (slot indices into the full plan) to the first
+ * `visibleLength` rows. Standard-view slicing keeps the row prefix, so
+ * indices stay valid — the window just gets cut off or dropped.
+ */
+export function clampRebalanceWindow(window, visibleLength) {
+  if (!window || window.startIdx >= visibleLength) return null;
+  return { startIdx: window.startIdx, endIdx: Math.min(window.endIdx, visibleLength - 1) };
+}
+
+// Flow-like fields: aggregated so that mean W × 1 h equals the summed slot
+// energy (missing slots in a partial hour count as zero).
+const ENERGY_MEAN_KEYS = [
+  "load", "pv",
+  "g2l", "g2b", "pv2l", "pv2b", "pv2g", "b2l", "b2g",
+  "g2ev", "pv2ev", "b2ev", "ev_charge",
+  "imp", "exp",
+];
+const SUM_KEYS = ["importCost_cents", "exportCost_cents"];
+const SLOT_MEAN_KEYS = ["ic", "ec"]; // prices: plain mean over present slots
+
+/**
+ * Aggregate 15-min plan rows into hourly rows of the same shape, for readable
+ * bar charts on multi-day horizons. Flows become the hour's average power
+ * (energy-preserving: mean W × 1 h = summed slot energy), prices the mean,
+ * costs the sum, and SoC values the hour's last slot.
+ */
+export function aggregateRowsHourly(rows, stepSize_m = 15) {
+  const slotsPerHour = Math.max(1, Math.round(60 / stepSize_m));
+  const buckets = new Map();
+
+  for (const row of rows) {
+    const dt = new Date(row.timestampMs);
+    dt.setMinutes(0, 0, 0);
+    const hourMs = dt.getTime();
+    if (!buckets.has(hourMs)) {
+      buckets.set(hourMs, { rows: [], hourMs });
+    }
+    buckets.get(hourMs).rows.push(row);
+  }
+
+  return [...buckets.values()]
+    .sort((a, b) => a.hourMs - b.hourMs)
+    .map(({ rows: slotRows, hourMs }, bucketIdx) => {
+      const last = slotRows[slotRows.length - 1];
+      const out = { ...last, tIdx: bucketIdx, timestampMs: hourMs };
+      for (const key of ENERGY_MEAN_KEYS) {
+        out[key] = slotRows.reduce((sum, r) => sum + (Number(r[key]) || 0), 0) / slotsPerHour;
+      }
+      for (const key of SUM_KEYS) {
+        out[key] = slotRows.reduce((sum, r) => sum + (Number(r[key]) || 0), 0);
+      }
+      for (const key of SLOT_MEAN_KEYS) {
+        out[key] = slotRows.reduce((sum, r) => sum + (Number(r[key]) || 0), 0) / slotRows.length;
+      }
+      // Original (pre-adjustment) predictions, only when some slot carried one.
+      for (const [key, base] of [["originalLoad", "load"], ["originalPv", "pv"]]) {
+        if (slotRows.some((r) => r[key] != null)) {
+          out[key] = slotRows.reduce((sum, r) => sum + (Number(r[key] ?? r[base]) || 0), 0) / slotsPerHour;
+        } else {
+          delete out[key];
+        }
+      }
+      return out;
+    });
+}
+
+/** Re-express a rebalance window given in `sourceRows` indices as indices into `targetRows` (by timestamp). */
+export function mapRebalanceWindowToRows(window, sourceRows, targetRows) {
+  if (!window) return null;
+  const startMs = sourceRows[window.startIdx]?.timestampMs;
+  const endMs = sourceRows[window.endIdx]?.timestampMs;
+  if (startMs == null || endMs == null) return null;
+  const containing = (ms) => {
+    let idx = -1;
+    for (let i = 0; i < targetRows.length; i++) {
+      if (targetRows[i].timestampMs <= ms) idx = i;
+      else break;
+    }
+    return idx;
+  };
+  const startIdx = containing(startMs);
+  const endIdx = containing(endMs);
+  if (startIdx < 0 || endIdx < 0) return null;
+  return { startIdx, endIdx };
+}
+
+// ---------------------------------------------------------------------------
+// Client-side persistence of the view toggles (localStorage; never synced)
+// ---------------------------------------------------------------------------
+
+export function getStoredViewRange() {
+  try {
+    return localStorage.getItem(VIEW_RANGE_KEY) === "full" ? "full" : "standard";
+  } catch {
+    return "standard";
+  }
+}
+
+export function storeViewRange(range) {
+  try {
+    localStorage.setItem(VIEW_RANGE_KEY, range === "full" ? "full" : "standard");
+  } catch { /* private mode etc. — the toggle just won't persist */ }
+}
+
+/** Explicit user choice ('15' | '60'), or null meaning "auto". */
+export function getStoredFlowsResolution() {
+  try {
+    const v = localStorage.getItem(FLOWS_RES_KEY);
+    return v === "15" || v === "60" ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+export function storeFlowsResolution(res) {
+  try {
+    localStorage.setItem(FLOWS_RES_KEY, res === "60" ? "60" : "15");
+  } catch { /* ignore */ }
+}

--- a/app/src/plan-view.js
+++ b/app/src/plan-view.js
@@ -10,9 +10,11 @@ const VIEW_RANGE_KEY = "optivolt:viewRange";
 const FLOWS_RES_KEY = "optivolt:flowsResolution";
 
 /**
- * End of the "standard" view for a plan starting at the given timestamp: the
- * classic day-ahead window (local midnight tonight before 13:00, midnight
- * tomorrow after), mirroring the server's forecast windows.
+ * Fallback end of the "standard" view for a plan starting at the given
+ * timestamp: the classic day-ahead window (local midnight tonight before
+ * 13:00, midnight tomorrow after). Only used when the server didn't provide
+ * `standardWindowEndMs` — the browser's timezone may differ from the one the
+ * plan was made in, so the server value is authoritative.
  */
 export function standardViewEndMs(firstTimestampMs) {
   const d = new Date(firstTimestampMs);
@@ -20,18 +22,26 @@ export function standardViewEndMs(firstTimestampMs) {
   return new Date(d.getFullYear(), d.getMonth(), d.getDate() + dayOffset, 0, 0, 0, 0).getTime();
 }
 
-/** Rows within the standard window (a prefix of the plan, so slot indices are preserved). */
-export function sliceRowsToStandardView(rows) {
+function resolveStandardEndMs(rows, standardEndMs) {
+  return Number.isFinite(standardEndMs) ? standardEndMs : standardViewEndMs(rows[0].timestampMs);
+}
+
+/**
+ * Rows within the standard window (a prefix of the plan, so slot indices are
+ * preserved). `standardEndMs` is the server-provided boundary; without it the
+ * browser-local fallback applies.
+ */
+export function sliceRowsToStandardView(rows, standardEndMs = null) {
   if (!Array.isArray(rows) || rows.length === 0) return rows ?? [];
-  const endMs = standardViewEndMs(rows[0].timestampMs);
+  const endMs = resolveStandardEndMs(rows, standardEndMs);
   const idx = rows.findIndex((r) => r.timestampMs >= endMs);
   return idx < 0 ? rows : rows.slice(0, idx);
 }
 
 /** True when the plan extends beyond the standard window (i.e. a view toggle is useful). */
-export function planExceedsStandardView(rows) {
+export function planExceedsStandardView(rows, standardEndMs = null) {
   if (!Array.isArray(rows) || rows.length === 0) return false;
-  return rows[rows.length - 1].timestampMs >= standardViewEndMs(rows[0].timestampMs);
+  return rows[rows.length - 1].timestampMs >= resolveStandardEndMs(rows, standardEndMs);
 }
 
 /** Span of the given rows in hours (0 for empty/single-row input). */
@@ -72,9 +82,10 @@ export function aggregateRowsHourly(rows, stepSize_m = 15) {
   const buckets = new Map();
 
   for (const row of rows) {
-    const dt = new Date(row.timestampMs);
-    dt.setMinutes(0, 0, 0);
-    const hourMs = dt.getTime();
+    // Bucket by absolute hour (epoch floor), not local wall-clock: at the
+    // autumn DST transition the repeated local hour would otherwise collapse
+    // two physical hours into one bucket.
+    const hourMs = Math.floor(row.timestampMs / 3_600_000) * 3_600_000;
     if (!buckets.has(hourMs)) {
       buckets.set(hourMs, { rows: [], hourMs });
     }

--- a/app/src/table.js
+++ b/app/src/table.js
@@ -185,9 +185,37 @@ export function renderTable({ rows, cfg, targets, showKwh, showDess = false, reb
       <tr class="border-t border-slate-100 dark:border-slate-800/60">${totalsRow}</tr>
     </thead>`;
 
-  const tbody = `
-    <tbody>
-      ${rows.map((r, ri) => {
+  // On multi-day (extended-horizon) views, group rows after the first day
+  // into collapsible day sections so the table stays navigable.
+  const spanH = rows.length > 1
+    ? (rows[rows.length - 1].timestampMs - rows[0].timestampMs) / 3_600_000
+    : 0;
+  const useDaySections = spanH > 48;
+  const fmtDay = new Intl.DateTimeFormat("en-GB", { weekday: "short", day: "2-digit", month: "short" });
+  const dayKeyOf = (ms) => {
+    const dt = new Date(ms);
+    return `${dt.getFullYear()}-${dt.getMonth() + 1}-${dt.getDate()}`;
+  };
+
+  const bodyParts = [];
+  let currentDayKey = rows.length ? dayKeyOf(rows[0].timestampMs) : null;
+  let inSection = false;
+
+  rows.forEach((r, ri) => {
+    if (useDaySections && ri > 0) {
+      const key = dayKeyOf(r.timestampMs);
+      if (key !== currentDayKey) {
+        currentDayKey = key;
+        inSection = true;
+        bodyParts.push(
+          `<tr class="cursor-pointer select-none bg-slate-100/80 dark:bg-slate-800/80" data-day-toggle="${key}">`
+          + `<td colspan="${cols.length}" class="px-2 py-1.5 text-left text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400">`
+          + `<span class="day-chevron inline-block transition-transform">▾</span> ${fmtDay.format(new Date(r.timestampMs))}`
+          + `</td></tr>`
+        );
+      }
+    }
+
     const timeLabel = cols[0].fmt(null, ri); // "time" column
     const isMidnightRow = /^\d{2}\/\d{2}$/.test(timeLabel);
 
@@ -209,12 +237,32 @@ export function renderTable({ rows, cfg, targets, showKwh, showDess = false, reb
     const isRebalancing = rebalanceWindow != null && ri >= rebalanceWindow.startIdx && ri <= rebalanceWindow.endIdx;
     const rowBg = isRebalancing ? "bg-sky-100 dark:bg-sky-900/50" : "";
     const isDeparture = departureIdxs.has(ri);
-    return `<tr class="border-b border-slate-100/70 dark:border-slate-800/60 hover:bg-slate-50/60 dark:hover:bg-slate-800/60 ${rowBg}${isDeparture ? ' ring-1 ring-inset ring-emerald-200 dark:ring-emerald-800/50' : ''}">${tds}</tr>`;
-  }).join("")}
+    const dayAttr = inSection ? ` data-day="${currentDayKey}"` : "";
+    bodyParts.push(`<tr${dayAttr} class="border-b border-slate-100/70 dark:border-slate-800/60 hover:bg-slate-50/60 dark:hover:bg-slate-800/60 ${rowBg}${isDeparture ? ' ring-1 ring-inset ring-emerald-200 dark:ring-emerald-800/50' : ''}">${tds}</tr>`);
+  });
+
+  const tbody = `
+    <tbody>
+      ${bodyParts.join("")}
     </tbody>`;
 
   table.innerHTML = thead + tbody;
   if (tableUnit) tableUnit.textContent = showKwh ? "kWh" : "W";
+
+  // Collapse/expand a day's rows by clicking its header (delegated; assigning
+  // onclick keeps a single handler across re-renders).
+  table.onclick = (event) => {
+    const header = event.target.closest?.("[data-day-toggle]");
+    if (!header || !table.contains(header)) return;
+    const key = header.getAttribute("data-day-toggle");
+    const collapsed = header.classList.toggle("day-collapsed");
+    // key is our own "YYYY-M-D" string — digits and dashes, no escaping needed.
+    for (const tr of table.querySelectorAll(`tr[data-day="${key}"]`)) {
+      tr.classList.toggle("hidden", collapsed);
+    }
+    const chevron = header.querySelector(".day-chevron");
+    if (chevron) chevron.style.transform = collapsed ? "rotate(-90deg)" : "";
+  };
 
   // helpers (module-local)
   function fmtEnergy(x, { dash = true } = {}) {

--- a/app/src/table.js
+++ b/app/src/table.js
@@ -197,7 +197,10 @@ export function renderTable({ rows, cfg, targets, showKwh, showDess = false, reb
     return `${dt.getFullYear()}-${dt.getMonth() + 1}-${dt.getDate()}`;
   };
 
-  const bodyParts = [];
+  // Each day after the first becomes its own <tbody> with a header row whose
+  // <button> toggles the section — a real button so the disclosure is
+  // keyboard-operable, with aria-expanded/aria-controls exposing its state.
+  const sections = [{ headerHtml: null, id: null, rowParts: [] }];
   let currentDayKey = rows.length ? dayKeyOf(rows[0].timestampMs) : null;
   let inSection = false;
 
@@ -207,12 +210,19 @@ export function renderTable({ rows, cfg, targets, showKwh, showDess = false, reb
       if (key !== currentDayKey) {
         currentDayKey = key;
         inSection = true;
-        bodyParts.push(
-          `<tr class="cursor-pointer select-none bg-slate-100/80 dark:bg-slate-800/80" data-day-toggle="${key}">`
-          + `<td colspan="${cols.length}" class="px-2 py-1.5 text-left text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400">`
-          + `<span class="day-chevron inline-block transition-transform">▾</span> ${fmtDay.format(new Date(r.timestampMs))}`
-          + `</td></tr>`
-        );
+        const sectionId = `schedule-day-${key}`;
+        const dayLabel = fmtDay.format(new Date(r.timestampMs));
+        sections.push({
+          id: sectionId,
+          headerHtml:
+            `<tr class="select-none bg-slate-100/80 dark:bg-slate-800/80">`
+            + `<td colspan="${cols.length}" class="p-0">`
+            + `<button type="button" data-day-toggle="${key}" aria-expanded="true" aria-controls="${sectionId}"`
+            + ` class="flex w-full cursor-pointer items-center gap-1.5 px-2 py-1.5 text-left text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400">`
+            + `<span class="day-chevron inline-block transition-transform" aria-hidden="true">▾</span> ${dayLabel}`
+            + `</button></td></tr>`,
+          rowParts: [],
+        });
       }
     }
 
@@ -238,29 +248,30 @@ export function renderTable({ rows, cfg, targets, showKwh, showDess = false, reb
     const rowBg = isRebalancing ? "bg-sky-100 dark:bg-sky-900/50" : "";
     const isDeparture = departureIdxs.has(ri);
     const dayAttr = inSection ? ` data-day="${currentDayKey}"` : "";
-    bodyParts.push(`<tr${dayAttr} class="border-b border-slate-100/70 dark:border-slate-800/60 hover:bg-slate-50/60 dark:hover:bg-slate-800/60 ${rowBg}${isDeparture ? ' ring-1 ring-inset ring-emerald-200 dark:ring-emerald-800/50' : ''}">${tds}</tr>`);
+    sections[sections.length - 1].rowParts.push(`<tr${dayAttr} class="border-b border-slate-100/70 dark:border-slate-800/60 hover:bg-slate-50/60 dark:hover:bg-slate-800/60 ${rowBg}${isDeparture ? ' ring-1 ring-inset ring-emerald-200 dark:ring-emerald-800/50' : ''}">${tds}</tr>`);
   });
 
-  const tbody = `
-    <tbody>
-      ${bodyParts.join("")}
-    </tbody>`;
+  const tbody = sections
+    .map((s) => `<tbody${s.id ? ` id="${s.id}"` : ""}>${s.headerHtml ?? ""}${s.rowParts.join("")}</tbody>`)
+    .join("");
 
   table.innerHTML = thead + tbody;
   if (tableUnit) tableUnit.textContent = showKwh ? "kWh" : "W";
 
-  // Collapse/expand a day's rows by clicking its header (delegated; assigning
-  // onclick keeps a single handler across re-renders).
+  // Collapse/expand a day's rows via its header button (delegated; assigning
+  // onclick keeps a single handler across re-renders). The button provides
+  // native keyboard activation (Enter/Space); we only track expanded state.
   table.onclick = (event) => {
-    const header = event.target.closest?.("[data-day-toggle]");
-    if (!header || !table.contains(header)) return;
-    const key = header.getAttribute("data-day-toggle");
-    const collapsed = header.classList.toggle("day-collapsed");
+    const button = event.target.closest?.("button[data-day-toggle]");
+    if (!button || !table.contains(button)) return;
+    const key = button.getAttribute("data-day-toggle");
+    const collapsed = button.getAttribute("aria-expanded") === "true";
+    button.setAttribute("aria-expanded", String(!collapsed));
     // key is our own "YYYY-M-D" string — digits and dashes, no escaping needed.
     for (const tr of table.querySelectorAll(`tr[data-day="${key}"]`)) {
       tr.classList.toggle("hidden", collapsed);
     }
-    const chevron = header.querySelector(".day-chevron");
+    const chevron = button.querySelector(".day-chevron");
     if (chevron) chevron.style.transform = collapsed ? "rotate(-90deg)" : "";
   };
 

--- a/app/src/ui-binding.js
+++ b/app/src/ui-binding.js
@@ -42,6 +42,12 @@ export function getElements() {
     planTsStart: $("#plan-ts-start"),
 
     // charts + status
+    viewRangeToggle: $("#view-range-toggle"),
+    viewRangeStandard: $("#view-range-standard"),
+    viewRangeFull: $("#view-range-full"),
+    flowsResToggle: $("#flows-res-toggle"),
+    flowsRes15: $("#flows-res-15"),
+    flowsRes60: $("#flows-res-60"),
     flows: $("#flows"),
     soc: $("#soc"),
     prices: $("#prices"),
@@ -139,7 +145,10 @@ export function getElements() {
 
 export function wireGlobalInputs(
   els,
-  { onInput, onSave = onInput, onRun, onTableDisplayChange = onRun, updateTerminalCustomUI }
+  {
+    onInput, onSave = onInput, onRun, onTableDisplayChange = onRun, updateTerminalCustomUI,
+    onViewRangeChange, onFlowsResolutionChange,
+  }
 ) {
   // Auto-save only settings-owned controls.
   for (const el of document.querySelectorAll("[data-settings-input]")) {
@@ -158,6 +167,16 @@ export function wireGlobalInputs(
   // Table display toggles
   els.tableKwh?.addEventListener("change", onTableDisplayChange);
   els.tableDess?.addEventListener("change", onTableDisplayChange);
+
+  // View-range + bar-resolution toggles (extended horizon)
+  if (onViewRangeChange) {
+    els.viewRangeStandard?.addEventListener("click", () => onViewRangeChange("standard"));
+    els.viewRangeFull?.addEventListener("click", () => onViewRangeChange("full"));
+  }
+  if (onFlowsResolutionChange) {
+    els.flowsRes15?.addEventListener("click", () => onFlowsResolutionChange("15"));
+    els.flowsRes60?.addEventListener("click", () => onFlowsResolutionChange("60"));
+  }
 
   // Keyboard shortcut: Ctrl+Enter (or Cmd+Enter) to Recompute
   document.addEventListener("keydown", (e) => {

--- a/plans/extended-horizon-plan.md
+++ b/plans/extended-horizon-plan.md
@@ -82,16 +82,22 @@ timestamp separating published day-ahead prices from model predictions.
   shadow period shows timeouts: loosen the MIP gap for large horizons, or
   coarsen far-out slots.
 
-## Phase 3 — Dashboard
+## Phase 3 — Dashboard (this branch)
 
-- Dashed price line beyond `pricesKnownUntilMs` (Chart.js `segment.borderDash`)
-  plus a shaded "forecast zone" background.
-- View-range toggle "Standard | Full horizon", defaulting to Standard so the
-  default UX is unchanged; persisted client-side.
-- Hourly aggregation for bar charts in the full-horizon view (sum energy,
-  average power), with a 15 min/1 h toggle; auto-select 1 h beyond ~48 h.
-- Verify multi-day EV annotations (previously skipped beyond the horizon) and
-  add day-collapsible sections to the table.
+- `/calculate` exposes `pricesKnownUntilMs`; the prices chart dashes the line
+  beyond it (`segment.borderDash`), shades the forecast zone, and marks
+  forecast slots in the tooltip.
+- View-range toggle "Standard | Full horizon" on the Power flows card, shown
+  only when the plan extends past the standard day-ahead window; defaults to
+  Standard (unchanged UX) and persists in localStorage.
+- Power-flows bars aggregate to hourly in views spanning > 48 h (energy-
+  preserving means; prices averaged, costs summed, SoC last-of-hour), with a
+  15 min/1 h toggle; auto-selects 1 h, the user's explicit choice persists.
+  The load/PV chart was already hourly; SoC and prices stay per-slot lines.
+- Multi-day EV annotations verified: markers already skip out-of-range times,
+  so they appear in the full view and vanish in Standard.
+- Schedule table groups days after the first into collapsible day sections on
+  views spanning > 48 h; the standard layout is untouched.
 
 ## Phase 4 — Validation
 

--- a/tests/api/api.test.js
+++ b/tests/api/api.test.js
@@ -98,6 +98,9 @@ describe('Integration: API', () => {
     expect(res.status).toBe(200);
     expect(res.body.solverStatus).toBe('Optimal');
     expect(res.body.rows).toHaveLength(5);
+    // Canonical day-ahead boundary for the client's "Standard" view slicing.
+    expect(res.body.standardWindowEndMs).toBeTypeOf('number');
+    expect(res.body.standardWindowEndMs).toBeGreaterThan(Date.now() - 24 * 3_600_000);
     expect(res.body.rebalanceNudge).toEqual({
       lastFullSocAt: null,
       daysSinceLastFullSoc: null,

--- a/tests/app/optimizer-controller.test.js
+++ b/tests/app/optimizer-controller.test.js
@@ -109,7 +109,7 @@ describe('optimizer controller', () => {
     expect(tableArgs.targets).toEqual({ table: els.table, tableUnit: els.tableUnit });
     expect(tableArgs.showKwh).toBe(true);
     expect(tableArgs.showDess).toBe(false);
-    expect(tableArgs.rebalanceWindow).toBe(rebalanceWindow);
+    expect(tableArgs.rebalanceWindow).toEqual(rebalanceWindow);
     expect(tableArgs.evSettings).toEqual({
       arrivals: [],
       departures: ['2026-05-01T18:30'],
@@ -125,7 +125,7 @@ describe('optimizer controller', () => {
       tableArgs.evSettings,
     );
     expect(services.drawSocChart).toHaveBeenCalledWith(els.soc, rows, 30, tableArgs.evSettings);
-    expect(services.drawPricesStepLines).toHaveBeenCalledWith(els.prices, rows, 30);
+    expect(services.drawPricesStepLines).toHaveBeenCalledWith(els.prices, rows, 30, null);
     expect(services.drawLoadPvGrouped).toHaveBeenCalledWith(els.loadpv, rows, 30);
     expect(services.updateEvPanel).toHaveBeenCalledWith(els, rows, summary, 30, tableArgs.evSettings);
     expect(els.status.textContent).toBe('Plan updated');

--- a/tests/app/plan-view.test.js
+++ b/tests/app/plan-view.test.js
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import {
+  standardViewEndMs,
+  sliceRowsToStandardView,
+  planExceedsStandardView,
+  rowsSpanHours,
+  clampRebalanceWindow,
+  aggregateRowsHourly,
+  mapRebalanceWindowToRows,
+} from '../../app/src/plan-view.js';
+
+// Build rows at 15-min steps starting from a local time.
+function makeRows(startLocal, count, fields = {}) {
+  const startMs = startLocal.getTime();
+  return Array.from({ length: count }, (_, i) => ({
+    tIdx: i,
+    timestampMs: startMs + i * 15 * 60_000,
+    load: 400, pv: 0, ic: 20, ec: 8,
+    g2l: 400, g2b: 0, pv2l: 0, pv2b: 0, pv2g: 0, b2l: 0, b2g: 0,
+    imp: 400, exp: 0,
+    importCost_cents: 2, exportCost_cents: 0,
+    soc_percent: 50 + i,
+    ...fields,
+  }));
+}
+
+describe('standard view slicing', () => {
+  it('ends at midnight tonight when the plan starts before 13:00', () => {
+    const start = new Date(2026, 4, 1, 10, 0); // May 1st, 10:00 local
+    expect(standardViewEndMs(start.getTime())).toBe(new Date(2026, 4, 2, 0, 0).getTime());
+  });
+
+  it('ends at midnight tomorrow when the plan starts at/after 13:00', () => {
+    const start = new Date(2026, 4, 1, 14, 0);
+    expect(standardViewEndMs(start.getTime())).toBe(new Date(2026, 4, 3, 0, 0).getTime());
+  });
+
+  it('slices rows to the standard window, keeping the prefix', () => {
+    // 14:00 local + 4 days of slots; standard end = midnight tomorrow (34 h → 136 slots).
+    const rows = makeRows(new Date(2026, 4, 1, 14, 0), 384);
+    const sliced = sliceRowsToStandardView(rows);
+    expect(sliced.length).toBe(136);
+    expect(sliced[0]).toBe(rows[0]);
+    expect(planExceedsStandardView(rows)).toBe(true);
+  });
+
+  it('returns the rows unchanged (same reference) when nothing extends past the window', () => {
+    const rows = makeRows(new Date(2026, 4, 1, 14, 0), 96); // 24 h < 34 h window
+    expect(sliceRowsToStandardView(rows)).toBe(rows);
+    expect(planExceedsStandardView(rows)).toBe(false);
+  });
+});
+
+describe('rowsSpanHours / clampRebalanceWindow', () => {
+  it('computes the span in hours', () => {
+    const rows = makeRows(new Date(2026, 4, 1, 0, 0), 97); // 96 steps of 15 min
+    expect(rowsSpanHours(rows)).toBe(24);
+  });
+
+  it('clamps a rebalance window to the visible prefix', () => {
+    expect(clampRebalanceWindow({ startIdx: 4, endIdx: 20 }, 10)).toEqual({ startIdx: 4, endIdx: 9 });
+    expect(clampRebalanceWindow({ startIdx: 12, endIdx: 20 }, 10)).toBeNull();
+    expect(clampRebalanceWindow(null, 10)).toBeNull();
+  });
+});
+
+describe('aggregateRowsHourly', () => {
+  it('preserves energy: mean W over the hour equals the summed slot energy', () => {
+    const rows = makeRows(new Date(2026, 4, 1, 10, 0), 8, {});
+    rows[0].g2l = 1000; rows[1].g2l = 0; rows[2].g2l = 0; rows[3].g2l = 0; // 0.25 kWh in hour 1
+    const hourly = aggregateRowsHourly(rows, 15);
+    expect(hourly).toHaveLength(2);
+    // 1000 W for one 15-min slot = 250 Wh → 250 W hourly mean × 1 h.
+    expect(hourly[0].g2l).toBe(250);
+    expect(hourly[0].timestampMs).toBe(new Date(2026, 4, 1, 10, 0).getTime());
+  });
+
+  it('averages prices, sums costs, and keeps the last SoC of each hour', () => {
+    const rows = makeRows(new Date(2026, 4, 1, 10, 0), 4);
+    rows.forEach((r, i) => { r.ic = 10 + i; r.importCost_cents = 1; });
+    const [hour] = aggregateRowsHourly(rows, 15);
+    expect(hour.ic).toBe(11.5);
+    expect(hour.importCost_cents).toBe(4);
+    expect(hour.soc_percent).toBe(rows[3].soc_percent);
+  });
+
+  it('treats missing slots of a partial hour as zero energy', () => {
+    // Plan starts at 10:45: one slot in the 10:00 hour.
+    const rows = makeRows(new Date(2026, 4, 1, 10, 45), 5, { g2l: 1000 });
+    const hourly = aggregateRowsHourly(rows, 15);
+    expect(hourly[0].g2l).toBe(250); // 1000 W × 0.25 h = 250 Wh over the hour
+    expect(hourly[1].g2l).toBe(1000);
+  });
+
+  it('only carries original predictions when a slot had one', () => {
+    const rows = makeRows(new Date(2026, 4, 1, 10, 0), 4);
+    expect(aggregateRowsHourly(rows, 15)[0].originalLoad).toBeUndefined();
+    rows[1].originalLoad = 800;
+    const [hour] = aggregateRowsHourly(rows, 15);
+    // 3 slots at 400 (fallback to load) + 1 at 800, over 4 slots.
+    expect(hour.originalLoad).toBe((400 * 3 + 800) / 4);
+  });
+});
+
+describe('mapRebalanceWindowToRows', () => {
+  it('re-expresses slot indices as hourly indices via timestamps', () => {
+    const rows = makeRows(new Date(2026, 4, 1, 10, 0), 12); // 3 hours
+    const hourly = aggregateRowsHourly(rows, 15);
+    // Slots 5..9 → 11:15 to 12:15 → hourly indices 1..2.
+    expect(mapRebalanceWindowToRows({ startIdx: 5, endIdx: 9 }, rows, hourly))
+      .toEqual({ startIdx: 1, endIdx: 2 });
+    expect(mapRebalanceWindowToRows(null, rows, hourly)).toBeNull();
+  });
+});

--- a/tests/app/plan-view.test.js
+++ b/tests/app/plan-view.test.js
@@ -113,3 +113,38 @@ describe('mapRebalanceWindowToRows', () => {
     expect(mapRebalanceWindowToRows(null, rows, hourly)).toBeNull();
   });
 });
+
+describe('server-provided standard boundary', () => {
+  it('prefers the explicit boundary over the browser-local rule', () => {
+    const rows = makeRows(new Date(2026, 4, 1, 14, 0), 384);
+    // A server in another timezone hands us a different cutoff than the
+    // local 34 h rule (136 slots): e.g. 24 h → 96 slots.
+    const serverEndMs = rows[0].timestampMs + 24 * 3_600_000;
+    expect(sliceRowsToStandardView(rows, serverEndMs)).toHaveLength(96);
+    expect(planExceedsStandardView(rows, serverEndMs)).toBe(true);
+    // Non-finite boundary falls back to the local rule.
+    expect(sliceRowsToStandardView(rows, null)).toHaveLength(136);
+  });
+});
+
+describe('aggregateRowsHourly — DST fall-back', () => {
+  it('keeps the two occurrences of the repeated autumn hour in separate buckets', () => {
+    // Brussels/Amsterdam falls back at 2026-10-25T01:00Z: local 02:00–02:59
+    // happens twice. 8 slots covering 00:00Z–02:00Z are two physical hours.
+    const startMs = Date.UTC(2026, 9, 25, 0, 0);
+    const rows = Array.from({ length: 8 }, (_, i) => ({
+      tIdx: i,
+      timestampMs: startMs + i * 15 * 60_000,
+      load: 400, pv: 0, ic: 20, ec: 8,
+      g2l: 1000, g2b: 0, pv2l: 0, pv2b: 0, pv2g: 0, b2l: 0, b2g: 0,
+      imp: 1000, exp: 0,
+      importCost_cents: 1, exportCost_cents: 0,
+      soc_percent: 50,
+    }));
+
+    const hourly = aggregateRowsHourly(rows, 15);
+    expect(hourly).toHaveLength(2); // local-hour bucketing would collapse them into one
+    expect(hourly.map(h => h.g2l)).toEqual([1000, 1000]);
+    expect(hourly.map(h => h.timestampMs)).toEqual([startMs, startMs + 3_600_000]);
+  });
+});

--- a/tests/app/table.test.js
+++ b/tests/app/table.test.js
@@ -95,3 +95,42 @@ describe('renderTable', () => {
     expect(table.innerHTML).toContain('Feed-in');
   });
 });
+
+describe('renderTable — multi-day day sections', () => {
+  const cfg = { stepSize_m: 15, batteryCapacity_Wh: 10000 };
+
+  function makeRows(startLocal, count) {
+    return Array.from({ length: count }, (_, i) =>
+      makeRow({ tIdx: i, timestampMs: startLocal.getTime() + i * 15 * 60_000 }));
+  }
+
+  it('adds collapsible day headers when the view spans more than 48 hours', () => {
+    const table = document.createElement('table');
+    document.body.appendChild(table);
+    const rows = makeRows(new Date(2026, 4, 1, 0, 0), 3 * 96); // 3 full days
+
+    renderTable({ rows, cfg, targets: { table }, showKwh: false });
+
+    const headers = table.querySelectorAll('[data-day-toggle]');
+    expect(headers).toHaveLength(2); // one per day after the first
+
+    // Clicking a header collapses that day's rows.
+    const header = headers[0];
+    const key = header.getAttribute('data-day-toggle');
+    const dayRows = table.querySelectorAll(`tr[data-day="${key}"]`);
+    expect(dayRows).toHaveLength(96);
+    header.querySelector('td').dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect([...dayRows].every(tr => tr.classList.contains('hidden'))).toBe(true);
+    header.querySelector('td').dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect([...dayRows].some(tr => tr.classList.contains('hidden'))).toBe(false);
+  });
+
+  it('keeps the classic layout (no day headers) within the standard window', () => {
+    const table = document.createElement('table');
+    const rows = makeRows(new Date(2026, 4, 1, 14, 0), 96); // 24 h crossing midnight once
+
+    renderTable({ rows, cfg, targets: { table }, showKwh: false });
+
+    expect(table.querySelectorAll('[data-day-toggle]')).toHaveLength(0);
+  });
+});

--- a/tests/app/table.test.js
+++ b/tests/app/table.test.js
@@ -111,17 +111,24 @@ describe('renderTable — multi-day day sections', () => {
 
     renderTable({ rows, cfg, targets: { table }, showKwh: false });
 
-    const headers = table.querySelectorAll('[data-day-toggle]');
-    expect(headers).toHaveLength(2); // one per day after the first
+    // A real, focusable button per day after the first, wired to its section.
+    const buttons = table.querySelectorAll('button[data-day-toggle]');
+    expect(buttons).toHaveLength(2);
+    const button = buttons[0];
+    expect(button.getAttribute('type')).toBe('button');
+    expect(button.getAttribute('aria-expanded')).toBe('true');
+    const sectionId = button.getAttribute('aria-controls');
+    expect(table.querySelector(`tbody[id="${sectionId}"]`)?.contains(button)).toBe(true);
 
-    // Clicking a header collapses that day's rows.
-    const header = headers[0];
-    const key = header.getAttribute('data-day-toggle');
+    // Activating the button collapses that day's rows and updates the state.
+    const key = button.getAttribute('data-day-toggle');
     const dayRows = table.querySelectorAll(`tr[data-day="${key}"]`);
     expect(dayRows).toHaveLength(96);
-    header.querySelector('td').dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(button.getAttribute('aria-expanded')).toBe('false');
     expect([...dayRows].every(tr => tr.classList.contains('hidden'))).toBe(true);
-    header.querySelector('td').dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(button.getAttribute('aria-expanded')).toBe('true');
     expect([...dayRows].some(tr => tr.classList.contains('hidden'))).toBe(false);
   });
 


### PR DESCRIPTION
Fourth stacked PR for the extended planning horizon (plan: `plans/extended-horizon-plan.md`). Stacked on #145 (phase 2); only the last commit is new here.

## What this adds

**Forecast prices are visually distinct:**
- `/calculate` now returns `pricesKnownUntilMs` (from the phase-1 SolverConfig field).
- The prices chart draws the forecast tail as a dashed line (`segment.borderDash`), shades the forecast region with a labeled zone, and the tooltip marks forecast slots.

**View-range toggle — Standard | Full horizon:**
- Lives in the Power flows card header and only appears when the plan actually extends past the standard day-ahead window, so nothing changes for non-extended setups.
- Standard (the default) slices all charts + the table to the classic window using the same local-midnight/13:00 rule as the server; the choice persists in localStorage.
- EV annotations needed no changes: markers already skip out-of-range times, so multi-day targets show up in the full view and drop out of the standard one.

**Readable bars on multi-day views:**
- When the visible span exceeds 48 h, the power-flows chart aggregates to hourly bars by default, with a 15 min / 1 h toggle (explicit choice persists). Aggregation is energy-preserving (mean W × 1 h = summed slot energy, missing slots in partial hours count as zero); prices are averaged, costs summed, SoC takes the hour's last slot. The rebalance-window highlight is remapped to hourly indices by timestamp.
- The load/PV chart was already hourly; SoC and prices remain per-slot lines (they stay legible).

**Schedule table:**
- On views spanning > 48 h, days after the first become collapsible sections with a clickable day header. The standard layout is byte-identical to before.

All slicing/aggregation logic is in a new pure module `app/src/plan-view.js`.

## Verification
- 20 new tests (541 total pass): standard-window slicing, energy-preserving hourly aggregation (incl. partial hours and original-prediction carry-through), rebalance-window clamping/remapping, table day sections, and updated controller assertions. Typecheck + lint clean.
- End-to-end smoke test: booted the server against a synthetic 4-day fixture (24 h actual prices + 3 days forecast) — Optimal 384-row plan, `pricesKnownUntilMs` at the exact boundary, actual price before it and forecast price after it in the response rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)