### PR TITLE
Extended horizon phase 4: validation and MILP guardrail

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Plan and control a home energy system with forecasts, dynamic tariffs, and a day
 - Server-side VRM integration for forecasts/prices and system limits
 - Optional Dynamic ESS schedule pushes over MQTT (first 4 slots)
 - EV charging integration: LP-optimized schedule with departure deadline, target SoC, and per-slot charge mode classification
+- Optional extended planning horizon (up to 6 extra days) with forecast prices, so multi-day EV targets ("80% in 3 days") become real constraints
 - Static, build-free web UI served by the same Express process
 - Persistent settings + time-series data under a configurable data directory
 
@@ -130,7 +131,36 @@ rest_command:
       }
 ```
 
-### 5. EV Charger Control via REST Sensor (Optional)
+### 5. Extended Planning Horizon (Optional)
+
+By default the plan covers the classic day-ahead window (~12–36 h, bounded by
+published prices and forecasts). Two settings in the UI's **Data Sources** card
+extend it to multiple days, so long-range EV targets ("80% in 3 days") become
+real solver constraints instead of manually staged intermediate targets:
+
+- **Extra horizon (days)** (`extendedHorizonDays`, 0–6, default 0 = off):
+  extends the load, PV, and price windows by that many days. Load predictions
+  extrapolate from history; PV forecasts come from Open-Meteo (ICON seamless
+  beyond 2 days); VRM forecasts are clamped to whatever VRM actually returns.
+- **Price forecast URL** (`priceForecastUrl`, default empty): a JSON feed of
+  predicted prices in the `energieprijs` `forecast.json` format
+  (`consumption_data` / `injection_data` arrays of `{time, price}` in
+  c€/kWh, 15-minute steps). OptiVolt pulls it during each `/calculate` update
+  and stores it separately from the actual prices.
+
+**Published prices always win.** Forecast values only extend the tail past the
+end of the actual price series; the dashboard draws that region as a dashed
+line with a shaded "forecast" zone. The plan itself is still bounded by the
+shortest available series, so a missing forecast simply shrinks the horizon
+back to today's behaviour. On multi-day plans the dashboard adds a
+"Standard | Full horizon" view toggle, hourly bar aggregation, and collapsible
+day sections in the schedule table.
+
+Note that only the first 4 slots are ever pushed to Victron — the extra days
+influence *today's* decisions (e.g. charging the EV during tomorrow's cheap
+valley instead of tonight) without changing what gets written to hardware.
+
+### 6. EV Charger Control via REST Sensor (Optional)
 
 Poll the `/ev/current` endpoint every minute to get the current slot's EV charging decision. Add this to your HA `configuration.yaml`:
 

--- a/api/services/planner-service.ts
+++ b/api/services/planner-service.ts
@@ -112,6 +112,25 @@ function attachOriginalPredictionValues(rows: PlanRow[], data: Data): PlanRow[] 
   });
 }
 
+/**
+ * Solver options for a config. The solve runs synchronously on the event
+ * loop, so a runaway MIP would block every HTTP request; the time limit
+ * bounds that (a limited solve comes back non-Optimal and is refused for
+ * hardware writes). The EV × rebalance combination on a multi-day horizon
+ * gets the loosened MIP gap; everything else keeps the tight default.
+ */
+export function selectSolveOptions(cfg: SolverConfig): { mip_rel_gap?: number; mip_abs_gap?: number; time_limit: number } {
+  const hasEv = cfg.ev != null;
+  const hasRebalance = (cfg.rebalanceRemainingSlots ?? 0) > 0;
+  if (!hasEv && !hasRebalance) return { time_limit: SOLVE_TIME_LIMIT_S };
+  const largeMilpCombo = hasEv && hasRebalance && cfg.load_W.length > LARGE_MILP_SLOTS;
+  return {
+    mip_rel_gap: largeMilpCombo ? MIP_REL_GAP_LARGE : MIP_REL_GAP,
+    mip_abs_gap: 0.01,
+    time_limit: SOLVE_TIME_LIMIT_S,
+  };
+}
+
 // Cache of the last computed plan, used by /ev/* endpoints
 let lastPlan: ComputePlanResult | undefined;
 
@@ -154,20 +173,8 @@ export async function computePlan({ updateData = false } = {}): Promise<ComputeP
 
   const lpText = buildLP(cfg);
   const highs = await getHighsInstance();
-  const hasEv = cfg.ev != null;
   const hasRebalance = (cfg.rebalanceRemainingSlots ?? 0) > 0;
-  const hasBinaries = hasEv || hasRebalance;
-  const largeMilpCombo = hasEv && hasRebalance && cfg.load_W.length > LARGE_MILP_SLOTS;
-  // The solve runs synchronously on the event loop, so a runaway MIP would
-  // block every HTTP request; the time limit bounds that. A limited solve
-  // comes back with a non-Optimal status and is refused for hardware writes.
-  const solveOptions = hasBinaries
-    ? {
-        mip_rel_gap: largeMilpCombo ? MIP_REL_GAP_LARGE : MIP_REL_GAP,
-        mip_abs_gap: 0.01,
-        time_limit: SOLVE_TIME_LIMIT_S,
-      }
-    : { time_limit: SOLVE_TIME_LIMIT_S };
+  const solveOptions = selectSolveOptions(cfg);
   let result: ReturnType<typeof highs.solve>;
   const t0 = performance.now();
   try {

--- a/api/services/planner-service.ts
+++ b/api/services/planner-service.ts
@@ -21,6 +21,14 @@ const DESS_SLOTS = 4;
 // solve well under a second; this only kicks in when something degenerates
 // (or once longer horizons multiply the binary count).
 const SOLVE_TIME_LIMIT_S = 30;
+// MIP gap tuning. The EV × rebalance combination on a multi-day horizon is
+// the one slow case (4-day benchmark: 18.5 s at 0.5% gap vs 7.5 s at 2% on an
+// M-series Mac — slower add-on hardware could hit the time limit, and a
+// timed-out solve blocks hardware writes entirely). Loosen the gap for that
+// combination only; everything else keeps the tight default.
+const MIP_REL_GAP = 0.005;
+const MIP_REL_GAP_LARGE = 0.02;
+const LARGE_MILP_SLOTS = 200;
 
 // Lazy, shared HiGHS instance
 type HighsInstance = Awaited<ReturnType<typeof highsFactory>>;
@@ -146,12 +154,19 @@ export async function computePlan({ updateData = false } = {}): Promise<ComputeP
 
   const lpText = buildLP(cfg);
   const highs = await getHighsInstance();
-  const hasBinaries = cfg.ev != null || (cfg.rebalanceRemainingSlots ?? 0) > 0;
+  const hasEv = cfg.ev != null;
+  const hasRebalance = (cfg.rebalanceRemainingSlots ?? 0) > 0;
+  const hasBinaries = hasEv || hasRebalance;
+  const largeMilpCombo = hasEv && hasRebalance && cfg.load_W.length > LARGE_MILP_SLOTS;
   // The solve runs synchronously on the event loop, so a runaway MIP would
   // block every HTTP request; the time limit bounds that. A limited solve
   // comes back with a non-Optimal status and is refused for hardware writes.
   const solveOptions = hasBinaries
-    ? { mip_rel_gap: 0.005, mip_abs_gap: 0.01, time_limit: SOLVE_TIME_LIMIT_S }
+    ? {
+        mip_rel_gap: largeMilpCombo ? MIP_REL_GAP_LARGE : MIP_REL_GAP,
+        mip_abs_gap: 0.01,
+        time_limit: SOLVE_TIME_LIMIT_S,
+      }
     : { time_limit: SOLVE_TIME_LIMIT_S };
   let result: ReturnType<typeof highs.solve>;
   const t0 = performance.now();
@@ -172,7 +187,8 @@ export async function computePlan({ updateData = false } = {}): Promise<ComputeP
   console.log('[calculate] solve', {
     slots: cfg.load_W.length,
     ev: evInfo,
-    rebalance: (cfg.rebalanceRemainingSlots ?? 0) > 0,
+    rebalance: hasRebalance,
+    ...('mip_rel_gap' in solveOptions ? { mipRelGap: solveOptions.mip_rel_gap } : {}),
     solveMs: Math.round(solveMs),
     status: result.Status,
   });

--- a/plans/extended-horizon-plan.md
+++ b/plans/extended-horizon-plan.md
@@ -99,10 +99,20 @@ timestamp separating published day-ahead prices from model predictions.
 - Schedule table groups days after the first into collapsible day sections on
   views spanning > 48 h; the standard layout is untouched.
 
-## Phase 4 — Validation
+## Phase 4 — Validation (this branch)
 
-- Unit tests: merge priority, leading-gap guard, horizon setting variations,
-  multi-day EV targets/windows, day-1 rebalance restriction.
-- Synthetic 4-day solve benchmark before relying on the MILP at ~384 slots.
-- Shadow period: run `extendedHorizonDays: 3` with calculation only (no
-  hardware writes) comparing `solveMs` and plan quality.
+- Unit tests for merge priority, the leading-gap guard, horizon settings,
+  multi-day EV targets, and the day-1 rebalance restriction shipped with
+  phases 0–3. This phase adds a full-pipeline integration test: persisted
+  data with a forecast price tail → config-builder merge → LP → a real HiGHS
+  solve → parsed rows, asserting the merged horizon, `pricesKnownUntilMs`,
+  and that a 3-days-out EV target is actually met.
+- Guardrail from the phase-2 benchmark: the EV × rebalance combination on a
+  multi-day horizon loosens `mip_rel_gap` from 0.5% to 2% (18.5 s → 7.5 s on
+  the benchmark), so slow hardware degrades to a slightly-less-optimal plan
+  instead of a timed-out solve — which would block hardware writes every
+  cycle. All other solves keep the tight gap. The gap is included in the
+  `[calculate] solve` log line for the shadow period.
+- Remaining (operational): shadow period — run `extendedHorizonDays: 3` with
+  calculation only (`writeToVictron: false`), watching `solveMs`, `status`,
+  and `mipRelGap` in the logs before enabling writes.

--- a/plans/extended-horizon-plan.md
+++ b/plans/extended-horizon-plan.md
@@ -116,3 +116,33 @@ timestamp separating published day-ahead prices from model predictions.
 - Remaining (operational): shadow period — run `extendedHorizonDays: 3` with
   calculation only (`writeToVictron: false`), watching `solveMs`, `status`,
   and `mipRelGap` in the logs before enabling writes.
+
+## Phase 5 — Cleanup (after the stack merges)
+
+Deliberately deferred so the stacked PRs stay reviewable; tracked in a GitHub
+issue. Do these as one small cleanup PR (items 2–4) plus a two-repo pair for
+item 1.
+
+1. **UTC timestamps in `forecast.json`, then shrink the parser.** The Intl
+   offset probing, DST candidate disambiguation, and sequence-aware
+   repeated-hour logic in `price-forecast-service.ts` exist only because the
+   feed emits bare Brussels wall-clock timestamps. Emit ISO-with-offset from
+   `epex_forecast.sh` (energieprijs repo) — the parser already accepts them —
+   then reduce the wall-clock path to a legacy fallback or delete it.
+2. **Stop rebuilding `Data` from an explicit key list in `vrm-refresh.ts`.**
+   Spread `...baseData` and override the fetched keys. The current list is a
+   field-drop trap: it silently drops `evLastState` every refresh (latent
+   ev-trips bug) and forced manual addition of the forecast keys.
+3. **One source of truth for the day-ahead window rule.** The 13:00/midnight
+   rule lives in `getForecastTimeRange`, `VRMClient.windowOptimizationHorizon`,
+   and the client fallback `standardViewEndMs`. Unify the two server copies;
+   keep (or delete) the client fallback once `standardWindowEndMs` is always
+   provided.
+4. **Unify the two hourly aggregators.** `aggregateRowsHourly` (plan-view)
+   and `aggregateLoadPvBuckets` (solution-charts) bucket near-identically —
+   the same DST bug was fixed in both, which is the sign they should be one
+   function.
+
+Explicitly not planned: splitting `table.js` / `config-builder.ts` (long but
+linear), and a schema-driven settings system (worthwhile someday, but a
+horizontal refactor that shouldn't couple to this feature).

--- a/tests/api/services/planner-service.test.js
+++ b/tests/api/services/planner-service.test.js
@@ -10,7 +10,7 @@ import { loadSettings, saveSettings } from '../../../api/services/settings-store
 import { loadData, saveData } from '../../../api/services/data-store.ts';
 import { refreshSeriesFromVrmAndPersist } from '../../../api/services/vrm-refresh.ts';
 import { setDynamicEssSchedule } from '../../../api/services/mqtt-service.ts';
-import { computePlan, planAndMaybeWrite } from '../../../api/services/planner-service.ts';
+import { computePlan, planAndMaybeWrite, selectSolveOptions } from '../../../api/services/planner-service.ts';
 import { FeedIn, Strategy } from '../../../lib/dess-mapper.ts';
 
 const NOW_STRING = '2024-01-01T00:00:00Z';
@@ -193,5 +193,40 @@ describe('computePlan — rebalance bookkeeping', () => {
     });
     expect(result.rows[1].originalLoad).toBeUndefined();
     expect(result.rows[1].originalPv).toBeUndefined();
+  });
+});
+
+describe('selectSolveOptions', () => {
+  const baseCfg = (slots) => ({
+    load_W: Array(slots).fill(400),
+    pv_W: Array(slots).fill(0),
+    importPrice: Array(slots).fill(10),
+    exportPrice: Array(slots).fill(5),
+  });
+  const ev = {
+    evMinChargePower_W: 1380, evMaxChargePower_W: 3680,
+    evBatteryCapacity_Wh: 60000, evInitialSoc_percent: 50,
+    evChargeEfficiency_percent: 90,
+    availabilityWindows: [], targets: [],
+  };
+
+  it('uses only a time limit for pure LPs', () => {
+    expect(selectSolveOptions(baseCfg(384))).toEqual({ time_limit: 30 });
+  });
+
+  it('keeps the tight gap for a single binary family, even on large horizons', () => {
+    expect(selectSolveOptions({ ...baseCfg(384), ev }).mip_rel_gap).toBe(0.005);
+    expect(selectSolveOptions({ ...baseCfg(384), rebalanceRemainingSlots: 12 }).mip_rel_gap).toBe(0.005);
+  });
+
+  it('loosens the gap only for EV × rebalance beyond 200 slots', () => {
+    const combo = (slots) => selectSolveOptions({ ...baseCfg(slots), ev, rebalanceRemainingSlots: 12 });
+    expect(combo(200).mip_rel_gap).toBe(0.005); // boundary: 200 is still tight
+    expect(combo(201).mip_rel_gap).toBe(0.02);  // boundary: first loosened size
+    expect(combo(384)).toEqual({ mip_rel_gap: 0.02, mip_abs_gap: 0.01, time_limit: 30 });
+  });
+
+  it('treats a completed rebalance (0 remaining slots) as no rebalance', () => {
+    expect(selectSolveOptions({ ...baseCfg(384), ev, rebalanceRemainingSlots: 0 }).mip_rel_gap).toBe(0.005);
   });
 });

--- a/tests/integration/extended-horizon-solve.test.js
+++ b/tests/integration/extended-horizon-solve.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { buildSolverConfigFromSettings } from '../../api/services/config-builder.ts';
+import { selectSolveOptions } from '../../api/services/planner-service.ts';
 import { buildLP } from '../../lib/build-lp.ts';
 import { parseSolution } from '../../lib/parse-solution.ts';
 import highsFactory from '../../vendor/highs-build/highs.js';
@@ -102,14 +103,17 @@ describe('extended horizon — full pipeline with real HiGHS solve', () => {
     expect(cfg.ev).toBeDefined();
     expect(cfg.ev.targets).toEqual([{ slot: 283, soc_Wh: 48000 }]);
 
+    // Solve with the production option selector (EV binaries, no rebalance →
+    // the tight gap). No duration assertion here: fake timers are active, so
+    // performance.now() would not measure anything real anyway.
+    const solveOptions = selectSolveOptions(cfg);
+    expect(solveOptions).toEqual({ mip_rel_gap: 0.005, mip_abs_gap: 0.01, time_limit: 30 });
+
     const highs = await highsFactory({});
     const lp = buildLP(cfg);
-    const t0 = performance.now();
-    const result = highs.solve(lp, { mip_rel_gap: 0.005, mip_abs_gap: 0.01, time_limit: 30 });
-    const solveMs = performance.now() - t0;
+    const result = highs.solve(lp, solveOptions);
 
     expect(result.Status).toBe('Optimal');
-    expect(solveMs).toBeLessThan(20_000);
 
     const rows = parseSolution(result, cfg, { startMs: nowMs, stepMin: 15 });
     expect(rows).toHaveLength(T);

--- a/tests/integration/extended-horizon-solve.test.js
+++ b/tests/integration/extended-horizon-solve.test.js
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { buildSolverConfigFromSettings } from '../../api/services/config-builder.ts';
+import { buildLP } from '../../lib/build-lp.ts';
+import { parseSolution } from '../../lib/parse-solution.ts';
+import highsFactory from '../../vendor/highs-build/highs.js';
+
+/**
+ * Full-pipeline integration test for the extended horizon: persisted-style
+ * data (actual prices + forecast tail) → config-builder merge → LP → a REAL
+ * HiGHS solve → parsed rows. Guards the interplay that unit tests mock away.
+ */
+
+const NOW_ISO = '2024-01-01T12:00:00Z';
+const SLOT_MS = 15 * 60_000;
+const T = 384; // 4 days
+
+const settings = {
+  stepSize_m: 15,
+  batteryCapacity_Wh: 20000,
+  minSoc_percent: 20,
+  maxSoc_percent: 100,
+  maxChargePower_W: 3600,
+  maxDischargePower_W: 4000,
+  maxGridImport_W: 5000,
+  maxGridExport_W: 5000,
+  chargeEfficiency_percent: 95,
+  dischargeEfficiency_percent: 95,
+  batteryCost_cent_per_kWh: 2,
+  idleDrain_W: 0,
+  terminalSocValuation: 'zero',
+  evSocValue_cents_per_kWh: 0,
+  extendedHorizonDays: 3,
+  evEnabled: true,
+  evMinChargeCurrent_A: 6,
+  evMaxChargeCurrent_A: 16,
+  evBatteryCapacity_kWh: 60,
+  evChargeEfficiency_percent: 90,
+  evTripSocBuffer_percent: 20,
+};
+
+function buildData() {
+  const nowMs = new Date(NOW_ISO).getTime();
+  // Daily price shape so the solver has real structure to optimise against.
+  const price = (i) => {
+    const h = ((i % 96) / 4 + 12) % 24; // slot 0 = 12:00
+    return Math.round((22 + 10 * Math.sin(((h - 6) / 24) * 2 * Math.PI)) * 100) / 100;
+  };
+  return {
+    load: { start: NOW_ISO, step: 15, values: Array.from({ length: T }, () => 400) },
+    pv: {
+      start: NOW_ISO, step: 15,
+      values: Array.from({ length: T }, (_, i) => {
+        const h = ((i % 96) / 4 + 12) % 24;
+        return h > 8 && h < 19 ? 2500 : 0;
+      }),
+    },
+    // Actual prices cover only the first 24 h; the forecast continues from there.
+    importPrice: { start: NOW_ISO, step: 15, values: Array.from({ length: 96 }, (_, i) => price(i)) },
+    exportPrice: { start: NOW_ISO, step: 15, values: Array.from({ length: 96 }, (_, i) => price(i) * 0.4) },
+    importPriceForecast: {
+      start: new Date(nowMs + 96 * SLOT_MS).toISOString(), step: 15,
+      values: Array.from({ length: T - 96 }, (_, i) => price(96 + i) + 1),
+    },
+    exportPriceForecast: {
+      start: new Date(nowMs + 96 * SLOT_MS).toISOString(), step: 15,
+      values: Array.from({ length: T - 96 }, (_, i) => (price(96 + i) + 1) * 0.4),
+    },
+    soc: { timestamp: NOW_ISO, value: 50 },
+    // "80% in 3 days": a target far beyond the standard horizon.
+    evScheduleEntries: [{
+      id: 'tgt1', type: 'target', time: '2024-01-04T11:00:00Z', soc_percent: 80,
+      createdAt: NOW_ISO, updatedAt: NOW_ISO,
+    }],
+  };
+}
+
+describe('extended horizon — full pipeline with real HiGHS solve', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(NOW_ISO));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('solves a 4-day plan with merged forecast prices and a multi-day EV target', async () => {
+    const nowMs = new Date(NOW_ISO).getTime();
+    const cfg = buildSolverConfigFromSettings(
+      settings, buildData(), nowMs,
+      { pluggedIn: true, soc_percent: 30 },
+    );
+
+    // The merge extended the horizon to the full 4 days, actuals first.
+    expect(cfg.load_W.length).toBe(T);
+    expect(cfg.pricesKnownUntilMs).toBe(nowMs + 96 * SLOT_MS);
+    // Forecast slots carry the +1 offset applied above.
+    expect(cfg.importPrice[96]).toBeCloseTo(cfg.importPrice[0] + 1, 6);
+
+    // The multi-day EV target survived into the solver config: the 11:00
+    // day-4 deadline is boundary slot 284, pinned at the slot before it.
+    expect(cfg.ev).toBeDefined();
+    expect(cfg.ev.targets).toEqual([{ slot: 283, soc_Wh: 48000 }]);
+
+    const highs = await highsFactory({});
+    const lp = buildLP(cfg);
+    const t0 = performance.now();
+    const result = highs.solve(lp, { mip_rel_gap: 0.005, mip_abs_gap: 0.01, time_limit: 30 });
+    const solveMs = performance.now() - t0;
+
+    expect(result.Status).toBe('Optimal');
+    expect(solveMs).toBeLessThan(20_000);
+
+    const rows = parseSolution(result, cfg, { startMs: nowMs, stepMin: 15 });
+    expect(rows).toHaveLength(T);
+    // The EV reaches its 3-days-out target by the deadline.
+    expect(rows[283].ev_soc_percent).toBeGreaterThanOrEqual(79.9);
+    // Load is met in every slot (LP balance holds through the forecast region).
+    for (const r of [rows[0], rows[200], rows[383]]) {
+      expect(r.g2l + r.pv2l + r.b2l).toBeCloseTo(r.load, 1);
+    }
+  }, 60_000);
+});


### PR DESCRIPTION
Fifth and final stacked PR for the extended planning horizon (plan: `plans/extended-horizon-plan.md`). Stacked on #146 (phase 3); only the last commit is new here.

## What this adds

**Full-pipeline integration test (real solver):**
- `tests/integration/extended-horizon-solve.test.js` runs persisted-style 4-day data — 24 h of actual prices plus a 3-day forecast tail and an "80% in 3 days" EV schedule entry — through `config-builder` → `buildLP` → an actual HiGHS WASM solve → `parseSolution`. It asserts the merged 384-slot horizon, `pricesKnownUntilMs` at the exact boundary, the far-out EV target surviving into the config, and the solved rows actually reaching 80% EV SoC by the deadline. Runs in ~0.6 s.

**MILP guardrail for the one slow case:**
- The phase-2 benchmark showed EV × rebalance on a 4-day horizon takes 18.5 s at the default 0.5% gap (7.5 s at 2%) on a fast machine — slow add-on hardware could hit the 30 s limit, and a timed-out solve is refused for hardware writes, which would block the Victron loop every cycle while a rebalance is active.
- That specific combination (both binary families present *and* > 200 slots) now solves at `mip_rel_gap: 0.02`; every other solve keeps 0.005. The applied gap is included in the `[calculate] solve` log line so the shadow period can watch it. Flagging the trade-off for review: 2% of a typical daily objective is a few cents of potential suboptimality, against a plan that reliably arrives.

**Docs:**
- README gains an "Extended Planning Horizon" section (the two settings, the `forecast.json` feed format, the actuals-always-win rule, dashboard behaviour, and the note that only the first 4 slots ever reach Victron) plus a feature bullet.

## What remains (operational, not code)
The shadow period from the plan doc: run `extendedHorizonDays: 3` with `writeToVictron: false` for a few days, watching `solveMs`, `status`, and `mipRelGap` in the `[calculate] solve` logs before enabling writes.

## Tests
542 pass (1 new integration test); typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)