### PR TITLE
Extended horizon: correctness fixes and dashboard follow-ups

### DIFF
--- a/api/routes/settings.ts
+++ b/api/routes/settings.ts
@@ -2,6 +2,11 @@ import express from 'express';
 import type { Request, Response, NextFunction } from 'express';
 import { assertCondition, toHttpError } from '../http-errors.ts';
 import { loadSettings, saveSettings } from '../services/settings-store.ts';
+import {
+  buildPredictionRunConfig,
+  runCombinedPredictionForecast,
+} from '../services/prediction-forecast-runner.ts';
+import type { Settings } from '../types.ts';
 
 const router = express.Router();
 
@@ -27,10 +32,43 @@ router.post('/', async (req: Request, res: Response, next: NextFunction) => {
     const mergedSettings = { ...prevSettings, ...incoming };
     await saveSettings(mergedSettings);
 
+    // Re-read so the comparison uses the normalized value (clamping and
+    // rounding happen on load, not on save).
+    const savedSettings = await loadSettings();
+    if (savedSettings.extendedHorizonDays !== prevSettings.extendedHorizonDays) {
+      await refreshForecastsForNewHorizon(savedSettings);
+    }
+
     res.json({ message: 'Settings saved successfully.', settings: mergedSettings });
   } catch (error) {
     next(toHttpError(error, 500, 'Failed to save settings'));
   }
 });
+
+/**
+ * The load and PV forecasts are generated over the configured horizon, but are
+ * otherwise only refreshed out-of-band (an HA cron hitting /predictions/forecast).
+ * A plan can never run past its data, so after a horizon change the stored
+ * series would cap the plan at the old window until that cron next fires.
+ * Regenerate them here instead.
+ *
+ * Awaited so the recompute that follows a settings change sees the new series.
+ * Failures are logged, not surfaced: the settings are already saved, and the
+ * next scheduled run recovers.
+ */
+async function refreshForecastsForNewHorizon(settings: Settings): Promise<void> {
+  // Only these sources are written by the forecast runner; skip the external
+  // calls entirely when neither applies.
+  if (settings.dataSources.load !== 'api' && settings.dataSources.pv !== 'api') return;
+  try {
+    const config = await buildPredictionRunConfig();
+    await runCombinedPredictionForecast(config, 'horizon-change');
+  } catch (error) {
+    console.warn(
+      '[settings] forecast refresh after horizon change failed:',
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+}
 
 export default router;

--- a/api/routes/settings.ts
+++ b/api/routes/settings.ts
@@ -35,11 +35,15 @@ router.post('/', async (req: Request, res: Response, next: NextFunction) => {
     // Re-read so the comparison uses the normalized value (clamping and
     // rounding happen on load, not on save).
     const savedSettings = await loadSettings();
+    let forecastsRefreshed = false;
     if (savedSettings.extendedHorizonDays !== prevSettings.extendedHorizonDays) {
-      await refreshForecastsForNewHorizon(savedSettings);
+      forecastsRefreshed = await refreshForecastsForNewHorizon(savedSettings);
     }
 
-    res.json({ message: 'Settings saved successfully.', settings: mergedSettings });
+    // Reported so the client can re-read the stored series: the Predictions tab
+    // caches them, and would otherwise show the old window until a manual
+    // forecast run or a page reload.
+    res.json({ message: 'Settings saved successfully.', settings: mergedSettings, forecastsRefreshed });
   } catch (error) {
     next(toHttpError(error, 500, 'Failed to save settings'));
   }
@@ -56,18 +60,20 @@ router.post('/', async (req: Request, res: Response, next: NextFunction) => {
  * Failures are logged, not surfaced: the settings are already saved, and the
  * next scheduled run recovers.
  */
-async function refreshForecastsForNewHorizon(settings: Settings): Promise<void> {
+async function refreshForecastsForNewHorizon(settings: Settings): Promise<boolean> {
   // Only these sources are written by the forecast runner; skip the external
   // calls entirely when neither applies.
-  if (settings.dataSources.load !== 'api' && settings.dataSources.pv !== 'api') return;
+  if (settings.dataSources.load !== 'api' && settings.dataSources.pv !== 'api') return false;
   try {
     const config = await buildPredictionRunConfig();
     await runCombinedPredictionForecast(config, 'horizon-change');
+    return true;
   } catch (error) {
     console.warn(
       '[settings] forecast refresh after horizon change failed:',
       error instanceof Error ? error.message : String(error),
     );
+    return false;
   }
 }
 

--- a/api/services/config-builder.ts
+++ b/api/services/config-builder.ts
@@ -3,7 +3,7 @@ import { loadSettings } from './settings-store.ts';
 import { loadData, saveData } from './data-store.ts';
 import { applyPredictionAdjustmentsToData, pruneExpiredPredictionAdjustments } from './prediction-adjustments.ts';
 import { recordFullSocObservation } from './rebalance-nudge.ts';
-import { extractWindow, extendSeriesWithForecast, getQuarterStart } from '../../lib/time-series-utils.ts';
+import { extractWindow, extendSeriesWithForecast, getForecastTimeRange, getQuarterStart } from '../../lib/time-series-utils.ts';
 import { fetchHaEntityState } from './ha-client.ts';
 import { buildEvConfig } from './ev-config-builder.ts';
 import { normalizeEvScheduleEntries, recordEvLastState } from './ev-schedule-entries.ts';
@@ -49,7 +49,12 @@ export function buildSolverConfigFromSettings(
   const pvEndMs     = getSeriesEndMs(data.pv);
   const importEndMs = getSeriesEndMs(importPrice);
   const exportEndMs = getSeriesEndMs(exportPrice);
-  const endMs = Math.min(loadEndMs, pvEndMs, importEndMs, exportEndMs);
+  // Clamp to the configured horizon. Series already in data.json are not
+  // truncated when extendedHorizonDays is lowered (and the price forecast is
+  // stored in full regardless), so without this the plan would keep running to
+  // the end of whatever stale data happens to be persisted.
+  const configuredEndMs = new Date(getForecastTimeRange(nowMs, settings.extendedHorizonDays).endIso).getTime();
+  const endMs = Math.min(loadEndMs, pvEndMs, importEndMs, exportEndMs, configuredEndMs);
 
   // A series that starts after the plan window begins would be silently
   // zero-padded by extractWindow for the leading slots. Zero PV just means

--- a/app/index.html
+++ b/app/index.html
@@ -684,15 +684,29 @@
               <span class="stat-label">Rebalancing</span>
               <span id="rebalance-status" class="text-sm font-medium"></span>
             </div>
+            <div class="summary-block border-t border-slate-100 dark:border-white/5">
+              <div class="flex items-baseline justify-between mb-2">
+                <span class="stat-label">Now</span>
+                <span id="now-slot-window" class="text-[11px] text-slate-400 dark:text-slate-600">—</span>
+              </div>
+              <div class="flex items-baseline justify-between gap-2">
+                <span id="now-action" class="text-sm font-medium text-ink dark:text-slate-100">—</span>
+                <span id="now-power" class="stat-value">—</span>
+              </div>
+              <div
+                class="mt-1 flex items-baseline justify-between font-mono text-[11px] text-slate-500 dark:text-slate-400">
+                <span class="color-flow-battery">SoC <span id="plan-soc-now">—</span>%</span>
+                <span id="now-soc-target"></span>
+              </div>
+            </div>
             <div class="grid grid-cols-2 border-t border-slate-100 dark:border-white/5">
               <div class="px-3 py-2.5 border-b border-r border-slate-100 dark:border-white/5">
-                <div class="stat-label mb-0.5">Current SoC</div>
-                <div class="stat-value color-flow-battery"><span id="plan-soc-now">—</span><span
-                    class="text-[10px] opacity-50 ml-0.5">%</span></div>
-              </div>
-              <div class="px-3 py-2.5 border-b border-slate-100 dark:border-white/5">
                 <div class="stat-label mb-0.5">Plan start</div>
                 <div id="plan-ts-start" class="stat-value">—</div>
+              </div>
+              <div class="px-3 py-2.5 border-b border-slate-100 dark:border-white/5">
+                <div class="stat-label mb-0.5">Plan end</div>
+                <div id="plan-ts-end" class="stat-value">—</div>
               </div>
               <div class="px-3 py-2.5 border-b border-r border-slate-100 dark:border-white/5">
                 <div class="stat-label mb-0.5">Predicted load</div>

--- a/app/index.html
+++ b/app/index.html
@@ -573,18 +573,7 @@
       <div class="card">
         <div class="mb-3 flex items-center justify-between gap-4">
           <h3 class="sidebar-label">Power flows</h3>
-          <div class="flex items-center gap-2">
-            <div id="flows-res-toggle" class="hidden inline-flex rounded-full bg-slate-100 p-0.5 dark:bg-slate-800"
-              role="group" aria-label="Bar resolution">
-              <button id="flows-res-15" type="button">15 min</button>
-              <button id="flows-res-60" type="button">1 h</button>
-            </div>
-            <div id="view-range-toggle" class="hidden inline-flex rounded-full bg-slate-100 p-0.5 dark:bg-slate-800"
-              role="group" aria-label="View range">
-              <button id="view-range-standard" type="button">Standard</button>
-              <button id="view-range-full" type="button">Full horizon</button>
-            </div>
-          </div>
+          <div id="optimizer-view-toggles" class="flex items-center gap-2"></div>
         </div>
         <div class="h-80 w-full chart-wrap">
           <canvas id="flows" class="h-full w-full"></canvas>
@@ -1080,13 +1069,7 @@
       <section class="card relative">
         <div class="mb-3 flex items-center justify-between gap-3">
           <h2 class="sidebar-label">Forecast</h2>
-          <div class="flex items-center gap-3">
-            <label class="toggle">
-              <input id="forecast-chart-15m" type="checkbox">
-              <span class="toggle-knob"></span>
-              <span class="text-sm text-slate-600 dark:text-slate-400">15m bars</span>
-            </label>
-          </div>
+          <div id="forecast-view-toggles" class="flex items-center gap-2"></div>
         </div>
         <div class="h-80 w-full chart-wrap">
           <canvas id="forecast-chart" class="h-full w-full"></canvas>
@@ -1699,7 +1682,10 @@
     <!-- Main: Charts + Table -->
     <section class="lg:col-span-2 space-y-6 min-w-0">
       <div class="card">
-        <h3 class="mb-3 sidebar-label">Charging flows</h3>
+        <div class="mb-3 flex items-center justify-between gap-4">
+          <h3 class="sidebar-label">Charging flows</h3>
+          <div id="ev-view-toggles" class="flex items-center gap-2"></div>
+        </div>
         <div class="h-52 w-full chart-wrap">
           <canvas id="ev-power-chart" class="h-full w-full"></canvas>
           <div class="chart-empty">

--- a/app/index.html
+++ b/app/index.html
@@ -685,18 +685,17 @@
               <span id="rebalance-status" class="text-sm font-medium"></span>
             </div>
             <div class="summary-block border-t border-slate-100 dark:border-white/5">
-              <div class="flex items-baseline justify-between mb-2">
+              <div class="flex items-baseline justify-between gap-3 mb-1">
                 <span class="stat-label">Now</span>
-                <span id="now-slot-window" class="text-[11px] text-slate-400 dark:text-slate-600">—</span>
+                <span id="now-slot-window" class="stat-value text-slate-500 dark:text-slate-400">—</span>
               </div>
-              <div class="flex items-baseline justify-between gap-2">
-                <span id="now-action" class="text-sm font-medium text-ink dark:text-slate-100">—</span>
+              <div class="flex items-baseline justify-between gap-3">
+                <span id="now-action" class="stat-value text-slate-500 dark:text-slate-400">—</span>
                 <span id="now-power" class="stat-value">—</span>
               </div>
-              <div
-                class="mt-1 flex items-baseline justify-between font-mono text-[11px] text-slate-500 dark:text-slate-400">
-                <span class="color-flow-battery">SoC <span id="plan-soc-now">—</span>%</span>
-                <span id="now-soc-target"></span>
+              <div class="mt-1 flex items-baseline justify-between gap-3">
+                <span class="stat-value color-flow-battery">SoC <span id="plan-soc-now">—</span>%</span>
+                <span id="now-soc-target" class="stat-value text-slate-400 dark:text-slate-500"></span>
               </div>
             </div>
             <div class="grid grid-cols-2 border-t border-slate-100 dark:border-white/5">

--- a/app/index.html
+++ b/app/index.html
@@ -574,12 +574,12 @@
         <div class="mb-3 flex items-center justify-between gap-4">
           <h3 class="sidebar-label">Power flows</h3>
           <div class="flex items-center gap-2">
-            <div id="flows-res-toggle" hidden class="inline-flex rounded-full bg-slate-100 p-0.5 dark:bg-slate-800"
+            <div id="flows-res-toggle" class="hidden inline-flex rounded-full bg-slate-100 p-0.5 dark:bg-slate-800"
               role="group" aria-label="Bar resolution">
               <button id="flows-res-15" type="button">15 min</button>
               <button id="flows-res-60" type="button">1 h</button>
             </div>
-            <div id="view-range-toggle" hidden class="inline-flex rounded-full bg-slate-100 p-0.5 dark:bg-slate-800"
+            <div id="view-range-toggle" class="hidden inline-flex rounded-full bg-slate-100 p-0.5 dark:bg-slate-800"
               role="group" aria-label="View range">
               <button id="view-range-standard" type="button">Standard</button>
               <button id="view-range-full" type="button">Full horizon</button>

--- a/app/main.js
+++ b/app/main.js
@@ -158,12 +158,16 @@ async function boot() {
   // Not awaited — HA may be slow or unconfigured; the initial solve should not wait for it.
   void refreshEvSensorStates(els);
 
-  // Initial compute
-  await optimizer.onRun();
-
-  // Reveal cards on the initial (optimizer) panel after first compute
+  // Reveal the cards *before* the first solve. Cards are opacity:0 until
+  // revealed, so revealing afterwards left the whole panel blank for the
+  // duration of the solve — including the status line and the Recompute
+  // spinner, the very things meant to signal that work is in progress. On a
+  // multi-day horizon that blank period is long enough to look broken.
   const optimizerPanel = document.getElementById('panel-optimizer');
   if (optimizerPanel) revealCards(optimizerPanel);
+
+  // Initial compute
+  await optimizer.onRun();
 }
 
 // ---------- Actions ----------

--- a/app/main.js
+++ b/app/main.js
@@ -134,8 +134,6 @@ async function boot() {
     onSave: optimizer.queuePersistSnapshot,
     onRun: optimizer.onRun,
     onTableDisplayChange: optimizer.onTableDisplayChange,
-    onViewRangeChange: optimizer.onViewRangeChange,
-    onFlowsResolutionChange: optimizer.onFlowsResolutionChange,
     updateTerminalCustomUI: () => updateTerminalCustomUI(els),
   });
 

--- a/app/main.js
+++ b/app/main.js
@@ -1,6 +1,6 @@
 import { refreshVrmSettings } from "./src/api/api.js";
 import { loadInitialConfig } from "./src/config-store.js";
-import { initPredictionsTab } from "./src/predictions.js";
+import { initPredictionsTab, reloadStoredForecasts } from "./src/predictions.js";
 import {
   refreshEvSensorStates,
   wireEvSensorInputs,
@@ -34,6 +34,9 @@ const optimizer = createOptimizerController({
   els,
   getEvEntries: () => evSchedule?.getEntries() ?? [],
   onPlanRows: (rows) => evSchedule?.refreshHorizonQuickSet(rows),
+  // The server regenerates the stored load/PV series when the horizon changes;
+  // the Predictions tab caches them, so it has to re-read.
+  onForecastsRefreshed: () => reloadStoredForecasts(),
 });
 evSchedule = createEvScheduleController({
   els,

--- a/app/src/charts/core.js
+++ b/app/src/charts/core.js
@@ -7,15 +7,16 @@ export function fmtHHMM(dt) {
   return `${HH}:${MM}`;
 }
 
+// Midnight ticks name the day that is starting. On a multi-day axis a weekday
+// reads far faster than a numeric date, and the horizon is short enough that
+// the abbreviation is effectively unambiguous.
+const WEEKDAY_FMT = new Intl.DateTimeFormat("en-GB", { weekday: "short" });
+
 function fmtTickHourOrDate(dt) {
   const mins = dt.getMinutes();
   if (mins !== 0) return "";
   const hrs = dt.getHours();
-  if (hrs === 0) {
-    const dd = String(dt.getDate()).padStart(2, "0");
-    const mm = String(dt.getMonth() + 1).padStart(2, "0");
-    return `${dd}/${mm}`;
-  }
+  if (hrs === 0) return WEEKDAY_FMT.format(dt);
   return `${String(hrs).padStart(2, "0")}:00`;
 }
 

--- a/app/src/config-store.js
+++ b/app/src/config-store.js
@@ -14,6 +14,7 @@ export async function loadInitialConfig() {
   }
 }
 
+/** Returns the server's response, which reports whether it regenerated the stored forecasts. */
 export async function saveConfig(config) {
-  await saveStoredSettings(config);
+  return saveStoredSettings(config);
 }

--- a/app/src/ev-tab.js
+++ b/app/src/ev-tab.js
@@ -1,5 +1,33 @@
 import { SOLUTION_COLORS, toRGBA, drawEvPowerChart, drawEvSocChartTab } from "./charts.js";
 import { formatKWh, updateStackedBarContainer } from "./state.js";
+import {
+  aggregateRowsHourly,
+  getStoredViewRange,
+  planExceedsStandardView,
+  rowsSpanHours,
+  sliceRowsToStandardView,
+} from "./plan-view.js";
+import {
+  getStandardWindowEndMs,
+  mountViewToggles,
+  resolveFlowsResolution,
+  subscribeViewToggles,
+} from "./view-toggles.js";
+
+// Last plan rendered into the tab, replayed when a view toggle changes.
+let lastPanelArgs = null;
+let viewToggles = null;
+
+/**
+ * Mount the EV tab's view toggles. Kept separate from updateEvPanel so the
+ * controls exist (and re-render on change) before the first plan arrives.
+ */
+export function initEvPanelToggles(els) {
+  viewToggles = mountViewToggles(els.evViewToggles);
+  subscribeViewToggles(() => {
+    if (lastPanelArgs) updateEvPanel(...lastPanelArgs);
+  });
+}
 
 /**
  * Derive the chart/table annotation inputs from the EV schedule entries: arrival and departure
@@ -36,6 +64,7 @@ export function collectEvSettings(entries = [], tripBuffer_percent = 20) {
 }
 
 export function updateEvPanel(els, rows, summary, stepSize_m = 15, evSettings = { arrivals: [], departures: [], targets: [] }) {
+  lastPanelArgs = [els, rows, summary, stepSize_m, evSettings];
   const evTotal = summary?.evChargeTotal_kWh ?? 0;
   const hasEv = evTotal > 0;
 
@@ -85,9 +114,21 @@ export function updateEvPanel(els, rows, summary, stepSize_m = 15, evSettings = 
     renderModeRows(els.evTabModeRows, evRows);
   }
 
-  if (els.evPowerChart) drawEvPowerChart(els.evPowerChart, rows, stepSize_m, evSettings);
-  if (els.evSocChartTab) drawEvSocChartTab(els.evSocChartTab, rows, evSettings);
-  renderEvTable(evRows, els.evScheduleTable, stepSize_m, evSettings);
+  // The stat panel stays whole-plan (it summarises the plan, not the view);
+  // only the charts and the table follow the view toggles, as on the optimizer.
+  const standardEndMs = getStandardWindowEndMs();
+  const hasExtended = planExceedsStandardView(rows, standardEndMs);
+  const view = hasExtended ? getStoredViewRange() : "standard";
+  const viewRows = view === "full" ? rows : sliceRowsToStandardView(rows, standardEndMs);
+  const resolution = resolveFlowsResolution(rowsSpanHours(viewRows));
+  viewToggles?.update({ hasExtended, view, resolution });
+
+  if (els.evPowerChart) {
+    const powerRows = resolution === "60" ? aggregateRowsHourly(viewRows, stepSize_m) : viewRows;
+    drawEvPowerChart(els.evPowerChart, powerRows, resolution === "60" ? 60 : stepSize_m, evSettings);
+  }
+  if (els.evSocChartTab) drawEvSocChartTab(els.evSocChartTab, viewRows, evSettings);
+  renderEvTable(viewRows.filter(r => (r.ev_soc_percent ?? 0) > 0), els.evScheduleTable, stepSize_m, evSettings);
 }
 
 const MODE_CONFIG = [

--- a/app/src/now-panel.js
+++ b/app/src/now-panel.js
@@ -1,0 +1,134 @@
+/**
+ * now-panel.js
+ *
+ * The "Now" block of the plan summary: what the plan says the battery is doing
+ * in the slot we are currently in.
+ *
+ * The slot is picked by wall clock rather than taken as row 0, because a plan
+ * is recomputed periodically and row 0 goes stale within its own quarter. A
+ * ticker re-renders on the same basis so the block stays honest without a
+ * page reload.
+ *
+ * This reports the *plan*, not measured hardware state — those diverge when
+ * Victron overrides or the plan has expired.
+ */
+
+// Below this, a flow is rounding noise rather than a real decision.
+const IDLE_THRESHOLD_W = 10;
+
+/** Index of the row whose [t, t+step) contains nowMs, or -1 when outside the plan. */
+export function findCurrentRowIndex(rows, stepSize_m = 15, nowMs = Date.now()) {
+  if (!Array.isArray(rows) || rows.length === 0) return -1;
+  const stepMs = stepSize_m * 60_000;
+  for (let i = 0; i < rows.length; i++) {
+    const start = rows[i].timestampMs;
+    if (nowMs >= start && nowMs < start + stepMs) return i;
+  }
+  return -1;
+}
+
+/**
+ * What the battery is doing this slot, derived from the solved flows rather
+ * than the DESS strategy: the flows say what happens, the strategy is only the
+ * instruction sent to Victron.
+ */
+export function describeSlotAction(row) {
+  if (!row) return { label: "—", power_W: 0 };
+
+  const toBattery = (row.g2b ?? 0) + (row.pv2b ?? 0);
+  const fromBattery = (row.b2l ?? 0) + (row.b2g ?? 0) + (row.b2ev ?? 0);
+  const evCharge = row.ev_charge ?? 0;
+
+  if (toBattery >= fromBattery && toBattery > IDLE_THRESHOLD_W) {
+    const pv = row.pv2b ?? 0;
+    const grid = row.g2b ?? 0;
+    let source = "grid";
+    if (pv > IDLE_THRESHOLD_W && grid > IDLE_THRESHOLD_W) source = "grid + PV";
+    else if (pv >= grid) source = "PV";
+    return { label: `Charging from ${source}`, power_W: toBattery };
+  }
+
+  if (fromBattery > IDLE_THRESHOLD_W) {
+    const toLoad = row.b2l ?? 0;
+    const toGrid = row.b2g ?? 0;
+    const toEv = row.b2ev ?? 0;
+    const biggest = Math.max(toLoad, toGrid, toEv);
+    let sink = "load";
+    if (biggest === toGrid) sink = "grid";
+    else if (biggest === toEv) sink = "EV";
+    return { label: `Discharging to ${sink}`, power_W: fromBattery };
+  }
+
+  if (evCharge > IDLE_THRESHOLD_W) {
+    return { label: "Charging EV", power_W: evCharge };
+  }
+
+  return { label: "Idle", power_W: 0 };
+}
+
+/**
+ * Planned SoC entering slot `idx`. The first slot starts from the measured
+ * value the plan was built on; later slots from the previous slot's result.
+ */
+export function socEnteringSlot(rows, idx, initialSoc_percent) {
+  if (idx <= 0) {
+    // Number(null) is 0, which would render a missing reading as an empty battery.
+    const measured = initialSoc_percent == null ? NaN : Number(initialSoc_percent);
+    return Number.isFinite(measured) ? measured : rows?.[0]?.soc_percent ?? null;
+  }
+  const prev = rows?.[idx - 1]?.soc_percent;
+  return Number.isFinite(prev) ? prev : null;
+}
+
+function fmtClock(ms) {
+  const d = new Date(ms);
+  return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+}
+
+function fmtPower(w) {
+  const kw = w / 1000;
+  return `${kw.toFixed(kw >= 10 ? 0 : 2)} kW`;
+}
+
+/** Render the block for `nowMs`. Safe to call with an empty plan. */
+export function renderNowPanel(els, { rows = [], stepSize_m = 15, initialSoc_percent = null } = {}, nowMs = Date.now()) {
+  const setText = (el, text) => { if (el) el.textContent = text; };
+
+  const idx = findCurrentRowIndex(rows, stepSize_m, nowMs);
+  if (idx < 0) {
+    // Either no plan yet, or wall clock has run past the end of the last one.
+    setText(els.nowSlotWindow, rows.length ? "plan expired" : "—");
+    setText(els.nowAction, rows.length ? "Recompute for a current plan" : "—");
+    setText(els.nowPower, "—");
+    setText(els.nowSoc, "—");
+    setText(els.nowSocTarget, "");
+    return idx;
+  }
+
+  const row = rows[idx];
+  const stepMs = stepSize_m * 60_000;
+  setText(els.nowSlotWindow, `${fmtClock(row.timestampMs)} – ${fmtClock(row.timestampMs + stepMs)}`);
+
+  const { label, power_W } = describeSlotAction(row);
+  setText(els.nowAction, label);
+  setText(els.nowPower, power_W > 0 ? fmtPower(power_W) : "—");
+
+  const soc = socEnteringSlot(rows, idx, initialSoc_percent);
+  setText(els.nowSoc, soc == null ? "—" : String(Math.round(soc)));
+
+  const target = row.dess?.socTarget_percent;
+  setText(els.nowSocTarget, Number.isFinite(target) ? `target ${Math.round(target)}%` : "");
+
+  return idx;
+}
+
+/**
+ * Keep the block in step with the wall clock. Returns a stop function.
+ * A slot is 15 min, so a 30 s tick is far more than enough to land on the
+ * right slot promptly without doing meaningful work.
+ */
+export function startNowPanelTicker(render, intervalMs = 30_000) {
+  render();
+  const id = setInterval(render, intervalMs);
+  return () => clearInterval(id);
+}

--- a/app/src/optimizer-controller.js
+++ b/app/src/optimizer-controller.js
@@ -32,6 +32,16 @@ import {
 } from "./view-toggles.js";
 import { renderNowPanel, startNowPanelTicker } from "./now-panel.js";
 
+const CHART_PLACEHOLDER_IDLE = "Run the optimizer to see results";
+const PLACEHOLDER_SELECTOR = "#panel-optimizer .chart-empty span, #panel-ev .chart-empty span";
+
+/** Text of the not-yet-drawn chart overlays on the plan-driven tabs. */
+function setChartPlaceholders(text) {
+  for (const span of document.querySelectorAll(PLACEHOLDER_SELECTOR)) {
+    span.textContent = text;
+  }
+}
+
 export function createOptimizerController({ els, services = {}, getEvEntries = () => [], onPlanRows = () => {} }) {
   const deps = {
     debounce,
@@ -82,6 +92,10 @@ export function createOptimizerController({ els, services = {}, getEvEntries = (
       els.status.textContent = "Calculating…";
       els.status.className = "text-sm font-medium text-ink dark:text-slate-100";
     }
+    // Until the first plan lands the charts are bare placeholders reading
+    // "Run the optimizer…", which contradicts the status line while a solve is
+    // actually in flight. renderChart hides them for good once it draws.
+    setChartPlaceholders("Calculating…");
 
     const runBtn = els.run;
     if (runBtn) {
@@ -131,6 +145,7 @@ export function createOptimizerController({ els, services = {}, getEvEntries = (
         els.status.textContent = `Error: ${err.message}`;
         els.status.className = "text-sm font-medium text-red-600 dark:text-red-400";
       }
+      setChartPlaceholders(CHART_PLACEHOLDER_IDLE);
       deps.updateSummaryUI(els, null);
     } finally {
       if (runBtn) {

--- a/app/src/optimizer-controller.js
+++ b/app/src/optimizer-controller.js
@@ -42,7 +42,13 @@ function setChartPlaceholders(text) {
   }
 }
 
-export function createOptimizerController({ els, services = {}, getEvEntries = () => [], onPlanRows = () => {} }) {
+export function createOptimizerController({
+  els,
+  services = {},
+  getEvEntries = () => [],
+  onPlanRows = () => {},
+  onForecastsRefreshed = () => {},
+}) {
   const deps = {
     debounce,
     drawFlowsBarStackSigned,
@@ -225,7 +231,11 @@ export function createOptimizerController({ els, services = {}, getEvEntries = (
 
   async function persistConfig(cfg = deps.snapshotUI(els)) {
     try {
-      await deps.saveConfig(cfg);
+      const result = await deps.saveConfig(cfg);
+      // Changing the horizon makes the server regenerate the load/PV forecasts.
+      // The Predictions tab caches those series, so it has to re-read them or
+      // it keeps charting the old window until a manual run or a reload.
+      if (result?.forecastsRefreshed) await onForecastsRefreshed();
     } catch (error) {
       console.error("Failed to persist settings", error);
       if (els.status) els.status.textContent = `Settings error: ${error.message}`;

--- a/app/src/optimizer-controller.js
+++ b/app/src/optimizer-controller.js
@@ -8,7 +8,7 @@ import { renderTable } from "./table.js";
 import { debounce } from "./utils.js";
 import { saveConfig } from "./config-store.js";
 import { requestRemoteSolve } from "./api/api.js";
-import { updateEvPanel, collectEvSettings } from "./ev-tab.js";
+import { updateEvPanel, collectEvSettings, initEvPanelToggles } from "./ev-tab.js";
 import {
   snapshotUI,
   updatePlanMeta,
@@ -18,15 +18,18 @@ import {
 import {
   aggregateRowsHourly,
   clampRebalanceWindow,
-  getStoredFlowsResolution,
   getStoredViewRange,
   mapRebalanceWindowToRows,
   planExceedsStandardView,
   rowsSpanHours,
   sliceRowsToStandardView,
-  storeFlowsResolution,
-  storeViewRange,
 } from "./plan-view.js";
+import {
+  mountViewToggles,
+  resolveFlowsResolution,
+  setStandardWindowEndMs,
+  subscribeViewToggles,
+} from "./view-toggles.js";
 
 export function createOptimizerController({ els, services = {}, getEvEntries = () => [], onPlanRows = () => {} }) {
   const deps = {
@@ -50,6 +53,10 @@ export function createOptimizerController({ els, services = {}, getEvEntries = (
   let lastTableRebalanceWindow = null;
   let lastPricesKnownUntilMs = null;
   let lastStandardWindowEndMs = null;
+
+  const viewToggles = mountViewToggles(els.optimizerViewToggles);
+  initEvPanelToggles(els);
+  subscribeViewToggles(() => { renderVisuals(); });
 
   const debounceRun = deps.debounce(onRun, 250);
   const persistConfigDebounced = deps.debounce((cfg) => {
@@ -95,6 +102,8 @@ export function createOptimizerController({ els, services = {}, getEvEntries = (
       lastTableRebalanceWindow = result.rebalanceWindow ?? null;
       lastPricesKnownUntilMs = result.pricesKnownUntilMs ?? null;
       lastStandardWindowEndMs = result.standardWindowEndMs ?? null;
+      // Share the server boundary so the EV and forecast tabs slice alike.
+      setStandardWindowEndMs(lastStandardWindowEndMs);
 
       renderVisuals();
       deps.updateEvPanel(els, rows, result.summary, cfgForViz.stepSize_m, evSettings);
@@ -159,13 +168,11 @@ export function createOptimizerController({ els, services = {}, getEvEntries = (
     const { rows, view, hasExtended } = getVisibleRows();
     const rebalanceWindow = clampRebalanceWindow(lastTableRebalanceWindow, rows.length);
 
-    // Hourly bars keep the multi-day view readable; the standard view always
-    // uses native slots. Default to hourly beyond 48 h unless the user chose.
-    const spanH = rowsSpanHours(rows);
-    const canAggregate = spanH > 48;
-    const resolution = canAggregate ? (getStoredFlowsResolution() ?? "60") : "15";
+    // Hourly bars keep multi-day views readable, so that is the default beyond
+    // 48 h — but the control is always available, whatever the span.
+    const resolution = resolveFlowsResolution(rowsSpanHours(rows));
 
-    updateViewToggleUI(hasExtended, view, canAggregate, resolution);
+    viewToggles.update({ hasExtended, view, resolution });
 
     if (resolution === "60") {
       const hourlyRows = aggregateRowsHourly(rows, cfg.stepSize_m);
@@ -182,36 +189,6 @@ export function createOptimizerController({ els, services = {}, getEvEntries = (
     deps.drawLoadPvGrouped(els.loadpv, rows, cfg.stepSize_m);
     renderScheduleTable();
     return true;
-  }
-
-  const SEG_ACTIVE = "rounded-full px-2.5 py-1 text-xs font-medium bg-white text-ink shadow-sm dark:bg-slate-700 dark:text-slate-100 transition-all";
-  const SEG_INACTIVE = "rounded-full px-2.5 py-1 text-xs font-medium text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200 transition-all";
-
-  function setSegState(btn, active) {
-    if (!btn) return;
-    btn.className = active ? SEG_ACTIVE : SEG_INACTIVE;
-    btn.setAttribute("aria-pressed", String(active));
-  }
-
-  function updateViewToggleUI(hasExtended, view, canAggregate, resolution) {
-    // Tailwind's .hidden utility, not the `hidden` attribute: the toggles carry
-    // `inline-flex`, which overrides the attribute's display:none.
-    els.viewRangeToggle?.classList.toggle("hidden", !hasExtended);
-    setSegState(els.viewRangeStandard, view === "standard");
-    setSegState(els.viewRangeFull, view === "full");
-    els.flowsResToggle?.classList.toggle("hidden", !canAggregate);
-    setSegState(els.flowsRes15, resolution === "15");
-    setSegState(els.flowsRes60, resolution === "60");
-  }
-
-  function onViewRangeChange(range) {
-    storeViewRange(range);
-    renderVisuals();
-  }
-
-  function onFlowsResolutionChange(resolution) {
-    storeFlowsResolution(resolution);
-    renderVisuals();
   }
 
   async function persistConfig(cfg = deps.snapshotUI(els)) {
@@ -266,8 +243,6 @@ export function createOptimizerController({ els, services = {}, getEvEntries = (
     debounceRun,
     onRun,
     onTableDisplayChange,
-    onViewRangeChange,
-    onFlowsResolutionChange,
     persistConfig,
     persistConfigDebounced,
     queuePersistSnapshot,

--- a/app/src/optimizer-controller.js
+++ b/app/src/optimizer-controller.js
@@ -30,6 +30,7 @@ import {
   setStandardWindowEndMs,
   subscribeViewToggles,
 } from "./view-toggles.js";
+import { renderNowPanel, startNowPanelTicker } from "./now-panel.js";
 
 export function createOptimizerController({ els, services = {}, getEvEntries = () => [], onPlanRows = () => {} }) {
   const deps = {
@@ -53,10 +54,19 @@ export function createOptimizerController({ els, services = {}, getEvEntries = (
   let lastTableRebalanceWindow = null;
   let lastPricesKnownUntilMs = null;
   let lastStandardWindowEndMs = null;
+  let lastInitialSoc_percent = null;
 
   const viewToggles = mountViewToggles(els.optimizerViewToggles);
   initEvPanelToggles(els);
   subscribeViewToggles(() => { renderVisuals(); });
+
+  // The "Now" block follows the wall clock, not the plan's first row, so it
+  // keeps pointing at the right slot without a page reload.
+  startNowPanelTicker(() => renderNowPanel(els, {
+    rows: lastTableRows,
+    stepSize_m: getVizConfig().stepSize_m,
+    initialSoc_percent: lastInitialSoc_percent,
+  }));
 
   const debounceRun = deps.debounce(onRun, 250);
   const persistConfigDebounced = deps.debounce((cfg) => {
@@ -90,7 +100,8 @@ export function createOptimizerController({ els, services = {}, getEvEntries = (
       const solverStatus =
         typeof result?.solverStatus === "string" ? result.solverStatus : "OK";
 
-      deps.updatePlanMeta(els, result.initialSoc_percent, result.tsStart);
+      // Plan end is the last planned slot's start, not the boundary after it.
+      deps.updatePlanMeta(els, result.tsStart, rows[rows.length - 1]?.timestampMs ?? null);
       deps.updateSummaryUI(els, result.summary);
       deps.updateRebalanceNudgeUI(els, result.rebalanceNudge);
       updateRunStatus(solverStatus, writeToVictron);
@@ -99,6 +110,7 @@ export function createOptimizerController({ els, services = {}, getEvEntries = (
       const evSettings = getEvSettings();
 
       lastTableRows = rows;
+      lastInitialSoc_percent = result.initialSoc_percent ?? null;
       lastTableRebalanceWindow = result.rebalanceWindow ?? null;
       lastPricesKnownUntilMs = result.pricesKnownUntilMs ?? null;
       lastStandardWindowEndMs = result.standardWindowEndMs ?? null;
@@ -106,6 +118,11 @@ export function createOptimizerController({ els, services = {}, getEvEntries = (
       setStandardWindowEndMs(lastStandardWindowEndMs);
 
       renderVisuals();
+      renderNowPanel(els, {
+        rows,
+        stepSize_m: cfgForViz.stepSize_m,
+        initialSoc_percent: lastInitialSoc_percent,
+      });
       deps.updateEvPanel(els, rows, result.summary, cfgForViz.stepSize_m, evSettings);
       onPlanRows(rows);
     } catch (err) {

--- a/app/src/optimizer-controller.js
+++ b/app/src/optimizer-controller.js
@@ -194,10 +194,12 @@ export function createOptimizerController({ els, services = {}, getEvEntries = (
   }
 
   function updateViewToggleUI(hasExtended, view, canAggregate, resolution) {
-    if (els.viewRangeToggle) els.viewRangeToggle.hidden = !hasExtended;
+    // Tailwind's .hidden utility, not the `hidden` attribute: the toggles carry
+    // `inline-flex`, which overrides the attribute's display:none.
+    els.viewRangeToggle?.classList.toggle("hidden", !hasExtended);
     setSegState(els.viewRangeStandard, view === "standard");
     setSegState(els.viewRangeFull, view === "full");
-    if (els.flowsResToggle) els.flowsResToggle.hidden = !canAggregate;
+    els.flowsResToggle?.classList.toggle("hidden", !canAggregate);
     setSegState(els.flowsRes15, resolution === "15");
     setSegState(els.flowsRes60, resolution === "60");
   }

--- a/app/src/predictions.js
+++ b/app/src/predictions.js
@@ -50,7 +50,6 @@ export async function initPredictionsTab() {
   wirePredictionForm({
     onForecastAll,
     onPvForecast,
-    onForecastResolutionChange: forecastChart.render,
   });
   forecastChart.wireAdjustmentPopover();
   onForecastAll();

--- a/app/src/predictions.js
+++ b/app/src/predictions.js
@@ -46,7 +46,7 @@ const forecastChart = createForecastChartController({
 export async function initPredictionsTab() {
   await hydratePredictionForm();
   await forecastChart.loadAdjustments();
-  await hydrateForecastsFromStoredData();
+  await reloadStoredForecasts();
   wirePredictionForm({
     onForecastAll,
     onPvForecast,
@@ -65,7 +65,11 @@ function refreshAdjustedForecastsFromRaw() {
     : null;
 }
 
-async function hydrateForecastsFromStoredData() {
+/**
+ * Re-read the persisted load/PV series into the tab's cache and redraw.
+ * Also called after the server regenerates them on a horizon change.
+ */
+export async function reloadStoredForecasts() {
   try {
     const data = await fetchStoredData();
     const load = futureForecastSeries(data?.load);

--- a/app/src/predictions/config-form.js
+++ b/app/src/predictions/config-form.js
@@ -36,7 +36,7 @@ export function applyPredictionConfigToForm(config) {
   updatePredictorFieldVisibility();
 }
 
-export function wirePredictionForm({ onForecastAll, onPvForecast, onForecastResolutionChange }) {
+export function wirePredictionForm({ onForecastAll, onPvForecast }) {
   const debouncedSave = debounce(savePredictionFormSilently, 600);
 
   for (const el of document.querySelectorAll('[data-predictions-only="true"]')) {
@@ -53,8 +53,6 @@ export function wirePredictionForm({ onForecastAll, onPvForecast, onForecastReso
     ?.addEventListener('click', onForecastAll);
   document.getElementById('pred-pv-forecast')
     ?.addEventListener('click', onPvForecast);
-  document.getElementById('forecast-chart-15m')
-    ?.addEventListener('change', onForecastResolutionChange);
 
   const settingsToggle = document.getElementById('pred-settings-toggle');
   const settingsBody = document.getElementById('pred-settings-body');

--- a/app/src/predictions/forecast-chart.js
+++ b/app/src/predictions/forecast-chart.js
@@ -16,11 +16,30 @@ import {
   makeAdjustmentOverlayPlugin,
   makeForecastOriginalMarkersPlugin,
 } from '../charts/overlays.js';
+import { standardViewEndMs } from '../plan-view.js';
+import {
+  getStandardWindowEndMs,
+  getStoredViewRange,
+  mountViewToggles,
+  resolveFlowsResolution,
+  subscribeViewToggles,
+} from '../view-toggles.js';
 
 const stripe = (c) => window.pattern?.draw('diagonal', c) || c;
 
+/** Drop the part of a forecast series at or beyond `endMs`. */
+function sliceForecastToEnd(forecast, endMs) {
+  if (!forecast || !Array.isArray(forecast.values) || endMs == null) return forecast;
+  const startMs = new Date(forecast.start).getTime();
+  const stepMs = (forecast.step || 15) * 60_000;
+  const keep = Math.ceil((endMs - startMs) / stepMs);
+  if (!(keep > 0) || keep >= forecast.values.length) return forecast;
+  return { ...forecast, values: forecast.values.slice(0, keep) };
+}
+
 export function createForecastChartController({ getForecasts, onAdjustmentsChanged = () => {} }) {
   let predictionAdjustments = [];
+  let viewToggles = null;
   let forecastChartSelection = null;
   let forecastChartDrag = null;
   let adjustmentDraft = null;
@@ -45,13 +64,56 @@ export function createForecastChartController({ getForecasts, onAdjustmentsChang
     }
   }
 
+  /**
+   * Apply the shared view toggles to the forecast series. The standard-window
+   * boundary comes from the last plan when one has run, otherwise from the
+   * browser-local day-ahead rule.
+   */
+  function resolveForecastView({ load, pv, rawLoad, rawPv }) {
+    const reference = load ?? pv;
+    if (!reference?.values?.length) {
+      return {
+        view: { hasExtended: false, range: 'standard' },
+        resolution: resolveFlowsResolution(0),
+        series: { load, pv, rawLoad, rawPv },
+      };
+    }
+
+    const startMs = new Date(reference.start).getTime();
+    const stepMs = (reference.step || 15) * 60_000;
+    const endMs = startMs + reference.values.length * stepMs;
+    const standardEndMs = getStandardWindowEndMs() ?? standardViewEndMs(startMs);
+
+    const hasExtended = endMs > standardEndMs;
+    const range = hasExtended ? getStoredViewRange() : 'standard';
+    const cut = range === 'full' ? null : standardEndMs;
+    const spanH = ((cut != null ? Math.min(endMs, cut) : endMs) - startMs) / 3_600_000;
+
+    return {
+      view: { hasExtended, range },
+      resolution: resolveFlowsResolution(spanH),
+      series: {
+        load: sliceForecastToEnd(load, cut),
+        pv: sliceForecastToEnd(pv, cut),
+        rawLoad: sliceForecastToEnd(rawLoad, cut),
+        rawPv: sliceForecastToEnd(rawPv, cut),
+      },
+    };
+  }
+
   function renderCombinedForecastChart() {
     const canvas = document.getElementById('forecast-chart');
     if (!canvas) return;
+    if (!viewToggles) {
+      viewToggles = mountViewToggles(document.getElementById('forecast-view-toggles'));
+      subscribeViewToggles(renderCombinedForecastChart);
+    }
 
-    const { load, pv, rawLoad, rawPv } = getForecasts();
-    const is15m = document.getElementById('forecast-chart-15m')?.checked;
-    const stepMinutes = is15m ? 15 : 60;
+    const raw = getForecasts();
+    const { view, resolution, series } = resolveForecastView(raw);
+    const { load, pv, rawLoad, rawPv } = series;
+    const stepMinutes = resolution === '60' ? 60 : 15;
+    viewToggles?.update({ hasExtended: view.hasExtended, view: view.range, resolution });
 
     const loadAgg = load ? aggregateForecastKwh(load, stepMinutes) : { timestamps: [], values: [] };
     const pvAgg = pv ? aggregateForecastKwh(pv, stepMinutes) : { timestamps: [], values: [] };

--- a/app/src/state.js
+++ b/app/src/state.js
@@ -136,7 +136,9 @@ export function hydrateUI(els, obj = {}) {
 }
 
 // Plan metadata helper
-function fmtPlanStamp(ts) {
+const WEEKDAY_FMT = new Intl.DateTimeFormat("en-GB", { weekday: "short" });
+
+export function fmtPlanStamp(ts, { withWeekday = false } = {}) {
   if (!ts) return "—";
   const date = new Date(ts);
   if (isNaN(date.getTime())) return String(ts);
@@ -144,17 +146,21 @@ function fmtPlanStamp(ts) {
   const m = String(date.getMonth() + 1).padStart(2, "0");
   const H = String(date.getHours()).padStart(2, "0");
   const M = String(date.getMinutes()).padStart(2, "0");
-  return `${d}/${m} ${H}:${M}`;
+  const stamp = `${d}/${m} ${H}:${M}`;
+  return withWeekday ? `${WEEKDAY_FMT.format(date)} ${stamp}` : stamp;
 }
 
 /**
  * Plan start and end. The end is the *last planned slot's* start (e.g. 23:45),
  * not the exclusive boundary after it (00:00), which reads ambiguously — it is
  * not obvious whether the following day is included.
+ *
+ * Only the end carries a weekday: it can be days out, where "20/08" alone says
+ * little, while the start is always the current slot.
  */
 export function updatePlanMeta(els, tsStart, tsEnd) {
   if (els.planTsStart) els.planTsStart.textContent = fmtPlanStamp(tsStart);
-  if (els.planTsEnd) els.planTsEnd.textContent = fmtPlanStamp(tsEnd);
+  if (els.planTsEnd) els.planTsEnd.textContent = fmtPlanStamp(tsEnd, { withWeekday: true });
 }
 
 // Summary helper

--- a/app/src/state.js
+++ b/app/src/state.js
@@ -136,33 +136,25 @@ export function hydrateUI(els, obj = {}) {
 }
 
 // Plan metadata helper
-export function updatePlanMeta(els, initialSoc_percent, tsStart) {
-  if (els.planSocNow) {
-    if (initialSoc_percent == null || !Number.isFinite(Number(initialSoc_percent))) {
-      els.planSocNow.textContent = "—";
-    } else {
-      const n = Number(initialSoc_percent);
-      els.planSocNow.textContent = String(Math.round(n));
-    }
-  }
+function fmtPlanStamp(ts) {
+  if (!ts) return "—";
+  const date = new Date(ts);
+  if (isNaN(date.getTime())) return String(ts);
+  const d = String(date.getDate()).padStart(2, "0");
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const H = String(date.getHours()).padStart(2, "0");
+  const M = String(date.getMinutes()).padStart(2, "0");
+  return `${d}/${m} ${H}:${M}`;
+}
 
-  if (els.planTsStart) {
-    if (!tsStart) {
-      els.planTsStart.textContent = "—";
-    } else {
-      const raw = String(tsStart);
-      let display = raw;
-      const date = new Date(tsStart);
-      if (!isNaN(date.getTime())) {
-        const d = String(date.getDate()).padStart(2, "0");
-        const m = String(date.getMonth() + 1).padStart(2, "0");
-        const H = String(date.getHours()).padStart(2, "0");
-        const M = String(date.getMinutes()).padStart(2, "0");
-        display = `${d}/${m} ${H}:${M}`;
-      }
-      els.planTsStart.textContent = display;
-    }
-  }
+/**
+ * Plan start and end. The end is the *last planned slot's* start (e.g. 23:45),
+ * not the exclusive boundary after it (00:00), which reads ambiguously — it is
+ * not obvious whether the following day is included.
+ */
+export function updatePlanMeta(els, tsStart, tsEnd) {
+  if (els.planTsStart) els.planTsStart.textContent = fmtPlanStamp(tsStart);
+  if (els.planTsEnd) els.planTsEnd.textContent = fmtPlanStamp(tsEnd);
 }
 
 // Summary helper

--- a/app/src/ui-binding.js
+++ b/app/src/ui-binding.js
@@ -42,12 +42,8 @@ export function getElements() {
     planTsStart: $("#plan-ts-start"),
 
     // charts + status
-    viewRangeToggle: $("#view-range-toggle"),
-    viewRangeStandard: $("#view-range-standard"),
-    viewRangeFull: $("#view-range-full"),
-    flowsResToggle: $("#flows-res-toggle"),
-    flowsRes15: $("#flows-res-15"),
-    flowsRes60: $("#flows-res-60"),
+    optimizerViewToggles: $("#optimizer-view-toggles"),
+    evViewToggles: $("#ev-view-toggles"),
     flows: $("#flows"),
     soc: $("#soc"),
     prices: $("#prices"),
@@ -147,7 +143,6 @@ export function wireGlobalInputs(
   els,
   {
     onInput, onSave = onInput, onRun, onTableDisplayChange = onRun, updateTerminalCustomUI,
-    onViewRangeChange, onFlowsResolutionChange,
   }
 ) {
   // Auto-save only settings-owned controls.
@@ -167,16 +162,6 @@ export function wireGlobalInputs(
   // Table display toggles
   els.tableKwh?.addEventListener("change", onTableDisplayChange);
   els.tableDess?.addEventListener("change", onTableDisplayChange);
-
-  // View-range + bar-resolution toggles (extended horizon)
-  if (onViewRangeChange) {
-    els.viewRangeStandard?.addEventListener("click", () => onViewRangeChange("standard"));
-    els.viewRangeFull?.addEventListener("click", () => onViewRangeChange("full"));
-  }
-  if (onFlowsResolutionChange) {
-    els.flowsRes15?.addEventListener("click", () => onFlowsResolutionChange("15"));
-    els.flowsRes60?.addEventListener("click", () => onFlowsResolutionChange("60"));
-  }
 
   // Keyboard shortcut: Ctrl+Enter (or Cmd+Enter) to Recompute
   document.addEventListener("keydown", (e) => {

--- a/app/src/ui-binding.js
+++ b/app/src/ui-binding.js
@@ -38,12 +38,17 @@ export function getElements() {
     terminalCustom: $("#terminal-custom"),
 
     // plan metadata
-    planSocNow: $("#plan-soc-now"),
     planTsStart: $("#plan-ts-start"),
 
     // charts + status
     optimizerViewToggles: $("#optimizer-view-toggles"),
     evViewToggles: $("#ev-view-toggles"),
+    planTsEnd: $("#plan-ts-end"),
+    nowSlotWindow: $("#now-slot-window"),
+    nowAction: $("#now-action"),
+    nowPower: $("#now-power"),
+    nowSoc: $("#plan-soc-now"),
+    nowSocTarget: $("#now-soc-target"),
     flows: $("#flows"),
     soc: $("#soc"),
     prices: $("#prices"),

--- a/app/src/view-toggles.js
+++ b/app/src/view-toggles.js
@@ -1,0 +1,117 @@
+/**
+ * view-toggles.js
+ *
+ * The bar-resolution (15 min / 1 h) and view-range (Standard / Full horizon)
+ * segmented controls, shared by every tab that charts the plan.
+ *
+ * Each tab mounts its own pair in the header of its first chart, but the
+ * choice itself is global: it lives in localStorage (see plan-view.js) and a
+ * change on one tab broadcasts to the others so their cached charts re-render
+ * instead of going stale behind a tab switch.
+ */
+
+import {
+  getStoredFlowsResolution,
+  getStoredViewRange,
+  storeFlowsResolution,
+  storeViewRange,
+} from "./plan-view.js";
+
+const SEG_ACTIVE = "rounded-full px-2.5 py-1 text-xs font-medium bg-white text-ink shadow-sm dark:bg-slate-700 dark:text-slate-100 transition-all";
+const SEG_INACTIVE = "rounded-full px-2.5 py-1 text-xs font-medium text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200 transition-all";
+
+const GROUP_CLASS = "inline-flex rounded-full bg-slate-100 p-0.5 dark:bg-slate-800";
+
+const MARKUP = `
+  <div data-res-toggle class="${GROUP_CLASS}" role="group" aria-label="Bar resolution">
+    <button data-res="15" type="button">15 min</button>
+    <button data-res="60" type="button">1 h</button>
+  </div>
+  <div data-range-toggle class="hidden ${GROUP_CLASS}" role="group" aria-label="View range">
+    <button data-range="standard" type="button">Standard</button>
+    <button data-range="full" type="button">Full horizon</button>
+  </div>
+`;
+
+// Server-provided end of the standard window, published once a plan has run.
+// Null until then; consumers fall back to the browser-local rule in plan-view.
+let standardWindowEndMs = null;
+
+export function setStandardWindowEndMs(ms) {
+  standardWindowEndMs = Number.isFinite(ms) ? ms : null;
+}
+
+export function getStandardWindowEndMs() {
+  return standardWindowEndMs;
+}
+
+const listeners = new Set();
+
+/** Re-render callback, invoked on every tab whenever either toggle changes. */
+export function subscribeViewToggles(fn) {
+  listeners.add(fn);
+  return () => listeners.delete(fn);
+}
+
+function broadcast() {
+  for (const fn of listeners) {
+    try {
+      fn();
+    } catch (err) {
+      console.error("View toggle listener failed", err);
+    }
+  }
+}
+
+/**
+ * Resolution for a view spanning `spanH` hours: the user's explicit choice if
+ * they made one, otherwise hourly beyond 48 h to keep multi-day bars readable.
+ */
+export function resolveFlowsResolution(spanH) {
+  return getStoredFlowsResolution() ?? (spanH > 48 ? "60" : "15");
+}
+
+export { getStoredViewRange };
+
+function setSegState(btn, active) {
+  btn.className = active ? SEG_ACTIVE : SEG_INACTIVE;
+  btn.setAttribute("aria-pressed", String(active));
+}
+
+/**
+ * Render a toggle pair into `host` and wire it. Returns an `update` handle the
+ * caller invokes from its own render pass.
+ *
+ * The resolution pair is always shown — it is meaningful on any horizon. The
+ * range pair only appears once the plan actually exceeds the standard window,
+ * since there is nothing to switch to otherwise.
+ */
+export function mountViewToggles(host) {
+  if (!host) return { update: () => {} };
+
+  host.innerHTML = MARKUP;
+  const rangeToggle = host.querySelector("[data-range-toggle]");
+  const resButtons = [...host.querySelectorAll("[data-res]")];
+  const rangeButtons = [...host.querySelectorAll("[data-range]")];
+
+  for (const btn of resButtons) {
+    btn.addEventListener("click", () => {
+      storeFlowsResolution(btn.dataset.res);
+      broadcast();
+    });
+  }
+  for (const btn of rangeButtons) {
+    btn.addEventListener("click", () => {
+      storeViewRange(btn.dataset.range);
+      broadcast();
+    });
+  }
+
+  return {
+    update({ hasExtended = false, view = "standard", resolution = "15" } = {}) {
+      rangeToggle?.classList.toggle("hidden", !hasExtended);
+      for (const btn of resButtons) setSegState(btn, btn.dataset.res === resolution);
+      for (const btn of rangeButtons) setSegState(btn, btn.dataset.range === view);
+    },
+  };
+}

--- a/tests/api/services/config-builder.test.js
+++ b/tests/api/services/config-builder.test.js
@@ -167,3 +167,41 @@ describe('buildSolverConfigFromSettings — EV config (wiring)', () => {
     expect(cfg.evSocValue_cents_per_kWh).toBe(15);
   });
 });
+
+describe('buildSolverConfigFromSettings — extended horizon clamping', () => {
+  // Series stored while extendedHorizonDays was high are not truncated when the
+  // setting is lowered, so the configured window has to bound the plan.
+  const longData = () => ({
+    load: { start: NOW_STRING, step: 15, values: Array(400).fill(100) },
+    pv: { start: NOW_STRING, step: 15, values: Array(400).fill(0) },
+    importPrice: { start: NOW_STRING, step: 15, values: Array(400).fill(10) },
+    exportPrice: { start: NOW_STRING, step: 15, values: Array(400).fill(5) },
+    soc: { timestamp: NOW_STRING, value: 50 },
+  });
+
+  // NOW is 13:00 in Europe/Amsterdam (pinned in vitest.config.js), so the
+  // standard window runs to midnight the day after tomorrow: 35 h = 140 slots.
+  // Each extra day adds 24 h = 96 slots.
+  it.each([
+    [0, 140],
+    [1, 236],
+    [2, 332],
+  ])('plans %i extra day(s) as %i slots regardless of stored data length', (extendedHorizonDays, expected) => {
+    const cfg = buildSolverConfigFromSettings(
+      { ...mockSettings, extendedHorizonDays }, longData(), NOW_MS,
+    );
+    expect(cfg.load_W).toHaveLength(expected);
+    expect(cfg.importPrice).toHaveLength(expected);
+  });
+
+  it('still stops at the end of the data when that is shorter than the window', () => {
+    const short = longData();
+    for (const key of ['load', 'pv', 'importPrice', 'exportPrice']) {
+      short[key].values = short[key].values.slice(0, 96);
+    }
+    const cfg = buildSolverConfigFromSettings(
+      { ...mockSettings, extendedHorizonDays: 2 }, short, NOW_MS,
+    );
+    expect(cfg.load_W).toHaveLength(96);
+  });
+});

--- a/tests/api/settings-horizon-refresh.test.js
+++ b/tests/api/settings-horizon-refresh.test.js
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import app from '../../api/app.ts';
+
+vi.mock('../../api/services/settings-store.ts');
+vi.mock('../../api/services/prediction-forecast-runner.ts');
+
+import { loadSettings, saveSettings } from '../../api/services/settings-store.ts';
+import {
+  buildPredictionRunConfig,
+  runCombinedPredictionForecast,
+} from '../../api/services/prediction-forecast-runner.ts';
+
+const settingsWith = (extendedHorizonDays, dataSources = { load: 'api', pv: 'api', prices: 'vrm', soc: 'mqtt' }) => ({
+  stepSize_m: 15,
+  extendedHorizonDays,
+  dataSources,
+});
+
+/** loadSettings is called twice per POST: before the write, and after it to read back the normalized value. */
+const mockLoadSequence = (before, after) => {
+  loadSettings.mockResolvedValueOnce(before).mockResolvedValueOnce(after);
+};
+
+describe('POST /settings — forecast refresh on horizon change', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    saveSettings.mockResolvedValue(undefined);
+    buildPredictionRunConfig.mockResolvedValue({ sensors: [] });
+    runCombinedPredictionForecast.mockResolvedValue({ load: null, pv: null });
+  });
+
+  it('regenerates the load/PV forecasts when the horizon changes', async () => {
+    mockLoadSequence(settingsWith(1), settingsWith(3));
+
+    const res = await request(app).post('/settings').send({ extendedHorizonDays: 3 });
+
+    expect(res.status).toBe(200);
+    expect(runCombinedPredictionForecast).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not regenerate when the horizon is unchanged', async () => {
+    mockLoadSequence(settingsWith(2), settingsWith(2));
+
+    const res = await request(app).post('/settings').send({ maxSoc_percent: 90 });
+
+    expect(res.status).toBe(200);
+    expect(runCombinedPredictionForecast).not.toHaveBeenCalled();
+  });
+
+  it('does not regenerate when neither load nor PV is api-sourced', async () => {
+    const vrmSources = { load: 'vrm', pv: 'vrm', prices: 'vrm', soc: 'mqtt' };
+    mockLoadSequence(settingsWith(1, vrmSources), settingsWith(3, vrmSources));
+
+    const res = await request(app).post('/settings').send({ extendedHorizonDays: 3 });
+
+    expect(res.status).toBe(200);
+    expect(runCombinedPredictionForecast).not.toHaveBeenCalled();
+  });
+
+  it('still saves the settings when the forecast refresh fails', async () => {
+    mockLoadSequence(settingsWith(0), settingsWith(2));
+    runCombinedPredictionForecast.mockRejectedValue(new Error('HA unreachable'));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const res = await request(app).post('/settings').send({ extendedHorizonDays: 2 });
+
+    expect(res.status).toBe(200);
+    expect(saveSettings).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});

--- a/tests/api/settings-horizon-refresh.test.js
+++ b/tests/api/settings-horizon-refresh.test.js
@@ -37,6 +37,8 @@ describe('POST /settings — forecast refresh on horizon change', () => {
 
     expect(res.status).toBe(200);
     expect(runCombinedPredictionForecast).toHaveBeenCalledTimes(1);
+    // Reported so the client can re-read the series its Predictions tab caches.
+    expect(res.body.forecastsRefreshed).toBe(true);
   });
 
   it('does not regenerate when the horizon is unchanged', async () => {
@@ -46,6 +48,7 @@ describe('POST /settings — forecast refresh on horizon change', () => {
 
     expect(res.status).toBe(200);
     expect(runCombinedPredictionForecast).not.toHaveBeenCalled();
+    expect(res.body.forecastsRefreshed).toBe(false);
   });
 
   it('does not regenerate when neither load nor PV is api-sourced', async () => {
@@ -67,6 +70,8 @@ describe('POST /settings — forecast refresh on horizon change', () => {
 
     expect(res.status).toBe(200);
     expect(saveSettings).toHaveBeenCalled();
+    // Nothing was regenerated, so the client must not drop its cache.
+    expect(res.body.forecastsRefreshed).toBe(false);
     warn.mockRestore();
   });
 });

--- a/tests/app/charts-core-axis.test.js
+++ b/tests/app/charts-core-axis.test.js
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { buildTimeAxisFromTimestamps } from '../../app/src/charts/core.js';
+
+/** Build `count` timestamps at `stepMin` intervals from a local wall-clock start. */
+function series(startLocal, count, stepMin = 15) {
+  const start = new Date(startLocal).getTime();
+  return Array.from({ length: count }, (_, i) => start + i * stepMin * 60_000);
+}
+
+const ticksOf = (timestamps) => {
+  const axis = buildTimeAxisFromTimestamps(timestamps);
+  return timestamps.map((_, i) => axis.ticksCb(null, i));
+};
+
+describe('buildTimeAxisFromTimestamps — tick labels', () => {
+  it('labels midnight with the three-letter weekday, not a date', () => {
+    // 2026-08-16 is a Sunday, so midnight ticks land on Mon and Tue.
+    const ticks = ticksOf(series('2026-08-16T22:00:00', 4 * 24 * 3, 15));
+
+    expect(ticks).toContain('Mon');
+    expect(ticks).toContain('Tue');
+    expect(ticks.some(t => /^\d{2}\/\d{2}$/.test(t))).toBe(false);
+  });
+
+  it('still labels other hours as HH:00', () => {
+    const ticks = ticksOf(series('2026-08-17T00:00:00', 24 * 4, 15));
+
+    expect(ticks[0]).toBe('Mon');
+    expect(ticks).toContain('04:00');
+    expect(ticks).toContain('08:00');
+  });
+
+  it('leaves non-full-hour slots unlabelled', () => {
+    const ticks = ticksOf(series('2026-08-17T00:00:00', 8, 15));
+
+    expect(ticks[0]).toBe('Mon');
+    expect(ticks[1]).toBe('');
+    expect(ticks[2]).toBe('');
+    expect(ticks[3]).toBe('');
+  });
+});

--- a/tests/app/now-panel.test.js
+++ b/tests/app/now-panel.test.js
@@ -1,0 +1,150 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import {
+  describeSlotAction,
+  findCurrentRowIndex,
+  renderNowPanel,
+  socEnteringSlot,
+  startNowPanelTicker,
+} from '../../app/src/now-panel.js';
+
+const T0 = new Date('2026-08-16T18:00:00').getTime();
+const STEP = 15;
+const slotAt = (i, extra = {}) => ({
+  tIdx: i,
+  timestampMs: T0 + i * STEP * 60_000,
+  g2b: 0, pv2b: 0, b2l: 0, b2g: 0, b2ev: 0, ev_charge: 0,
+  soc_percent: 50 + i,
+  ...extra,
+});
+
+describe('findCurrentRowIndex', () => {
+  const rows = [slotAt(0), slotAt(1), slotAt(2)];
+
+  it('finds the slot containing the instant, not row 0', () => {
+    expect(findCurrentRowIndex(rows, STEP, T0)).toBe(0);
+    expect(findCurrentRowIndex(rows, STEP, T0 + 20 * 60_000)).toBe(1);
+    expect(findCurrentRowIndex(rows, STEP, T0 + 44 * 60_000)).toBe(2);
+  });
+
+  it('is half-open: a slot boundary belongs to the later slot', () => {
+    expect(findCurrentRowIndex(rows, STEP, T0 + 15 * 60_000)).toBe(1);
+  });
+
+  it('returns -1 outside the plan or with no plan', () => {
+    expect(findCurrentRowIndex(rows, STEP, T0 - 1)).toBe(-1);
+    expect(findCurrentRowIndex(rows, STEP, T0 + 45 * 60_000)).toBe(-1);
+    expect(findCurrentRowIndex([], STEP, T0)).toBe(-1);
+  });
+});
+
+describe('describeSlotAction', () => {
+  it('names the dominant charge source', () => {
+    expect(describeSlotAction(slotAt(0, { pv2b: 2000 })).label).toBe('Charging from PV');
+    expect(describeSlotAction(slotAt(0, { g2b: 2000 })).label).toBe('Charging from grid');
+    expect(describeSlotAction(slotAt(0, { g2b: 1000, pv2b: 900 })).label).toBe('Charging from grid + PV');
+  });
+
+  it('names the dominant discharge sink', () => {
+    expect(describeSlotAction(slotAt(0, { b2l: 800 })).label).toBe('Discharging to load');
+    expect(describeSlotAction(slotAt(0, { b2g: 800 })).label).toBe('Discharging to grid');
+    expect(describeSlotAction(slotAt(0, { b2ev: 800 })).label).toBe('Discharging to EV');
+  });
+
+  it('reports total battery power, not the dominant leg', () => {
+    expect(describeSlotAction(slotAt(0, { g2b: 1000, pv2b: 500 })).power_W).toBe(1500);
+    expect(describeSlotAction(slotAt(0, { b2l: 300, b2g: 200 })).power_W).toBe(500);
+  });
+
+  it('falls back to EV charging when the battery is idle', () => {
+    const action = describeSlotAction(slotAt(0, { ev_charge: 3000, g2ev: 3000 }));
+    expect(action).toEqual({ label: 'Charging EV', power_W: 3000 });
+  });
+
+  it('treats rounding noise as idle', () => {
+    expect(describeSlotAction(slotAt(0, { g2b: 3, b2l: 2 })).label).toBe('Idle');
+    expect(describeSlotAction(slotAt(0)).label).toBe('Idle');
+    expect(describeSlotAction(null).label).toBe('—');
+  });
+});
+
+describe('socEnteringSlot', () => {
+  const rows = [slotAt(0), slotAt(1), slotAt(2)];
+
+  it('uses the measured value for the first slot', () => {
+    expect(socEnteringSlot(rows, 0, 64)).toBe(64);
+  });
+
+  it('uses the previous slot result for later slots', () => {
+    expect(socEnteringSlot(rows, 2, 64)).toBe(51);
+  });
+
+  it('falls back when the measured value is missing', () => {
+    expect(socEnteringSlot(rows, 0, null)).toBe(50);
+  });
+});
+
+describe('renderNowPanel', () => {
+  let els;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <span id="w"></span><span id="a"></span><span id="p"></span>
+      <span id="s"></span><span id="t"></span>`;
+    els = {
+      nowSlotWindow: document.getElementById('w'),
+      nowAction: document.getElementById('a'),
+      nowPower: document.getElementById('p'),
+      nowSoc: document.getElementById('s'),
+      nowSocTarget: document.getElementById('t'),
+    };
+  });
+
+  it('renders the slot the clock is in, with its window and target', () => {
+    const rows = [
+      slotAt(0, { pv2b: 500 }),
+      slotAt(1, { g2b: 2400, dess: { socTarget_percent: 80 } }),
+    ];
+    const idx = renderNowPanel(els, { rows, stepSize_m: STEP, initialSoc_percent: 64 }, T0 + 20 * 60_000);
+
+    expect(idx).toBe(1);
+    expect(els.nowSlotWindow.textContent).toBe('18:15 – 18:30');
+    expect(els.nowAction.textContent).toBe('Charging from grid');
+    expect(els.nowPower.textContent).toBe('2.40 kW');
+    expect(els.nowSoc.textContent).toBe('50'); // previous slot's result
+    expect(els.nowSocTarget.textContent).toBe('target 80%');
+  });
+
+  it('flags an expired plan rather than showing a stale slot', () => {
+    const rows = [slotAt(0, { g2b: 1000 })];
+    const idx = renderNowPanel(els, { rows, stepSize_m: STEP }, T0 + 10 * 3_600_000);
+
+    expect(idx).toBe(-1);
+    expect(els.nowSlotWindow.textContent).toBe('plan expired');
+    expect(els.nowPower.textContent).toBe('—');
+  });
+
+  it('shows placeholders before the first plan', () => {
+    renderNowPanel(els, { rows: [] }, T0);
+    expect(els.nowSlotWindow.textContent).toBe('—');
+    expect(els.nowAction.textContent).toBe('—');
+  });
+});
+
+describe('startNowPanelTicker', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('renders immediately and then on each interval, until stopped', () => {
+    const render = vi.fn();
+    const stop = startNowPanelTicker(render, 30_000);
+
+    expect(render).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(60_000);
+    expect(render).toHaveBeenCalledTimes(3);
+
+    stop();
+    vi.advanceTimersByTime(60_000);
+    expect(render).toHaveBeenCalledTimes(3);
+  });
+});

--- a/tests/app/optimizer-controller.test.js
+++ b/tests/app/optimizer-controller.test.js
@@ -21,7 +21,7 @@ function immediateDebounce(fn) {
   return debounced;
 }
 
-function setupController() {
+function setupController(overrides = {}) {
   const rows = [{ tIdx: 0, timestampMs: 1714586400000, soc_percent: 55 }];
   const rebalanceWindow = { startIdx: 0, endIdx: 0 };
   const summary = { netGridCost_cents: 12.5 };
@@ -70,7 +70,7 @@ function setupController() {
 
   const evEntries = [{ type: 'departure', time: '2026-05-01T18:30', soc_percent: 80 }];
   return {
-    controller: createOptimizerController({ els, services, getEvEntries: () => evEntries }),
+    controller: createOptimizerController({ els, services, getEvEntries: () => evEntries, ...overrides }),
     els,
     rebalanceWindow,
     rows,
@@ -183,5 +183,25 @@ describe('optimizer controller', () => {
 
     expect(document.querySelector('.chart-empty span').textContent)
       .toBe('Run the optimizer to see results');
+  });
+
+  it('re-reads the cached forecasts when the server regenerated them', async () => {
+    const onForecastsRefreshed = vi.fn();
+    const { controller, services } = setupController({ onForecastsRefreshed });
+    services.saveConfig.mockResolvedValue({ forecastsRefreshed: true });
+
+    await controller.persistConfig();
+
+    expect(onForecastsRefreshed).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves the cached forecasts alone when the server did not regenerate', async () => {
+    const onForecastsRefreshed = vi.fn();
+    const { controller, services } = setupController({ onForecastsRefreshed });
+    services.saveConfig.mockResolvedValue({ forecastsRefreshed: false });
+
+    await controller.persistConfig();
+
+    expect(onForecastsRefreshed).not.toHaveBeenCalled();
   });
 });

--- a/tests/app/optimizer-controller.test.js
+++ b/tests/app/optimizer-controller.test.js
@@ -95,10 +95,11 @@ describe('optimizer controller', () => {
       updateData: true,
       writeToVictron: false,
     });
+    // Plan end is the last planned slot's start, not the boundary after it.
     expect(services.updatePlanMeta).toHaveBeenCalledWith(
       els,
-      42,
       '2026-05-01T12:00:00.000Z',
+      1714586400000,
     );
     expect(services.updateSummaryUI).toHaveBeenCalledWith(els, summary);
     expect(services.updateRebalanceNudgeUI).toHaveBeenCalledWith(els, undefined);

--- a/tests/app/optimizer-controller.test.js
+++ b/tests/app/optimizer-controller.test.js
@@ -148,4 +148,40 @@ describe('optimizer controller', () => {
     expect(services.renderTable.mock.calls[0][0].showKwh).toBe(false);
     expect(services.saveConfig).toHaveBeenCalledWith({ tableShowKwh: false });
   });
+
+  it('marks the chart placeholders as calculating while a solve is in flight', async () => {
+    document.body.innerHTML = `
+      <div id="panel-optimizer"><div class="chart-empty"><span>Run the optimizer to see results</span></div></div>
+      <div id="panel-ev"><div class="chart-empty"><span>Run the optimizer to see results</span></div></div>`;
+    const texts = () => [...document.querySelectorAll('.chart-empty span')].map(s => s.textContent);
+
+    const { controller, services } = setupController();
+    let releaseSolve;
+    services.requestRemoteSolve.mockImplementation(
+      () => new Promise(resolve => { releaseSolve = resolve; }),
+    );
+
+    const run = controller.onRun();
+    // Set synchronously, before the awaited config persist.
+    expect(texts()).toEqual(['Calculating…', 'Calculating…']);
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(texts()).toEqual(['Calculating…', 'Calculating…']);
+
+    releaseSolve({ rows: [], solverStatus: 'Optimal', summary: {} });
+    await run;
+  });
+
+  it('restores the actionable placeholder when a solve fails', async () => {
+    document.body.innerHTML =
+      '<div id="panel-optimizer"><div class="chart-empty"><span>x</span></div></div>';
+
+    const { controller, services } = setupController();
+    services.requestRemoteSolve.mockRejectedValue(new Error('boom'));
+
+    await controller.onRun();
+
+    expect(document.querySelector('.chart-empty span').textContent)
+      .toBe('Run the optimizer to see results');
+  });
 });

--- a/tests/app/predictions-config-form.test.js
+++ b/tests/app/predictions-config-form.test.js
@@ -54,7 +54,6 @@ function setupDom() {
     </select>
     <button id="pred-load-forecast" type="button"></button>
     <button id="pred-pv-forecast" type="button"></button>
-    <input id="forecast-chart-15m" type="checkbox" />
     <button id="pred-settings-toggle" type="button"></button>
     <div id="pred-settings-body" class="hidden"></div>
     <span id="pred-settings-toggle-icon"></span>
@@ -140,10 +139,9 @@ describe('prediction config form', () => {
   it('wires prediction-owned controls, buttons, and settings toggle', async () => {
     const onForecastAll = vi.fn();
     const onPvForecast = vi.fn();
-    const onForecastResolutionChange = vi.fn();
     savePredictionConfig.mockResolvedValue({});
 
-    wirePredictionForm({ onForecastAll, onPvForecast, onForecastResolutionChange });
+    wirePredictionForm({ onForecastAll, onPvForecast });
 
     document.getElementById('pred-active-type').value = 'fixed';
     document.getElementById('pred-active-type').dispatchEvent(new Event('change', { bubbles: true }));
@@ -158,12 +156,10 @@ describe('prediction config form', () => {
 
     document.getElementById('pred-load-forecast').click();
     document.getElementById('pred-pv-forecast').click();
-    document.getElementById('forecast-chart-15m').dispatchEvent(new Event('change', { bubbles: true }));
     document.getElementById('pred-settings-toggle').click();
 
     expect(onForecastAll).toHaveBeenCalledTimes(1);
     expect(onPvForecast).toHaveBeenCalledTimes(1);
-    expect(onForecastResolutionChange).toHaveBeenCalledTimes(1);
     expect(document.getElementById('pred-settings-body').classList.contains('hidden')).toBe(false);
   });
 });

--- a/tests/app/predictions-forecast-chart.test.js
+++ b/tests/app/predictions-forecast-chart.test.js
@@ -19,7 +19,7 @@ const flushPromises = () => new Promise(resolve => setTimeout(resolve, 0));
 
 function setupDom() {
   document.body.innerHTML = `
-    <input id="forecast-chart-15m" type="checkbox" />
+    <div id="forecast-view-toggles"></div>
     <div id="prediction-adjustments-count"></div>
     <div id="prediction-adjustments-list"></div>
     <div id="forecast-adjustment-popover" class="hidden">

--- a/tests/app/state.test.js
+++ b/tests/app/state.test.js
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { hydrateUI, snapshotUI, updateRebalanceNudgeUI, updateSummaryUI } from '../../app/src/state.js';
+import { hydrateUI, snapshotUI, updatePlanMeta, updateRebalanceNudgeUI, updateSummaryUI } from '../../app/src/state.js';
 
 afterEach(() => {
   vi.useRealTimers();
@@ -146,5 +146,32 @@ describe('settings state', () => {
     });
 
     expect(els.rebalanceNudge.classList.contains('hidden')).toBe(true);
+  });
+});
+
+describe('plan meta', () => {
+  it('formats the plan window, with a weekday only on the end', () => {
+    const planTsStart = document.createElement('div');
+    const planTsEnd = document.createElement('div');
+
+    // 2026-08-16 is a Sunday; the plan runs to Thursday 2026-08-20.
+    updatePlanMeta(
+      { planTsStart, planTsEnd },
+      new Date('2026-08-16T18:45:00').toISOString(),
+      new Date('2026-08-20T23:45:00').getTime(),
+    );
+
+    expect(planTsStart.textContent).toBe('16/08 18:45');
+    expect(planTsEnd.textContent).toBe('Thu 20/08 23:45');
+  });
+
+  it('renders a dash when either end is missing', () => {
+    const planTsStart = document.createElement('div');
+    const planTsEnd = document.createElement('div');
+
+    updatePlanMeta({ planTsStart, planTsEnd }, null, null);
+
+    expect(planTsStart.textContent).toBe('—');
+    expect(planTsEnd.textContent).toBe('—');
   });
 });

--- a/tests/app/view-toggles.test.js
+++ b/tests/app/view-toggles.test.js
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  mountViewToggles,
+  resolveFlowsResolution,
+  setStandardWindowEndMs,
+  getStandardWindowEndMs,
+  subscribeViewToggles,
+} from '../../app/src/view-toggles.js';
+
+const host = () => {
+  document.body.innerHTML = '<div id="host"></div>';
+  return document.getElementById('host');
+};
+
+const click = (el, selector) => el.querySelector(selector).dispatchEvent(new Event('click', { bubbles: true }));
+
+describe('resolveFlowsResolution', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('defaults to 15 min on short spans and hourly beyond 48 h', () => {
+    expect(resolveFlowsResolution(24)).toBe('15');
+    expect(resolveFlowsResolution(48)).toBe('15');
+    expect(resolveFlowsResolution(72)).toBe('60');
+  });
+
+  it('honours an explicit choice on any span', () => {
+    localStorage.setItem('optivolt:flowsResolution', '60');
+    expect(resolveFlowsResolution(12)).toBe('60');
+    localStorage.setItem('optivolt:flowsResolution', '15');
+    expect(resolveFlowsResolution(96)).toBe('15');
+  });
+});
+
+describe('mountViewToggles', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    setStandardWindowEndMs(null);
+  });
+
+  it('always shows the resolution pair, and the range pair only when extended', () => {
+    const el = host();
+    const toggles = mountViewToggles(el);
+
+    toggles.update({ hasExtended: false, view: 'standard', resolution: '15' });
+    expect(el.querySelector('[data-res-toggle]').classList.contains('hidden')).toBe(false);
+    expect(el.querySelector('[data-range-toggle]').classList.contains('hidden')).toBe(true);
+
+    toggles.update({ hasExtended: true, view: 'full', resolution: '60' });
+    expect(el.querySelector('[data-range-toggle]').classList.contains('hidden')).toBe(false);
+  });
+
+  it('marks the active button via aria-pressed', () => {
+    const el = host();
+    mountViewToggles(el).update({ hasExtended: true, view: 'full', resolution: '60' });
+
+    expect(el.querySelector('[data-res="60"]').getAttribute('aria-pressed')).toBe('true');
+    expect(el.querySelector('[data-res="15"]').getAttribute('aria-pressed')).toBe('false');
+    expect(el.querySelector('[data-range="full"]').getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('persists a click and notifies subscribers so other tabs re-render', () => {
+    const el = host();
+    mountViewToggles(el);
+    const listener = vi.fn();
+    const unsubscribe = subscribeViewToggles(listener);
+
+    click(el, '[data-res="60"]');
+    expect(localStorage.getItem('optivolt:flowsResolution')).toBe('60');
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    click(el, '[data-range="full"]');
+    expect(localStorage.getItem('optivolt:viewRange')).toBe('full');
+    expect(listener).toHaveBeenCalledTimes(2);
+
+    unsubscribe();
+    click(el, '[data-res="15"]');
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps two mounted pairs in sync through the shared store', () => {
+    document.body.innerHTML = '<div id="a"></div><div id="b"></div>';
+    const a = document.getElementById('a');
+    const b = document.getElementById('b');
+    mountViewToggles(a);
+    const bToggles = mountViewToggles(b);
+
+    click(a, '[data-res="60"]');
+    // The second pair reflects the shared choice on its next render pass.
+    bToggles.update({ hasExtended: false, view: 'standard', resolution: resolveFlowsResolution(24) });
+    expect(b.querySelector('[data-res="60"]').getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('tolerates a missing host', () => {
+    expect(() => mountViewToggles(null).update({})).not.toThrow();
+  });
+
+  it('round-trips the shared standard-window boundary', () => {
+    expect(getStandardWindowEndMs()).toBeNull();
+    setStandardWindowEndMs(1234);
+    expect(getStandardWindowEndMs()).toBe(1234);
+    setStandardWindowEndMs(undefined);
+    expect(getStandardWindowEndMs()).toBeNull();
+  });
+});


### PR DESCRIPTION
Bugs and follow-ups found while exercising the extended horizon on real hardware. Stacked on #147 (phase 4); all eight commits are new here.

The first three are correctness fixes in the planning pipeline; the rest are the dashboard work that using it surfaced.

## 1. The view toggles were always visible and did nothing

`app/index.html` gave the view-range and bar-resolution toggles both the `hidden` attribute and `inline-flex`. Equal specificity (0,1,0), and Tailwind's utilities layer comes after preflight — so `display: inline-flex` won and the attribute was a no-op. The toggles rendered on every plan, including plans with no extra days, and the `els.viewRangeToggle.hidden = !hasExtended` assignments meant to gate them were inert for the same reason.

Clicking them therefore stored a preference in localStorage that `getVisibleRows()`/`renderVisuals()` then overrode, since `hasExtended` and `canAggregate` were false. They read as broken controls.

## 2. Lowering `extendedHorizonDays` didn't shorten the plan

`config-builder.ts` derived the horizon entirely from stored series lengths:

```js
const endMs = Math.min(loadEndMs, pvEndMs, importEndMs, exportEndMs);
```

`extendedHorizonDays` only ever controlled what got *fetched*. Series already in `data.json` are not truncated when it drops, and the price forecast is stored in full and appended wholesale by `extendSeriesWithForecast`. So going 2 extra days → 1 kept planning 2; so did going to 0.

`endMs` is now also bounded by `getForecastTimeRange(nowMs, extendedHorizonDays)` — the same window `calculate.ts` already treats as authoritative for `standardWindowEndMs`. Data shorter than the window still wins, so nothing over-extends.

## 3. Raising `extendedHorizonDays` didn't lengthen it either

The mirror image, and the one that actually bites in production. Load and PV forecasts are generated over `getForecastTimeRange(now, extendedHorizonDays)`, but nothing re-runs them when that setting changes: `computePlan` refreshes only the VRM series and the price forecast, and `runCombinedPredictionForecast` is reachable only from `/predictions`, driven by an external HA cron. There is no scheduler in the server.

So the stored series kept covering the old window, and since a plan can never run past its data, `min(...)` capped the horizon there. Observed: 0 and 1 extra days worked, 2 and 3 were indistinguishable from 1.

The settings route now regenerates both forecasts when the normalized horizon actually changes — skipped unless `load` or `pv` is api-sourced (the only series the runner writes), awaited so the recompute the UI fires next sees the new data, and failures logged rather than surfaced since the settings are already saved and the next cron run recovers.

Deliberately *not* moved into `computePlan`: the load forecast queries HA statistics and the PV forecast hits Open-Meteo, too slow to run on every calculate.

## 4. The toggles now work across tabs, and the resolution pair is always shown

They only existed on the optimizer tab, and the predictions tab had a separate `15m bars` checkbox expressing the same idea.

New `app/src/view-toggles.js` owns the markup, the segmented styling and the shared state. Each tab mounts its own pair in the header of its first chart — matching how the optimizer already did it — but the choice is global: it persists to the existing localStorage keys and a click broadcasts to subscribers, so other tabs re-render instead of going stale behind a tab switch.

- **EV tab:** new pair on the Charging flows card, driving both EV charts and the EV table. The stat panel stays whole-plan, as the optimizer summary does.
- **Predictions:** the checkbox is replaced by the same pair. Accuracy charts are untouched — they plot a past validation window, where a plan-horizon toggle has no meaning.

The resolution pair is no longer gated on a >48 h span. Hourly remains the default beyond 48 h, but only as a default: an explicit choice now applies at any span. The range pair still hides when the plan doesn't exceed the standard window.

## 5. Midnight ticks name the day

A run of `dd/mm` labels is hard to read on a multi-day axis. Midnight starts a new day, so the tick names it: `Mon`, `Tue`, … `fmtTickHourOrDate` is the only place midnight ticks are formatted and every chart reaches it through `buildTimeAxisFromTimestamps`, so this covers flows, SoC, prices, load/PV, EV and forecast at once.

## 6. A "Now" block, and the plan end

The summary panel had two categories — Optivolt's own status, and plan aggregates — and Current SoC sat in the plan grid despite being neither. The missing category was the current slot: nothing showed what the plan says to do right now.

A Now block sits between the status rows and the plan grid: slot window, what the battery is doing and at what power, and the SoC entering the slot with its DESS target. Current SoC moves there, freeing the grid cell that Plan end now fills — so the grid stays exactly six cells of plan facts.

- The slot is found by **wall clock**, not taken as row 0, since a plan is recomputed periodically and row 0 goes stale within its own quarter. A 30 s ticker re-renders, so it advances without a reload, and an expired plan says so instead of showing a stale slot.
- The action is derived from the **solved flows**, not the DESS strategy: the flows say what happens, the strategy is only the instruction sent to Victron (already in the table).
- Plan end is the **last planned slot's start** (`Thu 20/08 23:45`) rather than the exclusive boundary after it (`00:00`), which reads ambiguously. Only the end carries a weekday — it can be days out; the start is always the current slot.

This reports the plan, not measured hardware state; those diverge when Victron overrides or the plan has expired.

## 7. The initial page load had no loading indicator at all

Not slow rendering — nothing to see. `.card:not(.revealed) { opacity: 0 }` hides every card until `revealCards()` runs, and `main.js` called it *after* awaiting the first solve. So the optimizer panel was blank for the whole solve, including `#status` ("Calculating…") and the Recompute spinner, which live inside `#card-algo`. The indicators existed but were behind the curtain; a longer horizon turns that blink into something that looks broken.

Cards are now revealed before the initial solve, and the chart overlays read `Calculating…` while one is in flight instead of `Run the optimizer to see results`.

## Behaviour at `extendedHorizonDays: 0`

Fix 2 clamps unconditionally, so it applies at 0 as well. On every built-in path this is a no-op — VRM's `windowOptimizationHorizon()` and the HA/Open-Meteo prediction services already end at exactly that boundary. The only case that changes is `dataSources: 'api'` with series pushed through `/data` that run past the standard window; those are now truncated at it.

## Tests

586 pass (38 new). Typecheck and lint clean. The clamp tests fail against the old code with exactly the reported symptom.

The dashboard changes have been exercised on the real add-on; the review-worthy judgement calls are called out inline above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)