### PR TITLE
Clearer price signal strip below the power flows chart

### DIFF
--- a/app/src/charts/colors.js
+++ b/app/src/charts/colors.js
@@ -13,16 +13,24 @@ export const SOLUTION_COLORS = {
   ev_charge: "rgb(16, 185, 129)", // EV total (emerald - distinct EV colour)
 };
 
-const BUY_PRICE_COLOR_NEUTRAL_RGB = [226, 232, 240];
-const BUY_PRICE_COLOR_STOPS = [
-  { value: -10, rgb: [37, 99, 235] },
-  { value: -1,  rgb: [96, 165, 250] },
-  { value: 0,   rgb: BUY_PRICE_COLOR_NEUTRAL_RGB }, // zero / neutral
-  { value: 1,   rgb: [254, 243, 199] },
-  { value: 12,  rgb: [251, 191, 36] },
-  { value: 24,  rgb: [249, 115, 22] },
-  { value: 35,  rgb: [220, 38, 38] },
+const PRICE_STRIP_NEUTRAL_RGB = [226, 232, 240];
+
+// Buy-price bands: one hue per band, ramping light → deep within the band.
+// The lightness reset at each boundary makes the 15/20/25/30c thresholds
+// read as hard seams while within-band differences stay visible.
+const BUY_PRICE_BANDS = [
+  { min: 0,  max: 15, from: [220, 252, 231], to: [22, 163, 74] },   // green: cheap
+  { min: 15, max: 20, from: [254, 249, 195], to: [234, 179, 8] },   // yellow
+  { min: 20, max: 25, from: [254, 215, 170], to: [234, 88, 12] },   // orange
+  { min: 25, max: 30, from: [254, 202, 202], to: [220, 38, 38] },   // red
+  { min: 30, max: 40, from: [185, 28, 28],  to: [127, 29, 29] },    // dark red
 ];
+
+// Overrides for the exceptional low-price regimes. Buy and sell derive from
+// the same raw price, so these zones sit below the banded scale and never
+// interleave with it.
+const PAID_TO_CONSUME_BAND = { span: 10, from: [191, 219, 254], to: [29, 78, 216] };  // blue, buy < 0
+const NEGATIVE_SELL_BAND = { span: 10, from: [221, 214, 254], to: [124, 58, 237] };   // violet, sell < 0
 
 function lerp(a, b, t) {
   return a + (b - a) * t;
@@ -85,25 +93,30 @@ function rgbString(rgb) {
   return `rgb(${rgb[0]}, ${rgb[1]}, ${rgb[2]})`;
 }
 
-export function getBuyPriceColor(price_cents_per_kWh) {
-  const price = Number(price_cents_per_kWh);
-  if (!Number.isFinite(price)) return rgbString(BUY_PRICE_COLOR_NEUTRAL_RGB);
+function bandColor(band, t) {
+  const clamped = Math.max(0, Math.min(1, t));
+  return rgbString(interpolateOklab(band.from, band.to, clamped));
+}
 
-  const first = BUY_PRICE_COLOR_STOPS[0];
-  const last = BUY_PRICE_COLOR_STOPS[BUY_PRICE_COLOR_STOPS.length - 1];
-  if (price <= first.value) return rgbString(first.rgb);
-  if (price >= last.value) return rgbString(last.rgb);
-
-  for (let i = 1; i < BUY_PRICE_COLOR_STOPS.length; i++) {
-    const lower = BUY_PRICE_COLOR_STOPS[i - 1];
-    const upper = BUY_PRICE_COLOR_STOPS[i];
-    if (price <= upper.value) {
-      const t = (price - lower.value) / (upper.value - lower.value);
-      return rgbString(interpolateOklab(lower.rgb, upper.rgb, t));
-    }
+export function getPriceStripColor(buyPrice_cents_per_kWh, sellPrice_cents_per_kWh = 0) {
+  const buy = Number(buyPrice_cents_per_kWh);
+  if (buyPrice_cents_per_kWh == null || !Number.isFinite(buy)) {
+    return rgbString(PRICE_STRIP_NEUTRAL_RGB);
   }
 
-  return rgbString(last.rgb);
+  if (buy < 0) return bandColor(PAID_TO_CONSUME_BAND, -buy / PAID_TO_CONSUME_BAND.span);
+
+  const sell = Number(sellPrice_cents_per_kWh);
+  if (Number.isFinite(sell) && sell < 0) {
+    return bandColor(NEGATIVE_SELL_BAND, -sell / NEGATIVE_SELL_BAND.span);
+  }
+
+  for (const band of BUY_PRICE_BANDS) {
+    if (buy < band.max) return bandColor(band, (buy - band.min) / (band.max - band.min));
+  }
+
+  const last = BUY_PRICE_BANDS[BUY_PRICE_BANDS.length - 1];
+  return rgbString(last.to);
 }
 
 export const toRGBA = (rgb, alpha = 1) => {

--- a/app/src/charts/overlays.js
+++ b/app/src/charts/overlays.js
@@ -1,5 +1,5 @@
 import { fmtKwh } from '../chart-tooltip.js';
-import { getBuyPriceColor, toRGBA, SOLUTION_COLORS } from './colors.js';
+import { getPriceStripColor, toRGBA, SOLUTION_COLORS } from './colors.js';
 import { fmtHHMM } from './core.js';
 
 export const BUY_PRICE_STRIP_HEIGHT = 7;
@@ -298,7 +298,7 @@ export function makeNegativePriceInjectionPlugin(rows, h) {
 export function makeBuyPriceStripPlugin(rows) {
   if (!rows?.length) return null;
 
-  const colors = rows.map(row => getBuyPriceColor(row?.ic));
+  const colors = rows.map(row => getPriceStripColor(row?.ic, row?.ec));
 
   return {
     id: 'buyPriceStrip',

--- a/tests/app/charts.test.js
+++ b/tests/app/charts.test.js
@@ -1,38 +1,48 @@
 import { describe, expect, it } from 'vitest';
-import { aggregateLoadPvBuckets, getBuyPriceColor } from '../../app/src/charts.js';
+import { aggregateLoadPvBuckets, getPriceStripColor } from '../../app/src/charts.js';
 
-describe('getBuyPriceColor', () => {
-  it('uses fixed colors at scale stops', () => {
-    expect(getBuyPriceColor(-10)).toBe('rgb(37, 99, 235)');
-    expect(getBuyPriceColor(-1)).toBe('rgb(96, 165, 250)');
-    expect(getBuyPriceColor(0)).toBe('rgb(226, 232, 240)');
-    expect(getBuyPriceColor(1)).toBe('rgb(254, 243, 199)');
-    expect(getBuyPriceColor(12)).toBe('rgb(251, 191, 36)');
-    expect(getBuyPriceColor(24)).toBe('rgb(249, 115, 22)');
-    expect(getBuyPriceColor(35)).toBe('rgb(220, 38, 38)');
+describe('getPriceStripColor', () => {
+  it('uses a blue ramp when the buy price is negative (paid to consume)', () => {
+    expect(getPriceStripColor(-0.5, -3)).toBe('rgb(182, 212, 253)');
+    expect(getPriceStripColor(-5.5, -6)).toBe('rgb(99, 145, 236)');
+    expect(getPriceStripColor(-10, -8)).toBe('rgb(29, 78, 216)');
+    expect(getPriceStripColor(-20, -12)).toBe('rgb(29, 78, 216)');
   });
 
-  it('clips prices outside the fixed scale', () => {
-    expect(getBuyPriceColor(-50)).toBe('rgb(37, 99, 235)');
-    expect(getBuyPriceColor(90)).toBe('rgb(220, 38, 38)');
+  it('uses a violet ramp when only the sell price is negative (injection costs money)', () => {
+    expect(getPriceStripColor(8, -0.5)).toBe('rgb(215, 207, 254)');
+    expect(getPriceStripColor(6, -5)).toBe('rgb(168, 144, 249)');
+    expect(getPriceStripColor(5, -10)).toBe('rgb(124, 58, 237)');
+    expect(getPriceStripColor(2, -20)).toBe('rgb(124, 58, 237)');
   });
 
-  it('makes small negative and positive prices visibly distinct', () => {
-    expect(getBuyPriceColor(-1)).toBe('rgb(96, 165, 250)');
-    expect(getBuyPriceColor(1)).toBe('rgb(254, 243, 199)');
+  it('ramps light to deep within each buy-price band', () => {
+    expect(getPriceStripColor(0, 2)).toBe('rgb(220, 252, 231)');
+    expect(getPriceStripColor(7.5, 2)).toBe('rgb(136, 208, 153)');
+    expect(getPriceStripColor(15, 2)).toBe('rgb(254, 249, 195)');
+    expect(getPriceStripColor(17.5, 2)).toBe('rgb(245, 214, 125)');
+    expect(getPriceStripColor(20, 2)).toBe('rgb(254, 215, 170)');
+    expect(getPriceStripColor(25, 2)).toBe('rgb(254, 202, 202)');
+    expect(getPriceStripColor(30, 2)).toBe('rgb(185, 28, 28)');
+    expect(getPriceStripColor(40, 2)).toBe('rgb(127, 29, 29)');
+    expect(getPriceStripColor(90, 2)).toBe('rgb(127, 29, 29)');
   });
 
-  it('interpolates between stops in OKLab space', () => {
-    expect(getBuyPriceColor(-5.5)).toBe('rgb(65, 133, 243)');
-    expect(getBuyPriceColor(-0.5)).toBe('rgb(162, 200, 247)');
-    expect(getBuyPriceColor(6.5)).toBe('rgb(253, 218, 133)');
-    expect(getBuyPriceColor(18)).toBe('rgb(252, 154, 29)');
-    expect(getBuyPriceColor(30)).toBe('rgb(234, 78, 34)');
+  it('makes band boundaries a hard seam, not a smooth blend', () => {
+    expect(getPriceStripColor(14.9, 2)).toBe('rgb(25, 164, 75)');
+    expect(getPriceStripColor(15, 2)).toBe('rgb(254, 249, 195)');
+    expect(getPriceStripColor(19.9, 2)).toBe('rgb(234, 180, 22)');
+    expect(getPriceStripColor(20, 2)).toBe('rgb(254, 215, 170)');
   });
 
-  it('treats invalid prices as neutral zero', () => {
-    expect(getBuyPriceColor(null)).toBe('rgb(226, 232, 240)');
-    expect(getBuyPriceColor(Number.NaN)).toBe('rgb(226, 232, 240)');
+  it('falls back to the buy-price bands when the sell price is missing', () => {
+    expect(getPriceStripColor(10)).toBe('rgb(106, 193, 127)');
+    expect(getPriceStripColor(10, null)).toBe('rgb(106, 193, 127)');
+  });
+
+  it('treats invalid buy prices as neutral', () => {
+    expect(getPriceStripColor(null, 2)).toBe('rgb(226, 232, 240)');
+    expect(getPriceStripColor(Number.NaN, 2)).toBe('rgb(226, 232, 240)');
   });
 });
 

--- a/tests/app/export-surface.test.js
+++ b/tests/app/export-surface.test.js
@@ -16,7 +16,7 @@ describe('browser module compatibility exports', () => {
       drawSocChart: expect.any(Function),
       fmtHHMM: expect.any(Function),
       getBaseOptions: expect.any(Function),
-      getBuyPriceColor: expect.any(Function),
+      getPriceStripColor: expect.any(Function),
       getChartTheme: expect.any(Function),
       refreshAllChartThemes: expect.any(Function),
       renderChart: expect.any(Function),


### PR DESCRIPTION
This pull request replaces the continuous gradient of the buy price strip under the power flows chart with a banded scale, and makes exceptional price regimes visible in the same lane.

The old single OKLab gradient washed out the differences that matter: 14c and 22c rendered as nearly identical ambers, and a negative sell price was only hinted at when the plan actually exported during those slots.

New per-slot coloring, in priority order:

1. Buy price < 0: blue ramp (you are paid to consume)
2. Sell price < 0: violet ramp (injecting electricity costs money), shown regardless of whether the plan exports
3. Otherwise, banded buy price colors: green 0-15c, yellow 15-20c, orange 20-25c, red 25-30c, dark red 30c+

Each band ramps light to deep in OKLab, so within-band differences stay visible (1c vs 14c are clearly different greens) while every threshold produces a hard color seam (14.9c deep green jumps to 15c pale yellow). Since buy and sell derive from the same raw price, the blue and violet zones sit naturally below the green band and the strip still reads as one monotonic cheap-to-expensive scale.

**Manual testing instructions**
- Open the main dashboard and check the strip under the power flows chart: runs of similar prices should read as solid blocks with crisp edges where the price crosses 15/20/25/30c
- Hover a bar: the tooltip's buy/sell prices should match the strip color's band
- With slots where the sell price is negative, those slots should show violet even if no export is planned

**Checklist**
- Tests: rewrote the color scale tests for the new zones, including a seam test at band boundaries; full suite (603) passes
- Docs: n/a
- Announcement: ✨ The price strip under the power flows chart now shows clear price bands and flags slots where injection costs money or consumption is paid
- AI: Claude Code implemented the feature after a design discussion, human reviewed
